### PR TITLE
Implement generalized event and log interfaces

### DIFF
--- a/event/base_event.go
+++ b/event/base_event.go
@@ -1,0 +1,52 @@
+package event
+
+import (
+	"sync"
+
+	"github.com/anacrolix/torrent/log"
+)
+
+// BaseEvent is an internal event type used for log
+type BaseEvent struct {
+	*sync.Mutex
+	data *map[string]interface{}
+}
+
+func eventMsg(e log.Event) string {
+	d := *e.Data()
+
+	var ifc interface{}
+	var msg string
+	var ok bool
+	if ifc, ok = d["msg"]; ok {
+		msg, ok = ifc.(string)
+	}
+	if !ok {
+		msg = ""
+	}
+
+	return msg
+}
+
+// String Base string method reeturns msg
+func (e BaseEvent) String() string {
+	return buildMsg(e)
+}
+
+// Data returns map of data associated with event
+func (e BaseEvent) Data() *map[string]interface{} {
+	return e.data
+}
+
+// AddValue adds a KV pair of data to the event (prevent adding of msg or level)
+func (e BaseEvent) AddValue(k string, v interface{}) {
+	if k == "msg" {
+		return
+	}
+
+	e.Lock()
+	defer e.Unlock()
+
+	d := *e.data
+	d[k] = v
+}

--- a/event/error_event.go
+++ b/event/error_event.go
@@ -1,0 +1,60 @@
+package event
+
+import (
+	"fmt"
+
+	"github.com/anacrolix/torrent/log"
+	"github.com/pkg/errors"
+)
+
+type stackTracer interface {
+	StackTrace() errors.StackTrace
+}
+
+// ErrorEvent represents an error event
+type ErrorEvent struct {
+	log.Event
+}
+
+// String returns formated string for this type of event
+func (e ErrorEvent) String() string {
+	return buildMsg(e, withLastStackFrame, withLevel)
+}
+
+// GetStackTrace returns StackTrace from event
+func GetStackTrace(e log.Event) *errors.StackTrace {
+	d := *e.Data()
+
+	// Unwrap stack trace
+	var ifc interface{}
+	var st stackTracer
+	var ok bool
+	if ifc, ok = d["error"]; ok {
+		st, ok = ifc.(stackTracer)
+	}
+
+	if !ok {
+		return nil
+	}
+
+	trace := st.StackTrace()
+	return &trace
+}
+
+func withLastStackFrame(e log.Event, s string) string {
+	tp := GetStackTrace(e)
+
+	// return original string if no stack trace present
+	if tp == nil {
+		return s
+	}
+	trace := *tp
+
+	// Assumption that caller is 3rd frame down (created with NewErrorEvent)
+	// return original string if 3rd frame is OOB
+	if len(trace) < 3 {
+		return s
+	}
+
+	return fmt.Sprintf("[%v] %v", trace[2], s)
+}

--- a/event/event_creators.go
+++ b/event/event_creators.go
@@ -1,0 +1,42 @@
+package event
+
+import (
+	"sync"
+
+	"github.com/anacrolix/torrent/log"
+	"github.com/pkg/errors"
+)
+
+func createBaseEvent(msg string) BaseEvent {
+	d := make(map[string]interface{})
+	d["msg"] = msg
+	return BaseEvent{&sync.Mutex{}, &d}
+}
+
+func createLeveledEvent(msg string, lvl Level) log.Event {
+	evt := createBaseEvent(msg)
+	evt.AddValue("level", lvl)
+	return LeveledEvent{evt}
+}
+
+func createErrorEvent(msg string) log.Event {
+	evt := createBaseEvent(msg)
+	evt.AddValue("level", ErrorLevel)
+	evt.AddValue("error", errors.WithStack(errors.New(msg)))
+	return ErrorEvent{evt}
+}
+
+// Debug creates a basic debug level LeveledEvent
+func Debug(msg string) log.Event {
+	return createLeveledEvent(msg, DebugLevel)
+}
+
+// Info creates a basic info level LeveledEvent
+func Info(msg string) log.Event {
+	return createLeveledEvent(msg, InfoLevel)
+}
+
+// Error creates a basic error level LeveledEvent
+func Error(msg string) log.Event {
+	return createErrorEvent(msg)
+}

--- a/event/event_creators.go
+++ b/event/event_creators.go
@@ -26,17 +26,17 @@ func createErrorEvent(msg string) log.Event {
 	return ErrorEvent{evt}
 }
 
-// Debug creates a basic debug level LeveledEvent
+// Debug creates a debug level LeveledEvent
 func Debug(msg string) log.Event {
 	return createLeveledEvent(msg, DebugLevel)
 }
 
-// Info creates a basic info level LeveledEvent
+// Info creates an info level LeveledEvent
 func Info(msg string) log.Event {
 	return createLeveledEvent(msg, InfoLevel)
 }
 
-// Error creates a basic error level LeveledEvent
+// Error creates an ErrorEvent
 func Error(msg string) log.Event {
 	return createErrorEvent(msg)
 }

--- a/event/event_level.go
+++ b/event/event_level.go
@@ -1,0 +1,30 @@
+package event
+
+// Level indicates what level an event is
+type Level int
+
+const (
+	// DebugLevel is for marking events at Debug level
+	DebugLevel = Level(iota)
+	// UnknownLevel is not used for marking events level
+	UnknownLevel
+	// InfoLevel is for marking events at Info level
+	InfoLevel
+	// ErrorLevel is for marking events at Error level
+	ErrorLevel
+	// SilentLevel should not be used for marking events and is the highest level
+	SilentLevel
+)
+
+func (l Level) String() string {
+	switch l {
+	case DebugLevel:
+		return "DEBUG"
+	case InfoLevel:
+		return "INFO"
+	case ErrorLevel:
+		return "ERROR"
+	default:
+		return "???"
+	}
+}

--- a/event/leveled_event.go
+++ b/event/leveled_event.go
@@ -1,0 +1,40 @@
+package event
+
+import (
+	"fmt"
+
+	"github.com/anacrolix/torrent/log"
+)
+
+// LeveledEvent is an internal event type used for log
+type LeveledEvent struct {
+	log.Event
+}
+
+// String returns a string which prints event msg
+func (e LeveledEvent) String() string {
+	return buildMsg(e, withLevel)
+}
+
+// GetEventLevel returns level of event
+func GetEventLevel(e log.Event) Level {
+	d := *e.Data()
+
+	// Unwrap level, set to unknown if non-existant
+	var ifc interface{}
+	var lvl Level
+	var ok bool
+	if ifc, ok = d["level"]; ok {
+		lvl, ok = ifc.(Level)
+	}
+	if !ok {
+		return UnknownLevel
+	}
+
+	return lvl
+}
+
+func withLevel(e log.Event, s string) string {
+	lvl := GetEventLevel(e)
+	return fmt.Sprintf("[%v] %s", lvl, s)
+}

--- a/event/log_builder.go
+++ b/event/log_builder.go
@@ -1,0 +1,14 @@
+package event
+
+import "github.com/anacrolix/torrent/log"
+
+type logBuilder func(log.Event, string) string
+
+func buildMsg(e log.Event, lbs ...logBuilder) string {
+	msg := eventMsg(e)
+	for _, lb := range lbs {
+		msg = lb(e, msg)
+	}
+
+	return msg
+}

--- a/leveled_logger/leveled_logger.go
+++ b/leveled_logger/leveled_logger.go
@@ -1,0 +1,30 @@
+package leveled_logger
+
+import (
+	stdLog "log"
+	"os"
+
+	"github.com/anacrolix/torrent/event"
+	"github.com/anacrolix/torrent/log"
+)
+
+// LeveledLogger is a simple logger type that just filters by level
+type LeveledLogger struct {
+	logger   *stdLog.Logger
+	logLevel *event.Level
+}
+
+// Log filters by log level and prints logs
+func (l LeveledLogger) Log(e log.Event) {
+	lvl := event.GetEventLevel(e)
+	if lvl < *l.logLevel {
+		return
+	}
+
+	l.logger.Println(e)
+}
+
+// NewLeveledLogger creates a leveled logger
+func NewLeveledLogger(lvl event.Level) LeveledLogger {
+	return LeveledLogger{stdLog.New(os.Stderr, "", stdLog.LstdFlags), &lvl}
+}

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,14 @@
+package log
+
+import "fmt"
+
+// Event is a internal system event which will be logged
+type Event interface {
+	fmt.Stringer
+	Data() *map[string]interface{}
+}
+
+// Logger is an interface to a something that can handle logging of events
+type Logger interface {
+	Log(Event)
+}


### PR DESCRIPTION
Ref: https://github.com/anacrolix/torrent/issues/271
 - Add `log` package containing generalized internal (`Event`) and external (`Logger`) interfaces
 - Implement a fairly generalized and flexible set of events for usage inside package (`event`)
 - Implement a simple leveled default logger (`leveled_logger`)

This PR is more to get feedback on how you feel about this type of implementation.  I feel I made it pretty flexible.  The idea is, when the client is instantiated, the config would have a `Logger` property as it does already.  I made a `Logger` interface for this so anyone can make their own `Logger`.  The `Logger` only receives `Event`s and handles them as desired.

The simplest implementation could have a NOOP style implementation of `Log` that would never log anything.  A more complex version could introspect the event and do it's own filtering and formatting as desired.

`Event` is primarily for internal implementation.  Types (which need to log something) can have a copy of the `Logger` passed to them when they are instantiated.  After that they can easily call the `Logger` with an `Event` they created.

I added a few basic `Event` types to do some basic event logging and error logging.

Below is an example usage of the `event` and `leveled_logger` subpackages:
```
package main

import (
	"github.com/anacrolix/torrent/event"
	"github.com/anacrolix/torrent/leveled_logger"
)

func main() {
	l := leveled_logger.NewLeveledLogger(event.DebugLevel)
	l.Log(event.Debug("Test2"))
	l.Log(event.Info("test"))
	l.Log(event.Error("test"))
}
```