### PR TITLE
Possibility to change UpnP ID

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,6 +32,7 @@ type ClientConfig struct {
 	ListenHost              func(network string) string
 	ListenPort              int
 	NoDefaultPortForwarding bool
+	UpnPID			string
 	// Don't announce to trackers. This only leaves DHT to discover peers.
 	DisableTrackers bool `long:"disable-trackers"`
 	DisablePEX      bool `long:"disable-pex"`
@@ -151,6 +152,7 @@ func NewDefaultClientConfig() *ClientConfig {
 		HTTPUserAgent:                  DefaultHTTPUserAgent,
 		ExtendedHandshakeClientVersion: "go.torrent dev 20181121",
 		Bep20:                          "-GT0002-",
+		UpnPID:				"anacrolix/torrent",
 		NominalDialTimeout:             20 * time.Second,
 		MinDialTimeout:                 3 * time.Second,
 		EstablishedConnsPerTorrent:     50,

--- a/config.go
+++ b/config.go
@@ -152,7 +152,7 @@ func NewDefaultClientConfig() *ClientConfig {
 		HTTPUserAgent:                  DefaultHTTPUserAgent,
 		ExtendedHandshakeClientVersion: "go.torrent dev 20181121",
 		Bep20:                          "-GT0002-",
-		UpnPID:				"anacrolix/torrent",
+		UpnpID:				"anacrolix/torrent",
 		NominalDialTimeout:             20 * time.Second,
 		MinDialTimeout:                 3 * time.Second,
 		EstablishedConnsPerTorrent:     50,

--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ type ClientConfig struct {
 	ListenHost              func(network string) string
 	ListenPort              int
 	NoDefaultPortForwarding bool
-	UpnPID			string
+	UpnpID			string
 	// Don't announce to trackers. This only leaves DHT to discover peers.
 	DisableTrackers bool `long:"disable-trackers"`
 	DisablePEX      bool `long:"disable-pex"`

--- a/portfwd.go
+++ b/portfwd.go
@@ -29,7 +29,7 @@ func (cl *Client) forwardPort() {
 	cl.lock()
 	cl.logger.Printf("discovered %d upnp devices", len(ds))
 	port := cl.incomingPeerPort()
-	id := cl.config.UpnPID
+	id := cl.config.UpnpID
 	cl.unlock()
 	for _, d := range ds {
 		go cl.addPortMapping(d, upnp.TCP, port, id)

--- a/portfwd.go
+++ b/portfwd.go
@@ -7,8 +7,8 @@ import (
 	"github.com/anacrolix/upnp"
 )
 
-func (cl *Client) addPortMapping(d upnp.Device, proto upnp.Protocol, internalPort int) {
-	externalPort, err := d.AddPortMapping(proto, internalPort, internalPort, "anacrolix/torrent", 0)
+func (cl *Client) addPortMapping(d upnp.Device, proto upnp.Protocol, internalPort int, upnpID string) {
+	externalPort, err := d.AddPortMapping(proto, internalPort, internalPort, upnpID, 0)
 	if err != nil {
 		cl.logger.WithValues(log.Warning).Printf("error adding %s port mapping: %s", proto, err)
 	} else if externalPort != internalPort {
@@ -29,10 +29,11 @@ func (cl *Client) forwardPort() {
 	cl.lock()
 	cl.logger.Printf("discovered %d upnp devices", len(ds))
 	port := cl.incomingPeerPort()
+	id := cl.config.UpnPID
 	cl.unlock()
 	for _, d := range ds {
-		go cl.addPortMapping(d, upnp.TCP, port)
-		go cl.addPortMapping(d, upnp.UDP, port)
+		go cl.addPortMapping(d, upnp.TCP, port, id)
+		go cl.addPortMapping(d, upnp.UDP, port, id)
 	}
 	cl.lock()
 }


### PR DESCRIPTION
New config option that one can set to change UpnP ID, which is listed as service name in routers etc. It's still anacrolix/torrent by default.