### PR TITLE
Align webtorrent tracker to BEP-3

### DIFF
--- a/webtorrent/tracker_protocol.go
+++ b/webtorrent/tracker_protocol.go
@@ -12,7 +12,7 @@ type AnnounceRequest struct {
 	Uploaded   int64   `json:"uploaded"`
 	Downloaded int64   `json:"downloaded"`
 	Left       int64   `json:"left"`
-	Event      string  `json:"event"`
+	Event      string  `json:"event,omitempty"`
 	Action     string  `json:"action"`
 	InfoHash   string  `json:"info_hash"`
 	PeerID     string  `json:"peer_id"`


### PR DESCRIPTION
Adding "omitempty" to json marshalling, bringing the webtorrent tracker AnnounceRequest in line
with BEP-3, which states omitting the the "event" field is acceptable.

Fixes half of: https://github.com/anacrolix/torrent/issues/416