### PR TITLE
added disable_libutp build flag usage

### DIFF
--- a/utp_go.go
+++ b/utp_go.go
@@ -1,4 +1,4 @@
-// +build !cgo
+// +build !cgo disable_libutp
 
 package torrent
 

--- a/utp_libutp.go
+++ b/utp_libutp.go
@@ -1,4 +1,4 @@
-// +build cgo
+// +build cgo,!disable_libutp
 
 package torrent
 


### PR DESCRIPTION
allow disable_libutp flag usage for build, in case cgo is used and you don't want to use libutp.