### PR TITLE
Added trigger for updatePieceCompletion()

### DIFF
--- a/torrent.go
+++ b/torrent.go
@@ -1004,6 +1004,11 @@ func (t *Torrent) putPieceInclination(pi []int) {
 	pieceInclinationsPut.Add(1)
 }
 
+// Trigger updatePieceCompletion
+func (t *Torrent) UpdatePieceCompletion(piece int) {
+	t.updatePieceCompletion(piece)
+}
+
 func (t *Torrent) updatePieceCompletion(piece int) {
 	pcu := t.pieceCompleteUncached(piece)
 	p := &t.pieces[piece]


### PR DESCRIPTION
When piece is completed it's marked as complete, but when it's not needed - we remove the piece and need to update completion properly, so that if we later need again this piece - it will be downloaded.

Could not find any better way other than triggering `updatePieceCompletion()` to avoid breaking the code.