### PR TITLE
Do not add nodes if dht is disabled

### DIFF
--- a/client.go
+++ b/client.go
@@ -1331,6 +1331,9 @@ func (cl *Client) DHT() *dht.Server {
 }
 
 func (cl *Client) AddDHTNodes(nodes []string) {
+	if cl.DHT() == nil {
+		return
+	}
 	for _, n := range nodes {
 		hmp := missinggo.SplitHostMaybePort(n)
 		ip := net.ParseIP(hmp.Host)


### PR DESCRIPTION
If DHT is diabled, `Client.dht` will be nil, and the invoking of `AddDHTNodes` will cause a `nil pointer` panic. maybe we can do nothing in `AddDHTNodes` if DHT is disabled.