### PR TITLE
fs: fix isSubPath for top-level directories

### DIFF
--- a/fs/torrentfs.go
+++ b/fs/torrentfs.go
@@ -158,6 +158,9 @@ var (
 )
 
 func isSubPath(parent, child string) bool {
+	if len(parent) == 0 {
+		return len(child) > 0
+	}
 	if !strings.HasPrefix(child, parent) {
 		return false
 	}

--- a/fs/torrentfs_test.go
+++ b/fs/torrentfs_test.go
@@ -214,6 +214,7 @@ func TestIsSubPath(t *testing.T) {
 	}{
 		{"", "", false},
 		{"", "/", true},
+		{"", "a", true},
 		{"a/b", "a/bc", false},
 		{"a/b", "a/b", false},
 		{"a/b", "a/b/c", true},


### PR DESCRIPTION
I return false if parent="" and child="" only to satisfy the test (not sure when this happens). Otherwise I would have made it `if len(parent) == 0 { return true }`

Fixes #104 