### PR TITLE
adding http user-agent setters and usage

### DIFF
--- a/cmd/tracker-announce/main.go
+++ b/cmd/tracker-announce/main.go
@@ -39,7 +39,7 @@ func main() {
 		ar.InfoHash = ts.InfoHash
 		for _, tier := range ts.Trackers {
 			for _, tURI := range tier {
-				resp, err := tracker.Announce(torrent.DefaultHTTPClient, tURI, &ar)
+				resp, err := tracker.Announce(torrent.DefaultHTTPClient, torrent.DefaultHTTPUserAgent, tURI, &ar)
 				if err != nil {
 					log.Print(err)
 					continue

--- a/config.go
+++ b/config.go
@@ -23,6 +23,7 @@ var DefaultHTTPClient = &http.Client{
 		TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
 	},
 }
+var DefaultHTTPUserAgent = "Go-Torrent/1.0"
 
 // Override Client defaults.
 type Config struct {
@@ -78,6 +79,8 @@ type Config struct {
 
 	// HTTP client used to query the tracker endpoint. Default is DefaultHTTPClient
 	HTTP *http.Client
+	// HTTPUserAgent changes default UserAgent for HTTP requests
+	HTTPUserAgent string `long:"http-user-agent"`
 	// Updated occasionally to when there's been some changes to client
 	// behaviour in case other clients are assuming anything of us. See also
 	// `bep20`.
@@ -103,6 +106,9 @@ type Config struct {
 func (cfg *Config) setDefaults() {
 	if cfg.HTTP == nil {
 		cfg.HTTP = DefaultHTTPClient
+	}
+	if cfg.HTTPUserAgent == "" {
+		cfg.HTTPUserAgent = DefaultHTTPUserAgent
 	}
 	if cfg.ExtendedHandshakeClientVersion == "" {
 		cfg.ExtendedHandshakeClientVersion = "go.torrent dev 20150624"

--- a/tracker/http.go
+++ b/tracker/http.go
@@ -73,10 +73,11 @@ func setAnnounceParams(_url *url.URL, ar *AnnounceRequest) {
 	_url.RawQuery = q.Encode()
 }
 
-func announceHTTP(cl *http.Client, ar *AnnounceRequest, _url *url.URL, host string) (ret AnnounceResponse, err error) {
+func announceHTTP(cl *http.Client, userAgent string, ar *AnnounceRequest, _url *url.URL, host string) (ret AnnounceResponse, err error) {
 	_url = httptoo.CopyURL(_url)
 	setAnnounceParams(_url, ar)
 	req, err := http.NewRequest("GET", _url.String(), nil)
+	req.Header.Set("User-Agent", userAgent)
 	req.Host = host
 	resp, err := cl.Do(req)
 	if err != nil {

--- a/tracker/http_test.go
+++ b/tracker/http_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/anacrolix/torrent/bencode"
 )
 
+var defaultHTTPUserAgent = "Go-Torrent"
+
 func TestUnmarshalHTTPResponsePeerDicts(t *testing.T) {
 	var hr httpResponse
 	require.NoError(t, bencode.Unmarshal([]byte("d5:peersl"+

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -54,18 +54,18 @@ var (
 	ErrBadScheme = errors.New("unknown scheme")
 )
 
-func Announce(cl *http.Client, urlStr string, req *AnnounceRequest) (res AnnounceResponse, err error) {
-	return AnnounceHost(cl, urlStr, req, "")
+func Announce(cl *http.Client, userAgent string, urlStr string, req *AnnounceRequest) (res AnnounceResponse, err error) {
+	return AnnounceHost(cl, userAgent, urlStr, req, "")
 }
 
-func AnnounceHost(cl *http.Client, urlStr string, req *AnnounceRequest, host string) (res AnnounceResponse, err error) {
+func AnnounceHost(cl *http.Client, userAgent string, urlStr string, req *AnnounceRequest, host string) (res AnnounceResponse, err error) {
 	_url, err := url.Parse(urlStr)
 	if err != nil {
 		return
 	}
 	switch _url.Scheme {
 	case "http", "https":
-		return announceHTTP(cl, req, _url, host)
+		return announceHTTP(cl, userAgent, req, _url, host)
 	case "udp":
 		return announceUDP(req, _url)
 	default:

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -21,7 +21,7 @@ var defaultClient = &http.Client{
 
 func TestUnsupportedTrackerScheme(t *testing.T) {
 	t.Parallel()
-	_, err := Announce(defaultClient, "lol://tracker.openbittorrent.com:80/announce", nil)
+	_, err := Announce(defaultClient, defaultHTTPUserAgent, "lol://tracker.openbittorrent.com:80/announce", nil)
 	if err != ErrBadScheme {
 		t.Fatal(err)
 	}

--- a/tracker/udp_test.go
+++ b/tracker/udp_test.go
@@ -114,7 +114,7 @@ func TestAnnounceLocalhost(t *testing.T) {
 	go func() {
 		require.NoError(t, srv.serveOne())
 	}()
-	ar, err := Announce(defaultClient, fmt.Sprintf("udp://%s/announce", srv.pc.LocalAddr().String()), &req)
+	ar, err := Announce(defaultClient, defaultHTTPUserAgent, fmt.Sprintf("udp://%s/announce", srv.pc.LocalAddr().String()), &req)
 	require.NoError(t, err)
 	assert.EqualValues(t, 1, ar.Seeders)
 	assert.EqualValues(t, 2, len(ar.Peers))
@@ -130,7 +130,7 @@ func TestUDPTracker(t *testing.T) {
 	}
 	rand.Read(req.PeerId[:])
 	copy(req.InfoHash[:], []uint8{0xa3, 0x56, 0x41, 0x43, 0x74, 0x23, 0xe6, 0x26, 0xd9, 0x38, 0x25, 0x4a, 0x6b, 0x80, 0x49, 0x10, 0xa6, 0x67, 0xa, 0xc1})
-	ar, err := Announce(defaultClient, "udp://tracker.openbittorrent.com:80/announce", &req)
+	ar, err := Announce(defaultClient, defaultHTTPUserAgent, "udp://tracker.openbittorrent.com:80/announce", &req)
 	// Skip any net errors as we don't control the server.
 	if _, ok := err.(net.Error); ok {
 		t.Skip(err)
@@ -166,7 +166,7 @@ func TestAnnounceRandomInfoHashThirdParty(t *testing.T) {
 		wg.Add(1)
 		go func(url string) {
 			defer wg.Done()
-			resp, err := Announce(defaultClient, url, &req)
+			resp, err := Announce(defaultClient, defaultHTTPUserAgent, url, &req)
 			if err != nil {
 				t.Logf("error announcing to %s: %s", url, err)
 				return
@@ -202,7 +202,7 @@ func TestURLPathOption(t *testing.T) {
 	}
 	defer conn.Close()
 	go func() {
-		_, err := Announce(defaultClient, (&url.URL{
+		_, err := Announce(defaultClient, defaultHTTPUserAgent, (&url.URL{
 			Scheme: "udp",
 			Host:   conn.LocalAddr().String(),
 			Path:   "/announce",

--- a/tracker_scraper.go
+++ b/tracker_scraper.go
@@ -85,7 +85,7 @@ func (me *trackerScraper) announce() (ret trackerAnnounceResult) {
 	me.t.cl.mu.Lock()
 	req := me.t.announceRequest()
 	me.t.cl.mu.Unlock()
-	res, err := tracker.AnnounceHost(me.t.cl.config.HTTP, urlToUse, &req, host)
+	res, err := tracker.AnnounceHost(me.t.cl.config.HTTP, me.t.cl.config.HTTPUserAgent, urlToUse, &req, host)
 	if err != nil {
 		ret.Err = err
 		return


### PR DESCRIPTION
Currently library is not setting User-Agent for HTTP requests, so by default it's 'Go-http-client/1.1' and that causes problems with trackers that have Whitelist settings.
Change allows to change default UserAgent to anything.