### PR TITLE
Added support for trackerless metainfo files

### DIFF
--- a/metainfo/_testdata/trackerless.torrent
+++ b/metainfo/_testdata/trackerless.torrent
@@ -1,0 +1,1 @@
+d7:comment19:This is just a test10:created by12:Johnny Bravo13:creation datei1430648794e8:encoding5:UTF-84:infod6:lengthi1128e4:name12:testfile.bin12:piece lengthi32768e6:pieces20:Õˆë	=‘UŒäiÎ^æ °Eâ?ÇÒe5:nodesll35:udp://tracker.openbittorrent.com:8035:udp://tracker.openbittorrent.com:80eee

--- a/metainfo/metainfo.go
+++ b/metainfo/metainfo.go
@@ -144,8 +144,9 @@ func (this InfoEx) MarshalBencode() ([]byte, error) {
 
 type MetaInfo struct {
 	Info         InfoEx      `bencode:"info"`
-	Announce     string      `bencode:"announce"`
+	Announce     string      `bencode:"announce,omitempty"`
 	AnnounceList [][]string  `bencode:"announce-list,omitempty"`
+	Nodes        [][]string  `bencode:"nodes,omitempty"`
 	CreationDate int64       `bencode:"creation date,omitempty"`
 	Comment      string      `bencode:"comment,omitempty"`
 	CreatedBy    string      `bencode:"created by,omitempty"`

--- a/metainfo/metainfo_test.go
+++ b/metainfo/metainfo_test.go
@@ -43,4 +43,5 @@ func TestFile(t *testing.T) {
 	test_file(t, "_testdata/archlinux-2011.08.19-netinstall-i686.iso.torrent")
 	test_file(t, "_testdata/continuum.torrent")
 	test_file(t, "_testdata/23516C72685E8DB0C8F15553382A927F185C4F01.torrent")
+	test_file(t, "_testdata/trackerless.torrent")
 }


### PR DESCRIPTION
Based on the official spec
(http://www.bittorrent.org/beps/bep_0005.html) trackerless metainfo
files do not contain announce key. Instead nodes key has to be
specified. This PR adds support for nodes key into metainfo package. It
also contains a test metainfo file.