### PR TITLE
fix: only log errors when debug is set to true

### DIFF
--- a/client.go
+++ b/client.go
@@ -318,10 +318,12 @@ func (cl *Client) newDhtServer(conn net.PacketConn) (s *dht.Server, err error) {
 	if err == nil {
 		go func() {
 			ts, err := s.Bootstrap()
-			if err != nil {
-				log.Printf("error bootstrapping dht: %s", err)
+			if cl.config.Debug {
+				if err != nil {
+					log.Printf("error bootstrapping dht: %s", err)
+				}
+				log.Printf("%s: dht bootstrap: %#v", s, ts)
 			}
-			log.Printf("%s: dht bootstrap: %#v", s, ts)
 		}()
 	}
 	return

--- a/portfwd.go
+++ b/portfwd.go
@@ -10,9 +10,9 @@ import (
 
 func addPortMapping(d upnp.Device, proto upnp.Protocol, internalPort int, debug bool) {
 	externalPort, err := d.AddPortMapping(proto, internalPort, internalPort, "anacrolix/torrent", 0)
-	if err != nil {
+	if err != nil && debug {
 		log.Printf("error adding %s port mapping: %s", proto, err)
-	} else if externalPort != internalPort {
+	} else if externalPort != internalPort && debug {
 		log.Printf("external port %d does not match internal port %d in port mapping", externalPort, internalPort)
 	} else if debug {
 		log.Printf("forwarded external %s port %d", proto, externalPort)
@@ -26,9 +26,12 @@ func (cl *Client) forwardPort() {
 		return
 	}
 	cl.unlock()
+	upnp.Debug = cl.config.Debug
 	ds := upnp.Discover(0, 2*time.Second)
 	cl.lock()
-	flog.Default.Handle(flog.Fmsg("discovered %d upnp devices", len(ds)))
+	if cl.config.Debug {
+		flog.Default.Handle(flog.Fmsg("discovered %d upnp devices", len(ds)))
+	}
 	port := cl.incomingPeerPort()
 	cl.unlock()
 	for _, d := range ds {


### PR DESCRIPTION
This is related to #271, simply put when `Debug` is set to `false` this PR makes it to the user will see almost no log calls, allowing to use this package as a third-party library and having more control of what is sent to `Stderr` or not

@anacrolix are there any log calls that you wouldn't skip showing here?