### PR TITLE
Added BootstrapNodes to dht.ServerConfig

### DIFF
--- a/dht/announce.go
+++ b/dht/announce.go
@@ -51,7 +51,7 @@ func (s *Server) Announce(infoHash string, port int, impliedPort bool) (*Announc
 	}()
 	s.mu.Unlock()
 	if len(startAddrs) == 0 {
-		addrs, err := bootstrapAddrs()
+		addrs, err := bootstrapAddrs(s.bootstrapNodes)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This is beneficial to users who are running their own private DHT servers or have outbound connections to port 6881 disallowed on firewalls.