### PR TITLE
Add BytesCompleted method for files

### DIFF
--- a/file.go
+++ b/file.go
@@ -6,6 +6,7 @@ import (
 	"github.com/anacrolix/missinggo/bitmap"
 
 	"github.com/anacrolix/torrent/metainfo"
+	pp "github.com/anacrolix/torrent/peer_protocol"
 )
 
 // Provides access to regions of torrent data that correspond to its files.
@@ -59,9 +60,28 @@ func (f *File) bytesCompleted() int64 {
 }
 
 func (f *File) bytesLeft() (left int64) {
-	bitmap.Flip(f.t.completedPieces, f.firstPieceIndex(), f.endPieceIndex()+1).IterTyped(func(piece int) bool {
+	firstPieceIndex := f.firstPieceIndex()
+	endPieceIndex := f.endPieceIndex()
+	bitmap.Flip(f.t.completedPieces, firstPieceIndex, endPieceIndex+1).IterTyped(func(piece int) bool {
 		p := &f.t.pieces[piece]
 		left += int64(p.length() - p.numDirtyBytes())
+		return true
+	})
+	startPiece := f.t.piece(firstPieceIndex)
+	endChunk := int(f.offset%f.t.info.PieceLength) * int(startPiece.numChunks()) / int(startPiece.length())
+	bitmap.Flip(startPiece.dirtyChunks, 0, endChunk).IterTyped(func(chunk int) bool {
+		left -= int64(startPiece.chunkSize())
+		return true
+	})
+	endPiece := f.t.piece(endPieceIndex)
+	startChunk := int((f.offset+f.length)%f.t.info.PieceLength) * int(endPiece.numChunks()) / int(endPiece.length())
+	lastChunkIndex := int(endPiece.lastChunkIndex())
+	bitmap.Flip(endPiece.dirtyChunks, startChunk, int(endPiece.numChunks())).IterTyped(func(chunk int) bool {
+		if chunk == lastChunkIndex {
+			left -= int64(endPiece.chunkIndexSpec(pp.Integer(chunk)).Length)
+		} else {
+			left -= int64(endPiece.chunkSize())
+		}
 		return true
 	})
 	return

--- a/file.go
+++ b/file.go
@@ -51,11 +51,7 @@ func (f *File) BytesCompleted() int64 {
 	return f.bytesCompleted()
 }
 
-// Don't call this before the info is available.
 func (f *File) bytesCompleted() int64 {
-	if !f.t.haveInfo() {
-		return 0
-	}
 	return f.length - f.bytesLeft()
 }
 


### PR DESCRIPTION
It would be good to have some method for getting the BytesCompleted per file.
This is a possible solution for that. We could probably add a check to ensure bytesLeft is never greater than the file length.