### PR TITLE
Add usage message to dht-ping cli

### DIFF
--- a/cmd/dht-ping/cli.go
+++ b/cmd/dht-ping/cli.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+const (
+	usageDoc = `dht-ping sends a Bittorrent DHT protocol "ping" message to the specified UDP
+address(es) (like router.bittorrent.com:6881) and reports the response
+it receives.
+`
+)
+
+var (
+	CommandLine = flag.NewFlagSet("dht-ping", 0)
+	timeout     = CommandLine.Duration("timeout", -1, "maximum timeout")
+)
+
+func init() {
+	CommandLine.Usage = usageMessageAndQuit
+}
+
+func usageMessageAndQuit() {
+	fmt.Printf("\nusage: dht-ping [-timeout] <node addresses>\n")
+	fmt.Printf("example: dht-ping router.bittorrent.com:6881\n")
+	flag.PrintDefaults()
+	fmt.Printf(usageDoc)
+	os.Exit(0)
+}

--- a/cmd/dht-ping/main.go
+++ b/cmd/dht-ping/main.go
@@ -2,7 +2,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"net"
@@ -20,13 +19,13 @@ type pingResponse struct {
 }
 
 func main() {
+	err := CommandLine.Parse(os.Args[1:])
+	pingStrAddrs := CommandLine.Args()
+
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
-	timeout := flag.Duration("timeout", -1, "maximum timeout")
-	flag.Parse()
-	pingStrAddrs := flag.Args()
 	if len(pingStrAddrs) == 0 {
-		os.Stderr.WriteString("u must specify addrs of nodes to ping e.g. router.bittorrent.com:6881\n")
-		os.Exit(2)
+		os.Stderr.WriteString("Error: no target UDP node addresses specified\n")
+		usageMessageAndQuit()
 	}
 	s, err := dht.NewServer(nil)
 	if err != nil {
@@ -79,6 +78,5 @@ pingResponsesLoop:
 			break pingResponsesLoop
 		}
 	}
-	// timeouts := len(pingStrAddrs) - responses
 	fmt.Printf("%d/%d responses (%f%%)\n", responses, len(pingStrAddrs), 100*float64(responses)/float64(len(pingStrAddrs)))
 }

--- a/cmd/dht-ping/main.go
+++ b/cmd/dht-ping/main.go
@@ -1,4 +1,5 @@
-// Pings DHT nodes with the given network addresses.
+// dht-ping is a cli tool that pings DHT nodes with the given UDP network
+// addresses and returns NodeID if sucessful
 package main
 
 import (
@@ -22,20 +23,28 @@ func main() {
 	err := CommandLine.Parse(os.Args[1:])
 	pingStrAddrs := CommandLine.Args()
 
-	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	if len(pingStrAddrs) == 0 {
 		os.Stderr.WriteString("Error: no target UDP node addresses specified\n")
 		usageMessageAndQuit()
 	}
+
+	err = sendPings(pingStrAddrs)
+	if err != nil {
+		fmt.Printf("Error: %s\n", err)
+		os.Exit(0)
+	}
+}
+
+// PingAddresses attempts to send the ping KRPC messages to the UDP addresses
+func sendPings(targets []string) error {
 	s, err := dht.NewServer(nil)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("cannot access UDP server for the dht node: %s", err)
 	}
-	log.Printf("dht server on %s", s.Addr())
 	pingResponsesChan := make(chan pingResponse)
 	timeoutChan := make(chan struct{})
 	go func() {
-		for i, netloc := range pingStrAddrs {
+		for i, netloc := range targets {
 			if i != 0 {
 				time.Sleep(1 * time.Millisecond)
 			}
@@ -66,7 +75,7 @@ func main() {
 	}()
 	responses := 0
 pingResponsesLoop:
-	for _ = range pingStrAddrs {
+	for _ = range targets {
 		select {
 		case resp := <-pingResponsesChan:
 			if !resp.msgOk {
@@ -77,6 +86,8 @@ pingResponsesLoop:
 		case <-timeoutChan:
 			break pingResponsesLoop
 		}
+		fmt.Printf("%d/%d responses (%f%%)\n", responses, len(targets), 100*float64(responses)/float64(len(targets)))
+
 	}
-	fmt.Printf("%d/%d responses (%f%%)\n", responses, len(pingStrAddrs), 100*float64(responses)/float64(len(pingStrAddrs)))
+	return nil
 }

--- a/cmd/dht-ping/send.go
+++ b/cmd/dht-ping/send.go
@@ -1,0 +1,1 @@
+package main

--- a/dht/doc.go
+++ b/dht/doc.go
@@ -1,25 +1,22 @@
-/*
-   Package dht implements a Distributed Hash Table (DHT) part of
-   the BitTorrent protocol,
-   as specified by BEP 5: http://www.bittorrent.org/beps/bep_0005.html
+// Package dht implements a Distributed Hash Table (DHT) part of
+//   the BitTorrent protocol,
+//   as specified by BEP 5: http://www.bittorrent.org/beps/bep_0005.html
+//
+//   BitTorrent uses a "distributed hash table" (DHT)
+//   for storing peer contact information for "trackerless" torrents.
+//    In effect, each peer becomes a tracker.
+//   The protocol is based on Kademila DHT protocol and is implemented over UDP.
+//
+//   Please note the terminology used to avoid confusion.
+//  A "peer" is a client/server listening on a TCP port that
+//  implements the BitTorrent protocol.
+//  A "node" is a client/server listening on a UDP port implementing
+//   the distributed hash table protocol.
+//   The DHT is composed of nodes and stores the location of peers.
+//   BitTorrent clients include a DHT node, which is used to contact other nodes
+//   in the DHT to get the location of peers to
+//   download from using the BitTorrent protocol.
 
-   BitTorrent uses a "distributed hash table" (DHT)
-   for storing peer contact information for "trackerless" torrents.
-    In effect, each peer becomes a tracker.
-   The protocol is based on Kademila DHT protocol and is implemented over UDP.
-
-   Please note the terminology used to avoid confusion.
-  A "peer" is a client/server listening on a TCP port that
-  implements the BitTorrent protocol.
-  A "node" is a client/server listening on a UDP port implementing
-   the distributed hash table protocol.
-   The DHT is composed of nodes and stores the location of peers.
-   BitTorrent clients include a DHT node, which is used to contact other nodes
-   in the DHT to get the location of peers to
-   download from using the BitTorrent protocol.
-
-   Standard use involves creating a Server, and calling Announce on it with
-   the details of your local torrent client and infohash of interest.
-*/
-
+//   Standard use involves creating a Server, and calling Announce on it with
+//   the details of your local torrent client and infohash of interest.
 package dht


### PR DESCRIPTION
This: 
* prints a nice message on how to use dht-ping cli tool when appropriate (when called without arguments, invalid arguments& flags passed,  called with the `-help` key)
* Fixes package docstring for dht package

