### PR TITLE
add BEP references to documentation of metadata fields

### DIFF
--- a/metainfo/fileinfo.go
+++ b/metainfo/fileinfo.go
@@ -4,8 +4,8 @@ import "strings"
 
 // Information specific to a single file inside the MetaInfo structure.
 type FileInfo struct {
-	Length   int64    `bencode:"length"`
-	Path     []string `bencode:"path"`
+	Length   int64    `bencode:"length"` // BEP3
+	Path     []string `bencode:"path"`   // BEP3
 	PathUTF8 []string `bencode:"path.utf-8,omitempty"`
 }
 

--- a/metainfo/info.go
+++ b/metainfo/info.go
@@ -14,14 +14,14 @@ import (
 
 // The info dictionary.
 type Info struct {
-	PieceLength int64  `bencode:"piece length"`
-	Pieces      []byte `bencode:"pieces"`
-	Name        string `bencode:"name"`
-	Length      int64  `bencode:"length,omitempty"`
-	Private     *bool  `bencode:"private,omitempty"`
+	PieceLength int64  `bencode:"piece length"`      // BEP3
+	Pieces      []byte `bencode:"pieces"`            // BEP3
+	Name        string `bencode:"name"`              // BEP3
+	Length      int64  `bencode:"length,omitempty"`  // BEP3, mutually exclusive with Files
+	Private     *bool  `bencode:"private,omitempty"` // BEP27
 	// TODO: Document this field.
 	Source string     `bencode:"source,omitempty"`
-	Files  []FileInfo `bencode:"files,omitempty"`
+	Files  []FileInfo `bencode:"files,omitempty"` // BEP3, mutually exclusive with Length
 }
 
 // This is a helper that sets Files and Pieces from a root path and its

--- a/metainfo/metainfo.go
+++ b/metainfo/metainfo.go
@@ -9,15 +9,15 @@ import (
 )
 
 type MetaInfo struct {
-	InfoBytes    bencode.Bytes `bencode:"info,omitempty"`
-	Announce     string        `bencode:"announce,omitempty"`
-	AnnounceList AnnounceList  `bencode:"announce-list,omitempty"`
-	Nodes        []Node        `bencode:"nodes,omitempty"`
+	InfoBytes    bencode.Bytes `bencode:"info,omitempty"`          // BEP 3
+	Announce     string        `bencode:"announce,omitempty"`      // BEP 3
+	AnnounceList AnnounceList  `bencode:"announce-list,omitempty"` // BEP 12
+	Nodes        []Node        `bencode:"nodes,omitempty"`         // BEP 5
 	CreationDate int64         `bencode:"creation date,omitempty,ignore_unmarshal_type_error"`
 	Comment      string        `bencode:"comment,omitempty"`
 	CreatedBy    string        `bencode:"created by,omitempty"`
 	Encoding     string        `bencode:"encoding,omitempty"`
-	UrlList      UrlList       `bencode:"url-list,omitempty"`
+	UrlList      UrlList       `bencode:"url-list,omitempty"` // BEP 19
 }
 
 // Load a MetaInfo from an io.Reader. Returns a non-nil error in case of


### PR DESCRIPTION
Add respective BEP numbers to the comments for each of the metadata fields. This should help finding information on the format and appropriate use.

Those fields which I couldn't find in a BEP are left out.