### PR TITLE
Provide trackers specific http client

### DIFF
--- a/tracker/http.go
+++ b/tracker/http.go
@@ -24,6 +24,17 @@ type httpResponse struct {
 	Peers         interface{} `bencode:"peers"`
 }
 
+var netClient = &http.Client{
+	Timeout: time.Second * 15,
+	Transport: &http.Transport{
+		Dial: (&net.Dialer{
+			Timeout: 15 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: 15 * time.Second,
+		TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
+	},
+}
+
 func (r *httpResponse) UnmarshalPeers() (ret []Peer, err error) {
 	switch v := r.Peers.(type) {
 	case string:
@@ -78,7 +89,7 @@ func announceHTTP(ar *AnnounceRequest, _url *url.URL, host string) (ret Announce
 	setAnnounceParams(_url, ar)
 	req, err := http.NewRequest("GET", _url.String(), nil)
 	req.Host = host
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := netClient.Do(req)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Mainly follows https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779
but also disables HTTPS certificate verification.