### PR TITLE
PEX: impede full-meching in tracker-less swarms by adding a cooldown minute

### DIFF
--- a/pex.go
+++ b/pex.go
@@ -3,6 +3,7 @@ package torrent
 import (
 	"net"
 	"sync"
+	"time"
 
 	"github.com/anacrolix/dht/v2/krpc"
 	pp "github.com/anacrolix/torrent/peer_protocol"
@@ -181,6 +182,7 @@ func shortestIP(ip net.IP) net.IP {
 type pexState struct {
 	ev        []pexEvent    // event feed, append-only
 	hold      []pexEvent    // delayed drops
+	rest      time.Time     // cooldown deadline on inbound
 	nc        int           // net number of alive conns
 	initCache pexMsgFactory // last generated initial message
 	initSeq   int           // number of events which went into initCache
@@ -192,6 +194,7 @@ func (s *pexState) Reset() {
 	s.ev = nil
 	s.hold = nil
 	s.nc = 0
+	s.rest = time.Time{}
 	s.initLock.Lock()
 	s.initCache = pexMsgFactory{}
 	s.initSeq = 0


### PR DESCRIPTION
Tracker-less PEX-only swarms quickly turn fully meshed (every peer has a connection to every other peer), contrary to tracker-backed swarms which have periodic poll interval for contacting trackers.  Proposed  is to mimic the throttling of peering info supply by adding a  minute-long cool down period (which  coincides with  the shortest  tracker announce interval) during which incoming PEX messages are discarded without processing.

Thoughts and comments are welcome, @anacrolix 