### PR TITLE
guarantee randomness if reading data while downloading

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -549,7 +549,7 @@ func (cn *connection) updatePiecePriority(piece int) {
 	case PiecePriorityReadahead:
 		prio -= cn.t.numPieces()
 	case PiecePriorityNext, PiecePriorityNow:
-		prio -= 2 * cn.t.numPieces()
+		prio -= cn.t.numPieces()
 	default:
 		panic(tpp)
 	}


### PR DESCRIPTION
In my practice, I use a Reader to read torrent data sequentially while the torrent is downloading. In this condition, we reduce the priority of the piece which is reading right now, hope this piece will be download as soon as possible. However, this will result in sequential downloads as I read the data sequentially, loose randomness  between different connections. What about make the piece is reading right now has same priority with the pieces will be read ahead soon. This will promise some randomness  and the piece also can be available as soon as possible.