### PR TITLE
fix `Spec.Storage` and allow per-torrent dir

### DIFF
--- a/torrent_test.go
+++ b/torrent_test.go
@@ -75,7 +75,7 @@ func TestTorrentString(t *testing.T) {
 // piece priorities everytime a reader (possibly in another Torrent) changed.
 func BenchmarkUpdatePiecePriorities(b *testing.B) {
 	cl := &Client{}
-	t := cl.newTorrent(metainfo.Hash{})
+	t := cl.newTorrent(metainfo.Hash{}, nil)
 	t.info = &metainfo.Info{
 		Pieces:      make([]byte, 20*13410),
 		PieceLength: 256 << 10,


### PR DESCRIPTION
`TorrentSpec.Storage` was not honored when calling `Client.AddTorrentSpec`
and the configured `cfg.DefaultStorage` was always used. Now if you construct
your `TorrentSpec` you can specify any `StorageImpl`

Also, the most common use case for custom storage being per-torrent paths for
FileStorage, this adds a `pathMaker` function to the File implementation that
allows customization, along with the default (always use base path) and my use
case (which seemed common enough from the Gitter chat) which is infohash based
subdirectories.

All Public methods have not changed signature, but 1 private method did, hence
the test update.