### PR TITLE
torrentfs: fix panic when testPeer is not specified

### DIFF
--- a/cmd/torrentfs/main.go
+++ b/cmd/torrentfs/main.go
@@ -137,12 +137,15 @@ func main() {
 	resolveTestPeerAddr()
 	fs := torrentfs.New(client)
 	go exitSignalHandlers(fs)
-	go func() {
-		for {
-			addTestPeer(client)
-			time.Sleep(10 * time.Second)
-		}
-	}()
+
+	if testPeerAddr != nil {
+		go func() {
+			for {
+				addTestPeer(client)
+				time.Sleep(10 * time.Second)
+			}
+		}()
+	}
 
 	if err := fusefs.Serve(conn, fs); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Fixes #102