### PR TITLE
Update metainfo.go

### DIFF
--- a/metainfo/metainfo.go
+++ b/metainfo/metainfo.go
@@ -61,7 +61,7 @@ func (mi MetaInfo) Write(w io.Writer) error {
 
 // Set good default values in preparation for creating a new MetaInfo file.
 func (mi *MetaInfo) SetDefaults() {
-	mi.Comment = "yoloham"
+	mi.Comment = ""
 	mi.CreatedBy = "github.com/anacrolix/torrent"
 	mi.CreationDate = time.Now().Unix()
 	// mi.Info.PieceLength = 256 * 1024


### PR DESCRIPTION
delete "yoloham" so that is no longer the default comment string on torrents made without a comment specified. Should resolve https://github.com/anacrolix/torrent/issues/342