### PR TITLE
Speculative PR :-) Making using DHT more idiomatic Go

### DIFF
--- a/client.go
+++ b/client.go
@@ -588,6 +588,12 @@ func NewClient(cfg *Config) (cl *Client, err error) {
 		if err != nil {
 			return
 		}
+		go func() {
+			err := cl.dHT.Serve()
+			if err != nil {
+				panic(err)
+			}
+		}()
 	}
 
 	return
@@ -614,6 +620,9 @@ func (me *Client) Close() {
 	me.event.Broadcast()
 	for _, t := range me.torrents {
 		t.close()
+	}
+	if me.dHT != nil {
+		me.dHT.Close()
 	}
 }
 

--- a/cmd/dht-get-peers/main.go
+++ b/cmd/dht-get-peers/main.go
@@ -127,6 +127,12 @@ func setupSignals() {
 
 func main() {
 	seen := make(map[util.CompactPeer]struct{})
+	go func() {
+		err := s.Serve()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
 getPeers:
 	for {
 		ps, err := s.Announce(*infoHash, 0, false)

--- a/cmd/dht-ping/main.go
+++ b/cmd/dht-ping/main.go
@@ -31,7 +31,15 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("dht server on %s", s.Addr())
+
+	go func() {
+		log.Printf("dht server on %s", s.Addr())
+		err := s.Serve()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+
 	pingResponses := make(chan pingResponse)
 	timeoutChan := make(chan struct{})
 	go func() {

--- a/cmd/dht-server/main.go
+++ b/cmd/dht-server/main.go
@@ -85,7 +85,7 @@ func saveTable() error {
 	return nil
 }
 
-func setupSignals() {
+func setupSignals(s *dht.Server) {
 	ch := make(chan os.Signal)
 	signal.Notify(ch)
 	go func() {
@@ -108,7 +108,7 @@ func main() {
 		log.Fatalf("error loading table: %s", err)
 	}
 
-	setupSignals()
+	setupSignals(s)
 	log.Printf("dht server on %s, ID is %x", s.Addr(), s.ID())
 	if err := s.Serve(); err != nil {
 		log.Fatal(err)

--- a/dht/dht_test.go
+++ b/dht/dht_test.go
@@ -134,12 +134,16 @@ func TestPing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	go srv.Serve()
 	defer srv.Close()
+
 	srv0, err := NewServer(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	go srv0.Serve()
 	defer srv0.Close()
+
 	tn, err := srv.Ping(&net.UDPAddr{
 		IP:   []byte{127, 0, 0, 1},
 		Port: srv0.Addr().(*net.UDPAddr).Port,


### PR DESCRIPTION
NewServer returns reference to Server object but does not start
listening automatically. This is done via public Serve() method.
This makes writing server code more idiomatic Go - I have modified
dht-server code in cmd directory. ie. now the API now allows you to write code like
log.Fatal(s.Serve()) as oppose to empty selects and infinite loops etc.
I have also updated the tests which reflect the new API.
You will probably reject this PR but I'm giving this a shot anyway :)