### PR TITLE
PEX: integrate with send throttling

### DIFF
--- a/peerconn.go
+++ b/peerconn.go
@@ -564,7 +564,9 @@ func (cn *PeerConn) fillWriteBuffer(msg func(pp.Message) bool) {
 		cn.requestsLowWater = len(cn.requests) / 2
 	}
 	if cn.pex.IsEnabled() {
-		cn.pex.Share(msg) // gated internally
+		if flow := cn.pex.Share(msg); !flow {
+			return
+		}
 	}
 	cn.upload(msg)
 }


### PR DESCRIPTION
Prevent further write attempts if the write buffer is full. Extends #353.