### PR TITLE
add a feature: limit send piece rate

### DIFF
--- a/config.go
+++ b/config.go
@@ -40,6 +40,9 @@ type Config struct {
 
 	IPBlocklist iplist.Ranger
 	DisableIPv6 bool `long:"disable-ipv6"`
+	LimitSendPieceRate bool `long:"limit-send-piece-rate"`
+	// how many kB can be send every second
+	SendPieceRate uint32 `long:"max-kbyte-can-send-every-second"`
 	// Perform logging and any other behaviour that will help debug.
 	Debug bool `help:"enable debug logging"`
 }

--- a/connection.go
+++ b/connection.go
@@ -397,7 +397,7 @@ var (
 )
 
 // Writes buffers to the socket from the write channel.
-func (cn *connection) writer(keepAliveTimeout time.Duration) {
+func (cn *connection) writer(keepAliveTimeout time.Duration, cl *Client) {
 	defer func() {
 		cn.mu().Lock()
 		defer cn.mu().Unlock()
@@ -412,6 +412,9 @@ func (cn *connection) writer(keepAliveTimeout time.Duration) {
 			msg := cn.outgoingUnbufferedMessages.Remove(cn.outgoingUnbufferedMessages.Front()).(pp.Message)
 			cn.mu().Unlock()
 			b, err := msg.MarshalBinary()
+			if msg.Type == pp.Piece && cl.config.LimitSendPieceRate{
+				cl.rate.ApplyForSendByte(uint32(len(b)))
+			}
 			if err != nil {
 				panic(err)
 			}

--- a/connection_test.go
+++ b/connection_test.go
@@ -41,7 +41,7 @@ func TestCancelRequestOptimized(t *testing.T) {
 	// Check that write optimization filters out the Request, due to the
 	// Cancel. We should have received an Interested, due to the initial
 	// request, and then keep-alives until we close the connection.
-	go c.writer(0)
+	go c.writer(0, nil)
 	b := make([]byte, 9)
 	n, err := io.ReadFull(r, b)
 	require.NoError(t, err)
@@ -73,7 +73,11 @@ func TestSendBitfieldThenHave(t *testing.T) {
 		}{r, w},
 		outgoingUnbufferedMessages: list.New(),
 	}
-	go c.writer(time.Minute)
+	cfg := new(Config)
+	cfg.LimitSendPieceRate = true
+	cfg.SendPieceRate = 100
+	client, _ := NewClient(cfg)
+	go c.writer(time.Minute, client)
 	c.mu().Lock()
 	c.Bitfield([]bool{false, true, false})
 	c.mu().Unlock()

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -1,0 +1,63 @@
+package ratelimit
+
+import (
+	"sync"
+	"time"
+)
+
+type RateLimit struct {
+	MaxByte  uint32 // how many bytes can be send every second
+	RestByte uint32 // how many rest bytes can be seed
+	lock     sync.Mutex
+	period   time.Duration
+}
+
+func (r *RateLimit) PeriodicallyIncRate() {
+
+	if r.period == 0 {
+		r.period = time.Millisecond * 10
+	}
+
+	//assure period less than 1s
+	if r.period > time.Second {
+		r.period = time.Second
+	}
+
+	if r.RestByte == 0 {
+		r.RestByte = r.MaxByte
+	}
+	bytes := r.MaxByte / uint32((time.Second / r.period))
+	if bytes == 0{
+		panic("too small maxbyte")
+	}
+	ticker := time.NewTicker(r.period)
+	go func() {
+		for range ticker.C {
+			if r.RestByte >= r.MaxByte{
+				continue
+			}
+			r.lock.Lock()
+			r.RestByte += bytes
+			if r.RestByte > r.MaxByte{
+				r.RestByte = r.MaxByte
+			}
+			r.lock.Unlock()
+		}
+	}()
+}
+
+func (r *RateLimit) ApplyForSendByte(n uint32) {
+	for {
+		r.lock.Lock()
+		if r.RestByte >= n {
+			r.RestByte -= n
+			r.lock.Unlock()
+			break
+		} else {
+			r.lock.Unlock()
+			// just sleep
+			time.Sleep(r.period)
+		}
+
+	}
+}

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -1,0 +1,43 @@
+package ratelimit
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestRateLimit_ApplyForSendByte(t *testing.T) {
+	r := new(RateLimit)
+	r.RestByte = 10
+	r.MaxByte = 10
+	done1 := false
+	done2 := false
+	done3 := false
+	go func() {
+		r.ApplyForSendByte(11)
+		done1 = true
+	}()
+	go func() {
+		r.ApplyForSendByte(9)
+		done2 = true
+	}()
+	go func() {
+		r.ApplyForSendByte(9)
+		done3 = true
+	}()
+
+	time.Sleep(1 * time.Second)
+	assert.Equal(t, done1, false)
+	assert.Equal(t, done2 || done3, true)
+	assert.Equal(t, done2 && done3, false)
+}
+
+func TestRateLimit_PeriodicallyIncRate(t *testing.T) {
+
+	r := new(RateLimit)
+	r.RestByte = 10
+	r.MaxByte = 10 * 1024 * 1024
+	r.PeriodicallyIncRate()
+	time.Sleep(1 * time.Second)
+	assert.Equal(t, r.RestByte > 10, true)
+}


### PR DESCRIPTION
I want to add a feature which use [token bucket](https://en.wikipedia.org/wiki/Token_bucket)  to limit send piece rate. 