### PR TITLE
Anthonyraymond export well known

### DIFF
--- a/tracker/http.go
+++ b/tracker/http.go
@@ -18,7 +18,7 @@ import (
 	"github.com/anacrolix/torrent/bencode"
 )
 
-type httpResponse struct {
+type HttpResponse struct {
 	FailureReason string `bencode:"failure reason"`
 	Interval      int32  `bencode:"interval"`
 	TrackerId     string `bencode:"tracker id"`
@@ -136,7 +136,7 @@ func announceHTTP(opt Announce, _url *url.URL) (ret AnnounceResponse, err error)
 		err = fmt.Errorf("response from tracker: %s: %s", resp.Status, buf.String())
 		return
 	}
-	var trackerResponse httpResponse
+	var trackerResponse HttpResponse
 	err = bencode.Unmarshal(buf.Bytes(), &trackerResponse)
 	if _, ok := err.(bencode.ErrUnusedTrailingBytes); ok {
 		err = nil

--- a/tracker/http_test.go
+++ b/tracker/http_test.go
@@ -12,7 +12,7 @@ import (
 var defaultHTTPUserAgent = "Go-Torrent"
 
 func TestUnmarshalHTTPResponsePeerDicts(t *testing.T) {
-	var hr httpResponse
+	var hr HttpResponse
 	require.NoError(t, bencode.Unmarshal(
 		[]byte("d5:peersl"+
 			"d2:ip7:1.2.3.47:peer id20:thisisthe20bytepeeri4:porti9999ee"+
@@ -35,7 +35,7 @@ func TestUnmarshalHTTPResponsePeerDicts(t *testing.T) {
 }
 
 func TestUnmarshalHttpResponseNoPeers(t *testing.T) {
-	var hr httpResponse
+	var hr HttpResponse
 	require.NoError(t, bencode.Unmarshal(
 		[]byte("d6:peers618:123412341234123456e"),
 		&hr,
@@ -45,7 +45,7 @@ func TestUnmarshalHttpResponseNoPeers(t *testing.T) {
 }
 
 func TestUnmarshalHttpResponsePeers6NotCompact(t *testing.T) {
-	var hr httpResponse
+	var hr HttpResponse
 	require.Error(t, bencode.Unmarshal(
 		[]byte("d6:peers6lee"),
 		&hr,


### PR DESCRIPTION
Hi,

Since the `HttpResponse` that resides in tracker/http.go is a well known structure i'd like to have it exported. This structs is already tagged with bencode and is easily reusable, more than and than it's well tested. I feel like it should be exported to be use-able in other projects.

How do you feel about that?