### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ There is support for protocol encryption, DHT, PEX, uTP, and various extensions.
 
 ## Installation
 
-Install the library package with `go get github.com/anacrolix/torrent`, or one of the provided cmds with `go get github.com/anacrolix/...`.
+Install the library package with `go get github.com/anacrolix/torrent`, or the provided cmds with `go get github.com/anacrolix/torrent/cmd/...`.
 
 ## Library example
 

--- a/client.go
+++ b/client.go
@@ -3,12 +3,13 @@ Package torrent implements a torrent client.
 
 Simple example:
 
-	c, _ := NewClient()
-	t, _, c.AddMagnet("magnet:?xt=urn:btih:ZOCMZQIPFFW7OLLMIC5HUB6BPCSDEOQU")
+	c, _ := torrent.NewClient(&torrent.Config{})
+	defer c.Close()
+	t, _ := c.AddMagnet("magnet:?xt=urn:btih:ZOCMZQIPFFW7OLLMIC5HUB6BPCSDEOQU")
 	t.DownloadAll()
 	c.WaitAll()
-	log.Print("erhmahgerd, torrent downloaded")
-	c.Close()
+	log.Print("ermahgerd, torrent downloaded")
+
 
 */
 package torrent


### PR DESCRIPTION
Fixes some minor typos:
- The example in docstring: `:=` needed when initializing a `t` torrent
- The example in docstring: `NewClient` func's signature needs a pointer to a `Config` instance
- The example in docstring: when imported, needs the package name prefix (`torrent.`)
- To compile the binaries we go get `github.com/anacrolix/torrent/cmd/...`, not `github.com/anacrolix/...`

Excellent library, cudos!