### PR TITLE
fix listenedAddr  bug when TCP or UDP bind dynamic port

### DIFF
--- a/client.go
+++ b/client.go
@@ -222,18 +222,20 @@ func listen(tcp, utp bool, networkSuffix, addr string) (tcpL net.Listener, utpSo
 	if tcp && utp && port == 0 {
 		return listenBothSameDynamicPort(networkSuffix, host)
 	}
-	listenedAddr = addr
 	if tcp {
 		tcpL, err = listenTCP(networkSuffix, addr)
 		if err != nil {
 			return
 		}
+		listenedAddr = tcpL.Addr().String()
+
 	}
 	if utp {
 		utpSock, err = listenUTP(networkSuffix, addr)
 		if err != nil && tcp {
 			tcpL.Close()
 		}
+		listenedAddr = utpSock.Addr().String()
 	}
 	return
 }

--- a/client.go
+++ b/client.go
@@ -235,6 +235,7 @@ func listen(tcp, utp bool, networkSuffix, addr string) (tcpL net.Listener, utpSo
 		utpSock, err = listenUTP(networkSuffix, addr)
 		if err != nil && tcp {
 			tcpL.Close()
+			return
 		}
 		listenedAddr = utpSock.Addr().String()
 	}


### PR DESCRIPTION
when I disable TCP or UDP and  assign listen address  `x.x.x.x:0`, that means I want to use dynamic port to bind, then `listenedAddr` is not the real address. Anyway I think is a good choice to using `Addr().String()` for get bind real address.