### PR TITLE
fix disabling of global bootstrap servers

### DIFF
--- a/dht/announce.go
+++ b/dht/announce.go
@@ -61,7 +61,7 @@ func (s *Server) Announce(infoHash string, port int, impliedPort bool) (*Announc
 		return
 	}()
 	s.mu.Unlock()
-	if len(startAddrs) == 0 {
+	if len(startAddrs) == 0 && !s.config.NoDefaultBootstrap {
 		addrs, err := bootstrapAddrs(s.bootstrapNodes)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
A missing condition leaves the default root servers to be added even if `NoDefaultBootstrap` is `true` and no custom bootstrap servers are specified.

This pull request adds the missing check.