### PR TITLE
refactor struct identifiers to follow conventional go names

### DIFF
--- a/bencode/api.go
+++ b/bencode/api.go
@@ -18,8 +18,8 @@ type MarshalTypeError struct {
 	Type reflect.Type
 }
 
-func (this *MarshalTypeError) Error() string {
-	return "bencode: unsupported type: " + this.Type.String()
+func (e *MarshalTypeError) Error() string {
+	return "bencode: unsupported type: " + e.Type.String()
 }
 
 // Unmarshal argument must be a non-nil value of some pointer type.

--- a/bencode/tags.go
+++ b/bencode/tags.go
@@ -13,12 +13,12 @@ func parse_tag(tag string) (string, tag_options) {
 	return tag, tag_options("")
 }
 
-func (this tag_options) contains(option_name string) bool {
-	if len(this) == 0 {
+func (opts tag_options) contains(option_name string) bool {
+	if len(opts) == 0 {
 		return false
 	}
 
-	s := string(this)
+	s := string(opts)
 	for s != "" {
 		var next string
 		i := strings.Index(s, ",")

--- a/client_test.go
+++ b/client_test.go
@@ -443,15 +443,15 @@ func TestMergingTrackersByAddingSpecs(t *testing.T) {
 
 type badStorage struct{}
 
-func (me badStorage) OpenTorrent(*metainfo.InfoEx) (storage.Torrent, error) {
-	return me, nil
+func (bs badStorage) OpenTorrent(*metainfo.InfoEx) (storage.Torrent, error) {
+	return bs, nil
 }
 
-func (me badStorage) Close() error {
+func (bs badStorage) Close() error {
 	return nil
 }
 
-func (me badStorage) Piece(p metainfo.Piece) storage.Piece {
+func (bs badStorage) Piece(p metainfo.Piece) storage.Piece {
 	return badStoragePiece{p}
 }
 
@@ -459,25 +459,25 @@ type badStoragePiece struct {
 	p metainfo.Piece
 }
 
-func (me badStoragePiece) WriteAt(b []byte, off int64) (int, error) {
+func (p badStoragePiece) WriteAt(b []byte, off int64) (int, error) {
 	return 0, nil
 }
 
-func (me badStoragePiece) GetIsComplete() bool {
+func (p badStoragePiece) GetIsComplete() bool {
 	return true
 }
 
-func (me badStoragePiece) MarkComplete() error {
+func (p badStoragePiece) MarkComplete() error {
 	return errors.New("psyyyyyyyche")
 }
 
-func (me badStoragePiece) randomlyTruncatedDataString() string {
+func (p badStoragePiece) randomlyTruncatedDataString() string {
 	return "hello, world\n"[:rand.Intn(14)]
 }
 
-func (me badStoragePiece) ReadAt(b []byte, off int64) (n int, err error) {
-	r := strings.NewReader(me.randomlyTruncatedDataString())
-	return r.ReadAt(b, off+me.p.Offset())
+func (p badStoragePiece) ReadAt(b []byte, off int64) (n int, err error) {
+	r := strings.NewReader(p.randomlyTruncatedDataString())
+	return r.ReadAt(b, off+p.p.Offset())
 }
 
 // We read from a piece which is marked completed, but is missing data.

--- a/dht/closest_nodes.go
+++ b/dht/closest_nodes.go
@@ -9,23 +9,23 @@ type nodeMaxHeap struct {
 	Target nodeID
 }
 
-func (me nodeMaxHeap) Len() int { return len(me.IDs) }
+func (mh nodeMaxHeap) Len() int { return len(mh.IDs) }
 
-func (me nodeMaxHeap) Less(i, j int) bool {
-	m := me.IDs[i].Distance(&me.Target)
-	n := me.IDs[j].Distance(&me.Target)
+func (mh nodeMaxHeap) Less(i, j int) bool {
+	m := mh.IDs[i].Distance(&mh.Target)
+	n := mh.IDs[j].Distance(&mh.Target)
 	return m.Cmp(&n) > 0
 }
 
-func (me *nodeMaxHeap) Pop() (ret interface{}) {
-	ret, me.IDs = me.IDs[len(me.IDs)-1], me.IDs[:len(me.IDs)-1]
+func (mh *nodeMaxHeap) Pop() (ret interface{}) {
+	ret, mh.IDs = mh.IDs[len(mh.IDs)-1], mh.IDs[:len(mh.IDs)-1]
 	return
 }
-func (me *nodeMaxHeap) Push(val interface{}) {
-	me.IDs = append(me.IDs, val.(nodeID))
+func (mh *nodeMaxHeap) Push(val interface{}) {
+	mh.IDs = append(mh.IDs, val.(nodeID))
 }
-func (me nodeMaxHeap) Swap(i, j int) {
-	me.IDs[i], me.IDs[j] = me.IDs[j], me.IDs[i]
+func (mh nodeMaxHeap) Swap(i, j int) {
+	mh.IDs[i], mh.IDs[j] = mh.IDs[j], mh.IDs[i]
 }
 
 type closestNodesSelector struct {
@@ -33,15 +33,15 @@ type closestNodesSelector struct {
 	k       int
 }
 
-func (me *closestNodesSelector) Push(id nodeID) {
-	heap.Push(&me.closest, id)
-	if me.closest.Len() > me.k {
-		heap.Pop(&me.closest)
+func (cns *closestNodesSelector) Push(id nodeID) {
+	heap.Push(&cns.closest, id)
+	if cns.closest.Len() > cns.k {
+		heap.Pop(&cns.closest)
 	}
 }
 
-func (me *closestNodesSelector) IDs() []nodeID {
-	return me.closest.IDs
+func (cns *closestNodesSelector) IDs() []nodeID {
+	return cns.closest.IDs
 }
 
 func newKClosestNodesSelector(k int, targetID nodeID) (ret closestNodesSelector) {

--- a/dht/compactNodeInfo.go
+++ b/dht/compactNodeInfo.go
@@ -13,7 +13,7 @@ type CompactIPv4NodeInfo []NodeInfo
 
 var _ bencode.Unmarshaler = &CompactIPv4NodeInfo{}
 
-func (me *CompactIPv4NodeInfo) UnmarshalBencode(_b []byte) (err error) {
+func (i *CompactIPv4NodeInfo) UnmarshalBencode(_b []byte) (err error) {
 	var b []byte
 	err = bencode.Unmarshal(_b, &b)
 	if err != nil {
@@ -23,20 +23,20 @@ func (me *CompactIPv4NodeInfo) UnmarshalBencode(_b []byte) (err error) {
 		err = fmt.Errorf("bad length: %d", len(b))
 		return
 	}
-	for i := 0; i < len(b); i += CompactIPv4NodeInfoLen {
+	for k := 0; k < len(b); k += CompactIPv4NodeInfoLen {
 		var ni NodeInfo
-		err = ni.UnmarshalCompactIPv4(b[i : i+CompactIPv4NodeInfoLen])
+		err = ni.UnmarshalCompactIPv4(b[k : k+CompactIPv4NodeInfoLen])
 		if err != nil {
 			return
 		}
-		*me = append(*me, ni)
+		*i = append(*i, ni)
 	}
 	return
 }
 
-func (me CompactIPv4NodeInfo) MarshalBencode() (ret []byte, err error) {
+func (i CompactIPv4NodeInfo) MarshalBencode() (ret []byte, err error) {
 	var buf bytes.Buffer
-	for _, ni := range me {
+	for _, ni := range i {
 		buf.Write(ni.ID[:])
 		if ni.Addr == nil {
 			err = errors.New("nil addr in node info")

--- a/dht/dht.go
+++ b/dht/dht.go
@@ -194,8 +194,8 @@ type Peer struct {
 	Port int
 }
 
-func (me *Peer) String() string {
-	return net.JoinHostPort(me.IP.String(), strconv.FormatInt(int64(me.Port), 10))
+func (p *Peer) String() string {
+	return net.JoinHostPort(p.IP.String(), strconv.FormatInt(int64(p.Port), 10))
 }
 
 func bootstrapAddrs(nodeAddrs []string) (addrs []*net.UDPAddr, err error) {

--- a/dht/krpcError.go
+++ b/dht/krpcError.go
@@ -18,7 +18,7 @@ var (
 	_ error               = KRPCError{}
 )
 
-func (me *KRPCError) UnmarshalBencode(_b []byte) (err error) {
+func (e *KRPCError) UnmarshalBencode(_b []byte) (err error) {
 	var _v interface{}
 	err = bencode.Unmarshal(_b, &_v)
 	if err != nil {
@@ -26,20 +26,20 @@ func (me *KRPCError) UnmarshalBencode(_b []byte) (err error) {
 	}
 	switch v := _v.(type) {
 	case []interface{}:
-		me.Code = int(v[0].(int64))
-		me.Msg = v[1].(string)
+		e.Code = int(v[0].(int64))
+		e.Msg = v[1].(string)
 	case string:
-		me.Msg = v
+		e.Msg = v
 	default:
 		err = fmt.Errorf(`KRPC error bencode value has unexpected type: %T`, _v)
 	}
 	return
 }
 
-func (me KRPCError) MarshalBencode() (ret []byte, err error) {
-	return bencode.Marshal([]interface{}{me.Code, me.Msg})
+func (e KRPCError) MarshalBencode() (ret []byte, err error) {
+	return bencode.Marshal([]interface{}{e.Code, e.Msg})
 }
 
-func (me KRPCError) Error() string {
-	return fmt.Sprintf("KRPC error %d: %s", me.Code, me.Msg)
+func (e KRPCError) Error() string {
+	return fmt.Sprintf("KRPC error %d: %s", e.Code, e.Msg)
 }

--- a/dht/nodeinfo.go
+++ b/dht/nodeinfo.go
@@ -33,12 +33,12 @@ func (ni *NodeInfo) PutCompact(b []byte) error {
 	return nil
 }
 
-func (cni *NodeInfo) UnmarshalCompactIPv4(b []byte) error {
+func (ni *NodeInfo) UnmarshalCompactIPv4(b []byte) error {
 	if len(b) != CompactIPv4NodeInfoLen {
 		return errors.New("expected 26 bytes")
 	}
-	missinggo.CopyExact(cni.ID[:], b[:20])
-	cni.Addr = NewAddr(&net.UDPAddr{
+	missinggo.CopyExact(ni.ID[:], b[:20])
+	ni.Addr = NewAddr(&net.UDPAddr{
 		IP:   append(make([]byte, 0, 4), b[20:24]...),
 		Port: int(binary.BigEndian.Uint16(b[24:26])),
 	})

--- a/dht/server.go
+++ b/dht/server.go
@@ -709,7 +709,7 @@ func (s *Server) closestNodes(k int, target nodeID, filter func(*node) bool) []*
 	return ret
 }
 
-func (me *Server) badNode(addr Addr) {
-	me.badNodes.Add([]byte(addr.String()))
-	delete(me.nodes, addr.String())
+func (s *Server) badNode(addr Addr) {
+	s.badNodes.Add([]byte(addr.String()))
+	delete(s.nodes, addr.String())
 }

--- a/file.go
+++ b/file.go
@@ -24,11 +24,11 @@ func (f *File) Offset() int64 {
 	return f.offset
 }
 
-func (f File) FileInfo() metainfo.FileInfo {
+func (f *File) FileInfo() metainfo.FileInfo {
 	return f.fi
 }
 
-func (f File) Path() string {
+func (f *File) Path() string {
 	return f.path
 }
 

--- a/fs/torrentfs.go
+++ b/fs/torrentfs.go
@@ -227,15 +227,15 @@ func (dn dirNode) Attr(ctx context.Context, attr *fuse.Attr) error {
 	return nil
 }
 
-func (me rootNode) Lookup(ctx context.Context, name string) (_node fusefs.Node, err error) {
-	for _, t := range me.fs.Client.Torrents() {
+func (rn rootNode) Lookup(ctx context.Context, name string) (_node fusefs.Node, err error) {
+	for _, t := range rn.fs.Client.Torrents() {
 		info := t.Info()
 		if t.Name() != name || info == nil {
 			continue
 		}
 		__node := node{
 			metadata: info,
-			FS:       me.fs,
+			FS:       rn.fs,
 			t:        t,
 		}
 		if !info.IsDir() {
@@ -251,8 +251,8 @@ func (me rootNode) Lookup(ctx context.Context, name string) (_node fusefs.Node, 
 	return
 }
 
-func (me rootNode) ReadDirAll(ctx context.Context) (dirents []fuse.Dirent, err error) {
-	for _, t := range me.fs.Client.Torrents() {
+func (rn rootNode) ReadDirAll(ctx context.Context) (dirents []fuse.Dirent, err error) {
+	for _, t := range rn.fs.Client.Torrents() {
 		info := t.Info()
 		if info == nil {
 			continue
@@ -271,28 +271,28 @@ func (me rootNode) ReadDirAll(ctx context.Context) (dirents []fuse.Dirent, err e
 	return
 }
 
-func (rootNode) Attr(ctx context.Context, attr *fuse.Attr) error {
+func (rn rootNode) Attr(ctx context.Context, attr *fuse.Attr) error {
 	attr.Mode = os.ModeDir
 	return nil
 }
 
 // TODO(anacrolix): Why should rootNode implement this?
-func (me rootNode) Forget() {
-	me.fs.Destroy()
+func (rn rootNode) Forget() {
+	rn.fs.Destroy()
 }
 
 func (tfs *TorrentFS) Root() (fusefs.Node, error) {
 	return rootNode{tfs}, nil
 }
 
-func (me *TorrentFS) Destroy() {
-	me.mu.Lock()
+func (tfs *TorrentFS) Destroy() {
+	tfs.mu.Lock()
 	select {
-	case <-me.destroyed:
+	case <-tfs.destroyed:
 	default:
-		close(me.destroyed)
+		close(tfs.destroyed)
 	}
-	me.mu.Unlock()
+	tfs.mu.Unlock()
 }
 
 func New(cl *torrent.Client) *TorrentFS {

--- a/fs/torrentfs_test.go
+++ b/fs/torrentfs_test.go
@@ -60,8 +60,8 @@ type testLayout struct {
 	Metainfo  *metainfo.MetaInfo
 }
 
-func (me *testLayout) Destroy() error {
-	return os.RemoveAll(me.BaseDir)
+func (tl *testLayout) Destroy() error {
+	return os.RemoveAll(tl.BaseDir)
 }
 
 func newGreetingLayout() (tl testLayout, err error) {

--- a/iplist/iplist.go
+++ b/iplist/iplist.go
@@ -42,16 +42,16 @@ func New(initSorted []Range) *IPList {
 	}
 }
 
-func (me *IPList) NumRanges() int {
-	if me == nil {
+func (ipl *IPList) NumRanges() int {
+	if ipl == nil {
 		return 0
 	}
-	return len(me.ranges)
+	return len(ipl.ranges)
 }
 
 // Return the range the given IP is in. Returns nil if no range is found.
-func (me *IPList) Lookup(ip net.IP) (r Range, ok bool) {
-	if me == nil {
+func (ipl *IPList) Lookup(ip net.IP) (r Range, ok bool) {
+	if ipl == nil {
 		return
 	}
 	// TODO: Perhaps all addresses should be converted to IPv6, if the future
@@ -59,14 +59,14 @@ func (me *IPList) Lookup(ip net.IP) (r Range, ok bool) {
 	// memory for IPv4 addresses?
 	v4 := ip.To4()
 	if v4 != nil {
-		r, ok = me.lookup(v4)
+		r, ok = ipl.lookup(v4)
 		if ok {
 			return
 		}
 	}
 	v6 := ip.To16()
 	if v6 != nil {
-		return me.lookup(v6)
+		return ipl.lookup(v6)
 	}
 	if v4 == nil && v6 == nil {
 		r = Range{
@@ -103,12 +103,12 @@ func lookup(
 }
 
 // Return the range the given IP is in. Returns nil if no range is found.
-func (me *IPList) lookup(ip net.IP) (Range, bool) {
+func (ipl *IPList) lookup(ip net.IP) (Range, bool) {
 	return lookup(func(i int) net.IP {
-		return me.ranges[i].First
+		return ipl.ranges[i].First
 	}, func(i int) Range {
-		return me.ranges[i]
-	}, len(me.ranges), ip)
+		return ipl.ranges[i]
+	}, len(ipl.ranges), ip)
 }
 
 func minifyIP(ip *net.IP) {

--- a/metainfo/hash.go
+++ b/metainfo/hash.go
@@ -5,14 +5,14 @@ import "fmt"
 // 20-byte SHA1 hash used for info and pieces.
 type Hash [20]byte
 
-func (me Hash) Bytes() []byte {
-	return me[:]
+func (h Hash) Bytes() []byte {
+	return h[:]
 }
 
-func (ih *Hash) AsString() string {
-	return string(ih[:])
+func (h *Hash) AsString() string {
+	return string(h[:])
 }
 
-func (ih Hash) HexString() string {
-	return fmt.Sprintf("%x", ih[:])
+func (h Hash) HexString() string {
+	return fmt.Sprintf("%x", h[:])
 }

--- a/metainfo/metainfo.go
+++ b/metainfo/metainfo.go
@@ -138,45 +138,45 @@ func (info *Info) GeneratePieces(open func(fi FileInfo) (io.ReadCloser, error)) 
 	return nil
 }
 
-func (me *Info) TotalLength() (ret int64) {
-	if me.IsDir() {
-		for _, fi := range me.Files {
+func (info *Info) TotalLength() (ret int64) {
+	if info.IsDir() {
+		for _, fi := range info.Files {
 			ret += fi.Length
 		}
 	} else {
-		ret = me.Length
+		ret = info.Length
 	}
 	return
 }
 
-func (me *Info) NumPieces() int {
-	if len(me.Pieces)%20 != 0 {
-		panic(len(me.Pieces))
+func (info *Info) NumPieces() int {
+	if len(info.Pieces)%20 != 0 {
+		panic(len(info.Pieces))
 	}
-	return len(me.Pieces) / 20
+	return len(info.Pieces) / 20
 }
 
-func (me *InfoEx) Piece(i int) Piece {
-	return Piece{me, i}
+func (info *InfoEx) Piece(i int) Piece {
+	return Piece{info, i}
 }
 
-func (i *Info) IsDir() bool {
-	return len(i.Files) != 0
+func (info *Info) IsDir() bool {
+	return len(info.Files) != 0
 }
 
 // The files field, converted up from the old single-file in the parent info
 // dict if necessary. This is a helper to avoid having to conditionally handle
 // single and multi-file torrent infos.
-func (i *Info) UpvertedFiles() []FileInfo {
-	if len(i.Files) == 0 {
+func (info *Info) UpvertedFiles() []FileInfo {
+	if len(info.Files) == 0 {
 		return []FileInfo{{
-			Length: i.Length,
+			Length: info.Length,
 			// Callers should determine that Info.Name is the basename, and
 			// thus a regular file.
 			Path: nil,
 		}}
 	}
-	return i.Files
+	return info.Files
 }
 
 // The info dictionary with its hash and raw bytes exposed, as these are
@@ -192,23 +192,23 @@ var (
 	_ bencode.Unmarshaler = &InfoEx{}
 )
 
-func (this *InfoEx) UnmarshalBencode(data []byte) error {
-	this.Bytes = append(make([]byte, 0, len(data)), data...)
+func (ie *InfoEx) UnmarshalBencode(data []byte) error {
+	ie.Bytes = append(make([]byte, 0, len(data)), data...)
 	h := sha1.New()
-	_, err := h.Write(this.Bytes)
+	_, err := h.Write(ie.Bytes)
 	if err != nil {
 		panic(err)
 	}
-	this.Hash = new(Hash)
-	missinggo.CopyExact(this.Hash, h.Sum(nil))
-	return bencode.Unmarshal(data, &this.Info)
+	ie.Hash = new(Hash)
+	missinggo.CopyExact(ie.Hash, h.Sum(nil))
+	return bencode.Unmarshal(data, &ie.Info)
 }
 
-func (this InfoEx) MarshalBencode() ([]byte, error) {
-	if this.Bytes != nil {
-		return this.Bytes, nil
+func (ie InfoEx) MarshalBencode() ([]byte, error) {
+	if ie.Bytes != nil {
+		return ie.Bytes, nil
 	}
-	return bencode.Marshal(&this.Info)
+	return bencode.Marshal(&ie.Info)
 }
 
 type MetaInfo struct {

--- a/metainfo/nodes.go
+++ b/metainfo/nodes.go
@@ -14,7 +14,7 @@ var (
 	_ bencode.Unmarshaler = new(Node)
 )
 
-func (me *Node) UnmarshalBencode(b []byte) (err error) {
+func (n *Node) UnmarshalBencode(b []byte) (err error) {
 	var iface interface{}
 	err = bencode.Unmarshal(b, &iface)
 	if err != nil {
@@ -22,7 +22,7 @@ func (me *Node) UnmarshalBencode(b []byte) (err error) {
 	}
 	switch v := iface.(type) {
 	case string:
-		*me = Node(v)
+		*n = Node(v)
 	case []interface{}:
 		func() {
 			defer func() {
@@ -31,7 +31,7 @@ func (me *Node) UnmarshalBencode(b []byte) (err error) {
 					err = r.(error)
 				}
 			}()
-			*me = Node(net.JoinHostPort(v[0].(string), strconv.FormatInt(v[1].(int64), 10)))
+			*n = Node(net.JoinHostPort(v[0].(string), strconv.FormatInt(v[1].(int64), 10)))
 		}()
 	default:
 		err = fmt.Errorf("unsupported type: %T", iface)

--- a/metainfo/piece.go
+++ b/metainfo/piece.go
@@ -7,18 +7,18 @@ type Piece struct {
 	i    int
 }
 
-func (me Piece) Length() int64 {
-	if me.i == me.Info.NumPieces()-1 {
-		return me.Info.TotalLength() - int64(me.i)*me.Info.PieceLength
+func (p Piece) Length() int64 {
+	if p.i == p.Info.NumPieces()-1 {
+		return p.Info.TotalLength() - int64(p.i)*p.Info.PieceLength
 	}
-	return me.Info.PieceLength
+	return p.Info.PieceLength
 }
 
-func (me Piece) Offset() int64 {
-	return int64(me.i) * me.Info.PieceLength
+func (p Piece) Offset() int64 {
+	return int64(p.i) * p.Info.PieceLength
 }
 
-func (me Piece) Hash() (ret Hash) {
-	missinggo.CopyExact(&ret, me.Info.Pieces[me.i*20:(me.i+1)*20])
+func (p Piece) Hash() (ret Hash) {
+	missinggo.CopyExact(&ret, p.Info.Pieces[p.i*20:(p.i+1)*20])
 	return
 }

--- a/mmap_span/mmap_span.go
+++ b/mmap_span/mmap_span.go
@@ -11,20 +11,20 @@ type segment struct {
 	*mmap.MMap
 }
 
-func (me segment) Size() int64 {
-	return int64(len(*me.MMap))
+func (s segment) Size() int64 {
+	return int64(len(*s.MMap))
 }
 
 type MMapSpan struct {
 	span
 }
 
-func (me *MMapSpan) Append(mmap mmap.MMap) {
-	me.span = append(me.span, segment{&mmap})
+func (ms *MMapSpan) Append(mmap mmap.MMap) {
+	ms.span = append(ms.span, segment{&mmap})
 }
 
-func (me MMapSpan) Close() error {
-	for _, mMap := range me.span {
+func (ms MMapSpan) Close() error {
+	for _, mMap := range ms.span {
 		err := mMap.(segment).Unmap()
 		if err != nil {
 			log.Print(err)
@@ -33,15 +33,15 @@ func (me MMapSpan) Close() error {
 	return nil
 }
 
-func (me MMapSpan) Size() (ret int64) {
-	for _, seg := range me.span {
+func (ms MMapSpan) Size() (ret int64) {
+	for _, seg := range ms.span {
 		ret += seg.Size()
 	}
 	return
 }
 
-func (me MMapSpan) ReadAt(p []byte, off int64) (n int, err error) {
-	me.ApplyTo(off, func(intervalOffset int64, interval sizer) (stop bool) {
+func (ms MMapSpan) ReadAt(p []byte, off int64) (n int, err error) {
+	ms.ApplyTo(off, func(intervalOffset int64, interval sizer) (stop bool) {
 		_n := copy(p, (*interval.(segment).MMap)[intervalOffset:])
 		p = p[_n:]
 		n += _n
@@ -53,8 +53,8 @@ func (me MMapSpan) ReadAt(p []byte, off int64) (n int, err error) {
 	return
 }
 
-func (me MMapSpan) WriteAt(p []byte, off int64) (n int, err error) {
-	me.ApplyTo(off, func(iOff int64, i sizer) (stop bool) {
+func (ms MMapSpan) WriteAt(p []byte, off int64) (n int, err error) {
+	ms.ApplyTo(off, func(iOff int64, i sizer) (stop bool) {
 		mMap := i.(segment)
 		_n := copy((*mMap.MMap)[iOff:], p)
 		// err = mMap.Sync(gommap.MS_ASYNC)

--- a/mmap_span/span.go
+++ b/mmap_span/span.go
@@ -6,8 +6,8 @@ type sizer interface {
 
 type span []sizer
 
-func (me span) ApplyTo(off int64, f func(int64, sizer) (stop bool)) {
-	for _, interval := range me {
+func (s span) ApplyTo(off int64, f func(int64, sizer) (stop bool)) {
+	for _, interval := range s {
 		iSize := interval.Size()
 		if off >= iSize {
 			off -= iSize

--- a/mse/mse.go
+++ b/mse/mse.go
@@ -87,10 +87,10 @@ type cipherReader struct {
 	r io.Reader
 }
 
-func (me *cipherReader) Read(b []byte) (n int, err error) {
+func (cr *cipherReader) Read(b []byte) (n int, err error) {
 	be := make([]byte, len(b))
-	n, err = me.r.Read(be)
-	me.c.XORKeyStream(b[:n], be[:n])
+	n, err = cr.r.Read(be)
+	cr.c.XORKeyStream(b[:n], be[:n])
 	return
 }
 
@@ -103,14 +103,14 @@ type cipherWriter struct {
 	w io.Writer
 }
 
-func (me *cipherWriter) Write(b []byte) (n int, err error) {
+func (cr *cipherWriter) Write(b []byte) (n int, err error) {
 	be := make([]byte, len(b))
-	me.c.XORKeyStream(be, b)
-	n, err = me.w.Write(be)
+	cr.c.XORKeyStream(be, b)
+	n, err = cr.w.Write(be)
 	if n != len(be) {
 		// The cipher will have advanced beyond the callers stream position.
 		// We can't use the cipher anymore.
-		me.c = nil
+		cr.c = nil
 	}
 	return
 }

--- a/mse/mse_test.go
+++ b/mse/mse_test.go
@@ -109,9 +109,9 @@ type trackReader struct {
 	n int64
 }
 
-func (me *trackReader) Read(b []byte) (n int, err error) {
-	n, err = me.r.Read(b)
-	me.n += int64(n)
+func (tr *trackReader) Read(b []byte) (n int, err error) {
+	n, err = tr.r.Read(b)
+	tr.n += int64(n)
 	return
 }
 

--- a/piece.go
+++ b/piece.go
@@ -14,9 +14,9 @@ import (
 
 type piecePriority byte
 
-func (me *piecePriority) Raise(maybe piecePriority) {
-	if maybe > *me {
-		*me = maybe
+func (pp *piecePriority) Raise(maybe piecePriority) {
+	if maybe > *pp {
+		*pp = maybe
 	}
 }
 

--- a/storage/mmap.go
+++ b/storage/mmap.go
@@ -23,8 +23,8 @@ func NewMMap(baseDir string) I {
 	}
 }
 
-func (me *mmapStorage) OpenTorrent(info *metainfo.InfoEx) (t Torrent, err error) {
-	span, err := MMapTorrent(&info.Info, me.baseDir)
+func (s *mmapStorage) OpenTorrent(info *metainfo.InfoEx) (t Torrent, err error) {
+	span, err := MMapTorrent(&info.Info, s.baseDir)
 	t = &mmapTorrentStorage{
 		span: span,
 	}
@@ -36,17 +36,17 @@ type mmapTorrentStorage struct {
 	completed map[metainfo.Hash]bool
 }
 
-func (me *mmapTorrentStorage) Piece(p metainfo.Piece) Piece {
+func (ts *mmapTorrentStorage) Piece(p metainfo.Piece) Piece {
 	return mmapStoragePiece{
-		storage:  me,
+		storage:  ts,
 		p:        p,
-		ReaderAt: io.NewSectionReader(me.span, p.Offset(), p.Length()),
-		WriterAt: missinggo.NewSectionWriter(me.span, p.Offset(), p.Length()),
+		ReaderAt: io.NewSectionReader(ts.span, p.Offset(), p.Length()),
+		WriterAt: missinggo.NewSectionWriter(ts.span, p.Offset(), p.Length()),
 	}
 }
 
-func (me *mmapTorrentStorage) Close() error {
-	me.span.Close()
+func (ts *mmapTorrentStorage) Close() error {
+	ts.span.Close()
 	return nil
 }
 
@@ -57,15 +57,15 @@ type mmapStoragePiece struct {
 	io.WriterAt
 }
 
-func (me mmapStoragePiece) GetIsComplete() bool {
-	return me.storage.completed[me.p.Hash()]
+func (sp mmapStoragePiece) GetIsComplete() bool {
+	return sp.storage.completed[sp.p.Hash()]
 }
 
-func (me mmapStoragePiece) MarkComplete() error {
-	if me.storage.completed == nil {
-		me.storage.completed = make(map[metainfo.Hash]bool)
+func (sp mmapStoragePiece) MarkComplete() error {
+	if sp.storage.completed == nil {
+		sp.storage.completed = make(map[metainfo.Hash]bool)
 	}
-	me.storage.completed[me.p.Hash()] = true
+	sp.storage.completed[sp.p.Hash()] = true
 	return nil
 }
 

--- a/torrent.go
+++ b/torrent.go
@@ -670,9 +670,9 @@ func (t *Torrent) haveAllPieces() bool {
 	return t.completedPieces.Len() == t.numPieces()
 }
 
-func (me *Torrent) haveAnyPieces() bool {
-	for i := range me.pieces {
-		if me.pieceComplete(i) {
+func (t *Torrent) haveAnyPieces() bool {
+	for i := range t.pieces {
+		if t.pieceComplete(i) {
 			return true
 		}
 	}
@@ -701,9 +701,8 @@ func chunkIndex(cs chunkSpec, chunkSize pp.Integer) int {
 	return int(cs.Begin / chunkSize)
 }
 
-// TODO: This should probably be called wantPiece.
-func (t *Torrent) wantChunk(r request) bool {
-	if !t.wantPiece(int(r.Index)) {
+func (t *Torrent) wantPiece(r request) bool {
+	if !t.wantPieceIndex(int(r.Index)) {
 		return false
 	}
 	if t.pieces[r.Index].pendingChunk(r.chunkSpec, t.chunkSize) {
@@ -714,8 +713,7 @@ func (t *Torrent) wantChunk(r request) bool {
 	return false
 }
 
-// TODO: This should be called wantPieceIndex.
-func (t *Torrent) wantPiece(index int) bool {
+func (t *Torrent) wantPieceIndex(index int) bool {
 	if !t.haveInfo() {
 		return false
 	}

--- a/tracker/http.go
+++ b/tracker/http.go
@@ -56,9 +56,9 @@ func (r *httpResponse) UnmarshalPeers() (ret []Peer, err error) {
 	return
 }
 
-func (me *httpClient) Announce(ar *AnnounceRequest) (ret AnnounceResponse, err error) {
+func (c *httpClient) Announce(ar *AnnounceRequest) (ret AnnounceResponse, err error) {
 	// retain query parameters from announce URL
-	q := me.url.Query()
+	q := c.url.Query()
 
 	q.Set("info_hash", string(ar.InfoHash[:]))
 	q.Set("peer_id", string(ar.PeerId[:]))
@@ -73,7 +73,7 @@ func (me *httpClient) Announce(ar *AnnounceRequest) (ret AnnounceResponse, err e
 	q.Set("compact", "1")
 	// According to https://wiki.vuze.com/w/Message_Stream_Encryption.
 	q.Set("supportcrypto", "1")
-	var reqURL url.URL = me.url
+	var reqURL url.URL = c.url
 	reqURL.RawQuery = q.Encode()
 	resp, err := http.Get(reqURL.String())
 	if err != nil {
@@ -103,15 +103,15 @@ func (me *httpClient) Announce(ar *AnnounceRequest) (ret AnnounceResponse, err e
 	return
 }
 
-func (me *httpClient) Connect() error {
+func (c *httpClient) Connect() error {
 	// HTTP trackers do not require a connecting handshake.
 	return nil
 }
 
-func (me *httpClient) String() string {
-	return me.URL()
+func (c *httpClient) String() string {
+	return c.URL()
 }
 
-func (me *httpClient) URL() string {
-	return me.url.String()
+func (c *httpClient) URL() string {
+	return c.url.String()
 }

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -29,9 +29,9 @@ type AnnounceResponse struct {
 
 type AnnounceEvent int32
 
-func (me AnnounceEvent) String() string {
+func (e AnnounceEvent) String() string {
 	// See BEP 3, "event".
-	return []string{"empty", "completed", "started", "stopped"}[me]
+	return []string{"empty", "completed", "started", "stopped"}[e]
 }
 
 type Peer struct {

--- a/tracker/udp.go
+++ b/tracker/udp.go
@@ -93,9 +93,9 @@ type udpClient struct {
 	url                  url.URL
 }
 
-func (me *udpClient) Close() error {
-	if me.socket != nil {
-		return me.socket.Close()
+func (c *udpClient) Close() error {
+	if c.socket != nil {
+		return c.socket.Close()
 	}
 	return nil
 }

--- a/util/types.go
+++ b/util/types.go
@@ -22,19 +22,19 @@ var (
 )
 
 // This allows bencode.Unmarshal to do better than a string or []byte.
-func (me *CompactIPv4Peers) UnmarshalBencode(b []byte) (err error) {
+func (cps *CompactIPv4Peers) UnmarshalBencode(b []byte) (err error) {
 	var bb []byte
 	err = bencode.Unmarshal(b, &bb)
 	if err != nil {
 		return
 	}
-	*me, err = UnmarshalIPv4CompactPeers(bb)
+	*cps, err = UnmarshalIPv4CompactPeers(bb)
 	return
 }
 
-func (me CompactIPv4Peers) MarshalBinary() (ret []byte, err error) {
-	ret = make([]byte, len(me)*6)
-	for i, cp := range me {
+func (cps CompactIPv4Peers) MarshalBinary() (ret []byte, err error) {
+	ret = make([]byte, len(cps)*6)
+	for i, cp := range cps {
 		copy(ret[6*i:], cp.IP.To4())
 		binary.BigEndian.PutUint16(ret[6*i+4:], uint16(cp.Port))
 	}
@@ -52,39 +52,39 @@ var (
 	_ bencode.Unmarshaler = &CompactPeer{}
 )
 
-func (me CompactPeer) MarshalBencode() (ret []byte, err error) {
-	ip := me.IP
+func (cp CompactPeer) MarshalBencode() (ret []byte, err error) {
+	ip := cp.IP
 	if ip4 := ip.To4(); ip4 != nil {
 		ip = ip4
 	}
 	ret = make([]byte, len(ip)+2)
 	copy(ret, ip)
-	binary.BigEndian.PutUint16(ret[len(ip):], uint16(me.Port))
+	binary.BigEndian.PutUint16(ret[len(ip):], uint16(cp.Port))
 	return bencode.Marshal(ret)
 }
 
-func (me *CompactPeer) UnmarshalBinary(b []byte) error {
+func (cp *CompactPeer) UnmarshalBinary(b []byte) error {
 	switch len(b) {
 	case 18:
-		me.IP = make([]byte, 16)
+		cp.IP = make([]byte, 16)
 	case 6:
-		me.IP = make([]byte, 4)
+		cp.IP = make([]byte, 4)
 	default:
 		return fmt.Errorf("bad compact peer string: %q", b)
 	}
-	copy(me.IP, b)
-	b = b[len(me.IP):]
-	me.Port = int(binary.BigEndian.Uint16(b))
+	copy(cp.IP, b)
+	b = b[len(cp.IP):]
+	cp.Port = int(binary.BigEndian.Uint16(b))
 	return nil
 }
 
-func (me *CompactPeer) UnmarshalBencode(b []byte) (err error) {
+func (cp *CompactPeer) UnmarshalBencode(b []byte) (err error) {
 	var _b []byte
 	err = bencode.Unmarshal(b, &_b)
 	if err != nil {
 		return
 	}
-	return me.UnmarshalBinary(_b)
+	return cp.UnmarshalBinary(_b)
 }
 
 func UnmarshalIPv4CompactPeers(b []byte) (ret []CompactPeer, err error) {

--- a/worst_conns.go
+++ b/worst_conns.go
@@ -11,19 +11,19 @@ type worstConns struct {
 	cl *Client
 }
 
-func (me *worstConns) Len() int      { return len(me.c) }
-func (me *worstConns) Swap(i, j int) { me.c[i], me.c[j] = me.c[j], me.c[i] }
+func (wc *worstConns) Len() int      { return len(wc.c) }
+func (wc *worstConns) Swap(i, j int) { wc.c[i], wc.c[j] = wc.c[j], wc.c[i] }
 
-func (me *worstConns) Pop() (ret interface{}) {
-	old := me.c
+func (wc *worstConns) Pop() (ret interface{}) {
+	old := wc.c
 	n := len(old)
 	ret = old[n-1]
-	me.c = old[:n-1]
+	wc.c = old[:n-1]
 	return
 }
 
-func (me *worstConns) Push(x interface{}) {
-	me.c = append(me.c, x.(*connection))
+func (wc *worstConns) Push(x interface{}) {
+	wc.c = append(wc.c, x.(*connection))
 }
 
 type worstConnsSortKey struct {
@@ -32,20 +32,20 @@ type worstConnsSortKey struct {
 	connected   time.Time
 }
 
-func (me worstConnsSortKey) Less(other worstConnsSortKey) bool {
-	if me.useful != other.useful {
-		return !me.useful
+func (wc worstConnsSortKey) Less(other worstConnsSortKey) bool {
+	if wc.useful != other.useful {
+		return !wc.useful
 	}
-	if !me.lastHelpful.Equal(other.lastHelpful) {
-		return me.lastHelpful.Before(other.lastHelpful)
+	if !wc.lastHelpful.Equal(other.lastHelpful) {
+		return wc.lastHelpful.Before(other.lastHelpful)
 	}
-	return me.connected.Before(other.connected)
+	return wc.connected.Before(other.connected)
 }
 
-func (me *worstConns) key(i int) (key worstConnsSortKey) {
-	c := me.c[i]
-	key.useful = me.cl.usefulConn(me.t, c)
-	if me.cl.seeding(me.t) {
+func (wc *worstConns) key(i int) (key worstConnsSortKey) {
+	c := wc.c[i]
+	key.useful = wc.cl.usefulConn(wc.t, c)
+	if wc.cl.seeding(wc.t) {
 		key.lastHelpful = c.lastChunkSent
 	}
 	// Intentionally consider the last time a chunk was received when seeding,
@@ -57,6 +57,6 @@ func (me *worstConns) key(i int) (key worstConnsSortKey) {
 	return
 }
 
-func (me worstConns) Less(i, j int) bool {
-	return me.key(i).Less(me.key(j))
+func (wc worstConns) Less(i, j int) bool {
+	return wc.key(i).Less(wc.key(j))
 }


### PR DESCRIPTION
used gorename to ensure consistency - some function variables got renamed to make room 