### PR TITLE
Expose peer piece availability

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -326,6 +326,29 @@ func (cn *connection) PeerHasPiece(piece pieceIndex) bool {
 	return cn.peerSentHaveAll || cn.peerPieces.Contains(bitmap.BitIndex(piece))
 }
 
+func (cn *connection) PeerBitfield() []bool {
+	if !cn.t.haveInfo() {
+		return nil
+	}
+
+	bf := make([]bool, cn.t.numPieces())
+
+	if cn.peerSentHaveAll {
+		for i, _ := range(bf) {
+			bf[i] = true
+		}
+
+		return bf
+	}
+
+	cn.peerPieces.IterTyped(func(piece int) bool {
+		bf[piece] = true
+		return true
+	})
+
+	return bf
+}
+
 // Writes a message into the write buffer.
 func (cn *connection) Post(msg pp.Message) {
 	torrent.Add(fmt.Sprintf("messages posted of type %s", msg.Type.String()), 1)

--- a/torrent.go
+++ b/torrent.go
@@ -729,7 +729,7 @@ func (t *Torrent) PieceAvailabilityList() (connCount int, connBitfieldSum []int)
 				continue
 			}
 
-			availList[i] += 1
+			connBitfieldSum[i] += 1
 		}
 	}
 

--- a/torrent.go
+++ b/torrent.go
@@ -710,6 +710,31 @@ func (t *Torrent) bitfield() (bf []bool) {
 	return
 }
 
+func (t *Torrent) CompletedPiecesBitfield() []bool {
+	return t.bitfield()
+}
+
+func (t *Torrent) PieceAvailabilityList() (int, []int) {
+	if !t.haveInfo() {
+		return 0, nil
+	}
+
+	availList := make([]int, t.numPieces())
+	connCount := len(t.conns)
+	for conn := range t.conns {
+		bitfield := conn.PeerBitfield()
+		for i, bit := range bitfield {
+			if !bit {
+				continue
+			}
+
+			availList[i] += 1
+		}
+	}
+
+	return connCount, availList
+}
+
 func (t *Torrent) pieceNumChunks(piece pieceIndex) pp.Integer {
 	return (t.pieceLength(piece) + t.chunkSize - 1) / t.chunkSize
 }

--- a/torrent.go
+++ b/torrent.go
@@ -714,13 +714,14 @@ func (t *Torrent) CompletedPiecesBitfield() []bool {
 	return t.bitfield()
 }
 
-func (t *Torrent) PieceAvailabilityList() (int, []int) {
+// Returns a list containing the number of peers that have a specific piece available
+func (t *Torrent) PieceAvailabilityList() (connCount int, connBitfieldSum []int) {
 	if !t.haveInfo() {
-		return 0, nil
+		return
 	}
 
-	availList := make([]int, t.numPieces())
-	connCount := len(t.conns)
+	connBitfieldSum = make([]int, t.numPieces())
+	connCount = len(t.conns)
 	for conn := range t.conns {
 		bitfield := conn.PeerBitfield()
 		for i, bit := range bitfield {
@@ -732,7 +733,7 @@ func (t *Torrent) PieceAvailabilityList() (int, []int) {
 		}
 	}
 
-	return connCount, availList
+	return
 }
 
 func (t *Torrent) pieceNumChunks(piece pieceIndex) pp.Integer {


### PR DESCRIPTION
This will allow clients to read information relating to piece scarcity. One use case would be adjusting piece priority to download the uncommon pieces first.