### PR TITLE
use path.utf8 first for some torrent

### DIFF
--- a/metainfo/fileinfo.go
+++ b/metainfo/fileinfo.go
@@ -4,8 +4,9 @@ import "strings"
 
 // Information specific to a single file inside the MetaInfo structure.
 type FileInfo struct {
-	Length int64    `bencode:"length"`
-	Path   []string `bencode:"path"`
+	Length   int64    `bencode:"length"`
+	Path     []string `bencode:"path"`
+	PathUTF8 []string `bencode:"path.utf-8,omitempty"`
 }
 
 func (fi *FileInfo) DisplayPath(info *Info) string {

--- a/t.go
+++ b/t.go
@@ -189,9 +189,15 @@ func (t *Torrent) initFiles() {
 	var offset int64
 	t.files = new([]*File)
 	for _, fi := range t.info.UpvertedFiles() {
+		var path []string
+		if len(fi.PathUTF8) != 0 {
+			path = fi.PathUTF8
+		} else {
+			path = fi.Path
+		}
 		*t.files = append(*t.files, &File{
 			t,
-			strings.Join(append([]string{t.info.Name}, fi.Path...), "/"),
+			strings.Join(append([]string{t.info.Name}, path...), "/"),
 			offset,
 			fi.Length,
 			fi,


### PR DESCRIPTION
non-Latin letters in the file names will appear garbled. To solve this problem, some programs write the utf-8 name in the field path.utf-8 and write the field path in some other encoding.