### PR TITLE
torrentfs: some pathname-related fixes

### DIFF
--- a/fs/torrentfs.go
+++ b/fs/torrentfs.go
@@ -102,7 +102,12 @@ func (dn dirNode) ReadDirAll(ctx context.Context) (des []fuse.Dirent, err error)
 func (dn dirNode) Lookup(_ context.Context, name string) (fusefs.Node, error) {
 	dir := false
 	var file *torrent.File
-	fullPath := dn.path + "/" + name
+	var fullPath string
+	if dn.path != "" {
+		fullPath = dn.path + "/" + name
+	} else {
+		fullPath = name
+	}
 	for _, f := range dn.t.Files() {
 		if f.DisplayPath() == fullPath {
 			file = f

--- a/fs/torrentfs.go
+++ b/fs/torrentfs.go
@@ -78,10 +78,17 @@ func isSubPath(parent, child string) bool {
 func (dn dirNode) ReadDirAll(ctx context.Context) (des []fuse.Dirent, err error) {
 	names := map[string]bool{}
 	for _, fi := range dn.metadata.Files {
-		if !isSubPath(dn.path, strings.Join(fi.Path, "/")) {
+		filePathname := strings.Join(fi.Path, "/")
+		if !isSubPath(dn.path, filePathname) {
 			continue
 		}
-		name := fi.Path[len(dn.path)]
+		var name string
+		if dn.path == "" {
+			name = fi.Path[0]
+		} else {
+			dirPathname := strings.Split(dn.path, "/")
+			name = fi.Path[len(dirPathname)]
+		}
 		if names[name] {
 			continue
 		}


### PR DESCRIPTION
* Fix a bug where `ENOENT` is returned when the node for an entry in the root directory of a torrent is requested.  The problem was that the full pathname to each entry in that directory would wrongly get prefixed with a slash, which means that all comparisons against the pathnames of `(*torrent).File` objects would fail as the latter are always relative.
* Fix a bug where the basenames of files are extracted incorrectly when listing the entries in a directory.  The problem was that the `dirNode.path` string was treated as a list of path components when in fact it's just a pathname string.