### PR TITLE
Add public methods for torrent peer counts

### DIFF
--- a/torrent_stats.go
+++ b/torrent_stats.go
@@ -2,4 +2,9 @@ package torrent
 
 type TorrentStats struct {
 	ConnStats // Aggregates stats over all connections past and present.
+
+	ActivePeers   int
+	HalfOpenPeers int
+	PendingPeers  int
+	TotalPeers    int
 }


### PR DESCRIPTION
I'd need access to peer counts, so I added 4 new methods on the Torrent struct to provide them.

`NumActivePeers`
`NumHalfOpenPeers`
`NumPendingPeers`
`NumTotalPeers`

The first three are straightforward and return the length of the underlying map (`t.conns`, `t.halfOpen`, and `t.peers`, respectively)

`NumTotalPeers` builds a map containing the set of all peer addresses and returns the length of that map, thus ensuring peers present in multiple maps aren't double counted.