### PR TITLE
signal an event when torrent closed

### DIFF
--- a/torrent.go
+++ b/torrent.go
@@ -553,6 +553,7 @@ func (t *Torrent) close() (err error) {
 	for conn := range t.conns {
 		conn.Close()
 	}
+	t.cl.event.Broadcast()
 	t.pieceStateChanges.Close()
 	t.updateWantPeersEvent()
 	return


### PR DESCRIPTION
We need to broadcast an event when a torrent is closed, as other goroutines(such as the torrent `Reader`) maybe waiting for this.