### PR TITLE
torrent-metainfo-pprint: include the 'nodes' field into the output when non-empty

### DIFF
--- a/cmd/torrent-metainfo-pprint/main.go
+++ b/cmd/torrent-metainfo-pprint/main.go
@@ -47,6 +47,9 @@ func processReader(r io.Reader) error {
 		"AnnounceList": metainfo.AnnounceList,
 		"UrlList":      metainfo.UrlList,
 	}
+	if len(metainfo.Nodes) >  0 {
+		d["Nodes"] = metainfo.Nodes
+	}
 	if flags.Files {
 		d["Files"] = info.UpvertedFiles()
 	}


### PR DESCRIPTION
Helps to confirm custom addresses.