### PR TITLE
bug fix: race condition between outgoing connection and incoming conn…

### DIFF
--- a/client.go
+++ b/client.go
@@ -899,7 +899,7 @@ func (cl *Client) runInitiatedHandshookConn(c *connection, t *Torrent) {
 		cl.dopplegangerAddrs[addr] = struct{}{}
 		return
 	}
-	cl.runHandshookConn(c, t)
+	cl.runHandshookConn(c, t, true)
 }
 
 func (cl *Client) runReceivedConn(c *connection) {
@@ -926,14 +926,14 @@ func (cl *Client) runReceivedConn(c *connection) {
 		// doppleganger.
 		return
 	}
-	cl.runHandshookConn(c, t)
+	cl.runHandshookConn(c, t, false)
 }
 
-func (cl *Client) runHandshookConn(c *connection, t *Torrent) {
+func (cl *Client) runHandshookConn(c *connection, t *Torrent, outgoing bool) {
 	c.conn.SetWriteDeadline(time.Time{})
 	c.r = deadlineReader{c.conn, c.r}
 	completedHandshakeConnectionFlags.Add(c.connectionFlags(), 1)
-	if !t.addConnection(c) {
+	if !t.addConnection(c, outgoing) {
 		return
 	}
 	defer t.dropConnection(c)


### PR DESCRIPTION
I think there is a race condition between `incomingConnection` and `outgoingConnection`, as `outgoingConnection` creates the connection(in `establishOutgoingConn`) first and then invokes `runHandshookConn`, which will close the connection if the peer has received a connection from the same peer. Since these two operation(`establishOutgoingConn` and `runHandshookConn`) are not atomic, maybe both peer will close the connetion.
Think about the example as follows: Peer A find Peer B from tracker and Peer B found Peer A too. Both peer invoke `establishOutgoingConn`, which opens a connection to the other one, and each peer invokes `incomingConnection` and record the connection. then each peer invokes `runHandshookConn` after the `establishOutgoingConn` operation, and both find the connection opened by the other side, in this condition, both peers will close the connetion opened by itself, and causes no available connection between the two peers.

solution: In `runHandshookConn`, if we found a connection already exist with the same peers, close the conenction from peer with low ID to the higher one. This promise both peers close the same connection, and retain the other one.