### PR TITLE
Add support for building snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,83 @@
+name: torrent
+version: '1.0'
+summary: Full-featured BitTorrent client package and utilities
+description: |
+  Full-featured BitTorrent client package and utilities
+grade: stable
+confinement: strict
+base: core18
+parts:
+  torrent:
+    plugin: go
+    source: https://github.com/anacrolix/torrent.git
+    go-importpath: github.com/anacrolix/torrent
+    build-packages:
+      - build-essential
+apps:
+  iplist:
+    command: bin/iplist
+    plugs:
+      - home
+      - network
+  magnet-metainfo:
+    command: bin/magnet-metainfo
+    plugs:
+      - home
+      - network
+  pack-blocklist:
+    command: bin/pack-blocklist
+    plugs:
+      - home
+      - network
+  torrent:
+    command: bin/torrent
+    plugs:
+      - home
+      - network
+      - network-bind
+  torrent-create:
+    command: bin/torrent-create
+    plugs:
+      - home
+      - network
+  torrentfs:
+    command: bin/torrentfs
+    plugs:
+      - home
+      - network
+      - fuse-support
+  torrent-infohash:
+    command: bin/torrent-infohash
+    plugs:
+      - home
+      - network
+  torrent-magnet:
+    command: bin/torrent-magnet
+    plugs:
+      - home
+      - network
+  torrent-metainfo-pprint:
+    command: bin/torrent-metainfo-pprint
+    plugs:
+      - home
+      - network
+  torrent-pick:
+    command: bin/torrent-pick
+    plugs:
+      - home
+      - network
+  torrent-verify:
+    command: bin/torrent-verify
+    plugs:
+      - home
+      - network
+  tracker-announce:
+    command: bin/tracker-announce
+    plugs:
+      - home
+      - network
+      - network-bind
+
+
+
+


### PR DESCRIPTION
Hey Matt,

I played around with torrent, and it seems like a nice little client. I did struggle a little figure out how to make magnet links, but in the end I got it. While testing, I also created a standalone package of torrent in the form of a snap. And so, I'd like to ask you to add support for snaps.

You must have heard of snaps - cross-distro packages, self-contained and with automatic updates, available through the Snap Store to millions of users - any distro that supports snap can install snap packages seamlessly, from Ubuntu via Manjaro to Fedora and then some.

I think this could work well for torrent, given that you might want to keep ip lists/blocks up to add and maybe add new features, and with automatic updates, you'll always have all your users at the latest version you push. If this sounds interesting, then you will find the technical details below.

Hint: Since you're in Straya, you might need to turn your display 180 degrees.

Test system: Ubuntu 17.04 with snapcraft command line tool, building locally - you can use build/CI, too or our free build system (build.snapcraft.io). Once you have the snap created, you can then upload to the Snap Store (snapcraft.io/store). We can help with promotion and branding.

snap install snapcraft --classic --beta
git clone https://github.com/igorljubuncic/torrent.git
cd torrent
git checkout add-snapcraft
snapcraft

This creates a <torrent-version>.snap file, something like torrent_1.0_amd64.snap.

You can test-install locally to see it works as expected:

snap install torrent_1.0_amd64.snap --dangerous

The --dangerous flag is necessary because the app (snap) isn't signed just yet.

Once installed, the torrent commands can be executed, e.g.: snap run <torrent command> <options>.

Since there are 12 binaries in the bundle, some behave slightly differently:

All strictly confined (it's a security mechanism in snaps), with access to home and network interfaces.
Torrent and tracker-announce also have network-bind (so they can be servers and listen).
Torrentfs also has fuse-support.

If you accept the PR, then there are a couple more steps:

- Register a developer account in the snap store https://snapcraft.io/account.
- Register the torrent name in the store.
- Upload a built snap to the store. 

snapcraft login
snapcraft register
snapcraft push torrent_1.0_amd64.snap --release edge

You release snaps to a channel. Channels = risk levels, with edge, beta, candidate and stable available. Edge is the least stable, of course. You can promote as you see after testing, but it's usually best to start with edge, especially if you build from master.

Finally, you can install torrent for the second time - but this time from the Snap Store itself, just to verify it all works well:

snap install torrent --edge

There you go. I hope this covers everything.