### PR TITLE
reverting usage of proxy for http requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -217,6 +219,12 @@ func NewClient(cfg *ClientConfig) (cl *Client, err error) {
 		_, err = rand.Read(cl.peerID[o:])
 		if err != nil {
 			panic("error generating peer id")
+		}
+	}
+
+	if cl.config.HTTPProxy == nil && cl.config.ProxyURL != "" {
+		if fixedURL, err := url.Parse(cl.config.ProxyURL); err == nil {
+			cl.config.HTTPProxy = http.ProxyURL(fixedURL)
 		}
 	}
 

--- a/config.go
+++ b/config.go
@@ -2,6 +2,8 @@ package torrent
 
 import (
 	"net"
+	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/anacrolix/dht"
@@ -67,7 +69,8 @@ type ClientConfig struct {
 	EncryptionPolicy
 
 	// Sets usage of Socks5 Proxy. Authentication should be included in the url if needed.
-	// Example of setting: "socks5://demo:demo@192.168.99.100:1080"
+	// Examples: socks5://demo:demo@192.168.99.100:1080
+	// 			 http://proxy.domain.com:3128
 	ProxyURL string
 
 	IPBlocklist      iplist.Ranger
@@ -77,6 +80,12 @@ type ClientConfig struct {
 	// Perform logging and any other behaviour that will help debug.
 	Debug bool `help:"enable debugging"`
 
+	// HTTPProxy defines proxy for HTTP requests.
+	// Format: func(*Request) (*url.URL, error),
+	// or result of http.ProxyURL(HTTPProxy).
+	// By default, it is composed from ClientConfig.ProxyURL,
+	// if not set explicitly in ClientConfig struct
+	HTTPProxy func(*http.Request) (*url.URL, error)
 	// HTTPUserAgent changes default UserAgent for HTTP requests
 	HTTPUserAgent string
 	// Updated occasionally to when there's been some changes to client

--- a/tracker/http.go
+++ b/tracker/http.go
@@ -105,6 +105,7 @@ func announceHTTP(opt Announce, _url *url.URL) (ret AnnounceResponse, err error)
 			Dial: (&net.Dialer{
 				Timeout: 15 * time.Second,
 			}).Dial,
+			Proxy:               opt.HTTPProxy,
 			TLSHandshakeTimeout: 15 * time.Second,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -2,6 +2,7 @@ package tracker
 
 import (
 	"errors"
+	"net/http"
 	"net/url"
 
 	"github.com/anacrolix/dht/krpc"
@@ -52,6 +53,7 @@ type Announce struct {
 	TrackerUrl string
 	Request    AnnounceRequest
 	HostHeader string
+	HTTPProxy  func(*http.Request) (*url.URL, error)
 	ServerName string
 	UserAgent  string
 	UdpNetwork string

--- a/tracker_scraper.go
+++ b/tracker_scraper.go
@@ -111,6 +111,7 @@ func (me *trackerScraper) announce() (ret trackerAnnounceResult) {
 	req := me.t.announceRequest()
 	me.t.cl.unlock()
 	res, err := tracker.Announce{
+		HTTPProxy:  me.t.cl.config.HTTPProxy,
 		UserAgent:  me.t.cl.config.HTTPUserAgent,
 		TrackerUrl: me.trackerUrl(ip),
 		Request:    req,


### PR DESCRIPTION
Trying to revert usage of proxies for HTTP requests.
I remember you did not want to use this way, but I don't see any good approach with less actions to do.

The change will add HTTPProxy, which can differ from listener's proxy, if needed. 
Tried on my environment, looks fine, all connections are made to the proxy.
