### PR TITLE
Add DisallowDataDownload/Upload to TorrentSpec and small log cleanup

### DIFF
--- a/client.go
+++ b/client.go
@@ -1148,6 +1148,7 @@ func (cl *Client) AddTorrentSpec(spec *TorrentSpec) (t *Torrent, new bool, err e
 }
 
 // The trackers will be merged with the existing ones. If the Info isn't yet known, it will be set.
+// spec.DisallowDataDownload/Upload will be read and applied
 // The display name is replaced if the new spec provides one. Note that any `Storage` is ignored.
 func (t *Torrent) MergeSpec(spec *TorrentSpec) error {
 	if spec.DisplayName != "" {
@@ -1172,6 +1173,8 @@ func (t *Torrent) MergeSpec(spec *TorrentSpec) error {
 	}
 	t.addTrackers(spec.Trackers)
 	t.maybeNewConns()
+	t.dataDownloadDisallowed = spec.DisallowDataDownload
+	t.dataUploadDisallowed = spec.DisallowDataUpload
 	return nil
 }
 

--- a/spec.go
+++ b/spec.go
@@ -22,6 +22,10 @@ type TorrentSpec struct {
 	// The chunk size to use for outbound requests. Defaults to 16KiB if not set.
 	ChunkSize int
 	Storage   storage.ClientImpl
+
+	// Whether to allow data download or upload
+	DisallowDataUpload   bool
+	DisallowDataDownload bool
 }
 
 func TorrentSpecFromMagnetURI(uri string) (spec *TorrentSpec, err error) {

--- a/torrent.go
+++ b/torrent.go
@@ -1975,7 +1975,6 @@ func (t *Torrent) DisallowDataDownload() {
 }
 
 func (t *Torrent) disallowDataDownloadLocked() {
-	log.Printf("disallowing data download")
 	t.dataDownloadDisallowed = true
 	t.iterPeers(func(c *peer) {
 		c.updateRequests()
@@ -1985,7 +1984,6 @@ func (t *Torrent) disallowDataDownloadLocked() {
 func (t *Torrent) AllowDataDownload() {
 	t.cl.lock()
 	defer t.cl.unlock()
-	log.Printf("AllowDataDownload")
 	t.dataDownloadDisallowed = false
 	t.iterPeers(func(c *peer) {
 		c.updateRequests()
@@ -1995,7 +1993,6 @@ func (t *Torrent) AllowDataDownload() {
 func (t *Torrent) AllowDataUpload() {
 	t.cl.lock()
 	defer t.cl.unlock()
-	log.Printf("AllowDataUpload")
 	t.dataUploadDisallowed = false
 	for c := range t.conns {
 		c.updateRequests()
@@ -2005,7 +2002,6 @@ func (t *Torrent) AllowDataUpload() {
 func (t *Torrent) DisallowDataUpload() {
 	t.cl.lock()
 	defer t.cl.unlock()
-	log.Printf("DisallowDataUpload")
 	t.dataUploadDisallowed = true
 	for c := range t.conns {
 		c.updateRequests()


### PR DESCRIPTION
For https://github.com/anacrolix/torrent/pull/408#issuecomment-637211537

I wasn't 1000% sure about whether setting the torrent properties belonged in `MergeSpec`, but it seemed to follow the existing functionality.

Thanks!