### PR TITLE
 Break out dialer and accepting listener conn 

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,6 +37,9 @@ type ClientConfig struct {
 	DisableTrackers bool `long:"disable-trackers"`
 	DisablePEX      bool `long:"disable-pex"`
 
+	// Disables the default Listener and Dialers.
+	NoDefaultConns bool `long:"disable-default-conns"`
+
 	// Don't create a DHT.
 	NoDHT            bool `long:"disable-dht"`
 	DhtStartingNodes dht.StartingNodesGetter

--- a/connection_test.go
+++ b/connection_test.go
@@ -23,7 +23,7 @@ func TestSendBitfieldThenHave(t *testing.T) {
 		config: TestingConfig(),
 	}
 	cl.initLogger()
-	c := cl.newConnection(nil, false, IpPort{}, "")
+	c := cl.newConnection(nil, false, IpPort{})
 	c.setTorrent(cl.newTorrent(metainfo.Hash{}, nil))
 	c.t.setInfo(&metainfo.Info{
 		Pieces: make([]byte, metainfo.HashSize*3),
@@ -107,7 +107,7 @@ func BenchmarkConnectionMainReadLoop(b *testing.B) {
 	t.setChunkSize(defaultChunkSize)
 	t._pendingPieces.Set(0, PiecePriorityNormal.BitmapPriority())
 	r, w := net.Pipe()
-	cn := cl.newConnection(r, true, IpPort{}, "")
+	cn := cl.newConnection(r, true, IpPort{})
 	cn.setTorrent(t)
 	mrlErr := make(chan error)
 	msg := pp.Message{

--- a/socket.go
+++ b/socket.go
@@ -13,13 +13,13 @@ import (
 	"golang.org/x/net/proxy"
 )
 
-type dialer interface {
+type Dialer interface {
 	dial(_ context.Context, addr string) (net.Conn, error)
 }
 
 type socket interface {
 	net.Listener
-	dialer
+	Dialer
 }
 
 func getProxyDialer(proxyURL string) (proxy.Dialer, error) {


### PR DESCRIPTION
Addresses #356 

During testing I found that passing in a unix domain socket doesn't work because there is an assumption that addresses have port numbers. So if that was fixed, one could use TmpDir for the test, and of course pass in domain sockets in real client code.

My first approach was to try and make `NewClient` a wrapper around `NewClientWithSockets`, but the `listenAll` dependency on `cl.firewallFunction` meant that the client has to be instantiated before socket creation. That is why I split it out into `initClient` and `initSockets`. If, in a future API, Client was more like http.Server and separated construction from starting, then the client would be ready to go before we make the sockets.