### PR TITLE
Remove bradfitz/iter package dependency

### DIFF
--- a/bencode/bench_test.go
+++ b/bencode/bench_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/anacrolix/dht/v2/krpc"
-	"github.com/bradfitz/iter"
-
 	"github.com/anacrolix/torrent/bencode"
 )
 
@@ -40,7 +38,7 @@ func BenchmarkMarshalThenUnmarshalKrpcMsg(tb *testing.B) {
 	}
 	tb.ReportAllocs()
 	tb.ResetTimer()
-	for range iter.N(tb.N) {
+	for i := 0; i < tb.N; i++ {
 		marshalAndUnmarshal(tb, orig)
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -12,7 +12,6 @@ import (
 	"testing/iotest"
 	"time"
 
-	"github.com/bradfitz/iter"
 	"github.com/frankban/quicktest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -143,7 +142,7 @@ func TestAddDropManyTorrents(t *testing.T) {
 	cl, err := NewClient(TestingConfig(t))
 	require.NoError(t, err)
 	defer cl.Close()
-	for i := range iter.N(1000) {
+	for i := 0; i < 1000; i++ {
 		var spec TorrentSpec
 		binary.PutVarint(spec.InfoHash[:], int64(i))
 		tt, new, err := cl.AddTorrentSpec(&spec)
@@ -215,7 +214,7 @@ func BenchmarkAddLargeTorrent(b *testing.B) {
 	require.NoError(b, err)
 	defer cl.Close()
 	b.ReportAllocs()
-	for range iter.N(b.N) {
+	for i := 0; i < b.N; i++ {
 		t, err := cl.AddTorrentFromFile("testdata/bootstrap.dat.torrent")
 		if err != nil {
 			b.Fatal(err)
@@ -366,7 +365,7 @@ func TestTorrentDroppedBeforeGotInfo(t *testing.T) {
 }
 
 func writeTorrentData(ts *storage.Torrent, info metainfo.Info, b []byte) {
-	for i := range iter.N(info.NumPieces()) {
+	for i := 0; i < info.NumPieces(); i++ {
 		p := info.Piece(i)
 		ts.Piece(p).WriteAt(b[p.Offset():p.Offset()+p.Length()], 0)
 	}
@@ -619,7 +618,7 @@ func TestSetMaxEstablishedConn(t *testing.T) {
 	cfg := TestingConfig(t)
 	cfg.DisableAcceptRateLimiting = true
 	cfg.DropDuplicatePeerIds = true
-	for i := range iter.N(3) {
+	for i := 0; i < 3; i++ {
 		cl, err := NewClient(cfg)
 		require.NoError(t, err)
 		defer cl.Close()

--- a/cmd/torrent-metainfo-pprint/main.go
+++ b/cmd/torrent-metainfo-pprint/main.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/anacrolix/envpprof"
 	"github.com/anacrolix/tagflag"
-	"github.com/bradfitz/iter"
-
 	"github.com/anacrolix/torrent/metainfo"
 )
 
@@ -55,7 +53,7 @@ func processReader(r io.Reader) error {
 	}
 	if flags.PieceHashes {
 		d["PieceHashes"] = func() (ret []string) {
-			for i := range iter.N(info.NumPieces()) {
+			for i := 0; i < info.NumPieces(); i++ {
 				ret = append(ret, hex.EncodeToString(info.Pieces[i*20:(i+1)*20]))
 			}
 			return

--- a/cmd/torrent-verify/main.go
+++ b/cmd/torrent-verify/main.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 
 	"github.com/anacrolix/tagflag"
-	"github.com/bradfitz/iter"
 	"github.com/edsrzf/mmap-go"
 
 	"github.com/anacrolix/torrent/metainfo"
@@ -47,7 +46,7 @@ func verifyTorrent(info *metainfo.Info, root string) error {
 		span.Append(mm)
 	}
 	span.InitIndex()
-	for i := range iter.N(info.NumPieces()) {
+	for i := 0; i < info.NumPieces(); i++ {
 		p := info.Piece(i)
 		hash := sha1.New()
 		_, err := io.Copy(hash, io.NewSectionReader(span, p.Offset(), p.Length()))

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/anacrolix/tagflag v1.2.0
 	github.com/anacrolix/upnp v0.1.2-0.20200416075019-5e9378ed1425
 	github.com/anacrolix/utp v0.1.0
-	github.com/bradfitz/iter v0.0.0-20191230175014-e8f45d346db8
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dustin/go-humanize v1.0.0
 	github.com/edsrzf/mmap-go v1.0.0

--- a/iplist/iplist_test.go
+++ b/iplist/iplist_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bradfitz/iter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +40,7 @@ func init() {
 
 func TestIPv4RangeLen(t *testing.T) {
 	ranges, _ := sampleRanges(t)
-	for i := range iter.N(3) {
+	for i := 0; i < 3; i++ {
 		if len(ranges[i].First) != 4 {
 			t.FailNow()
 		}

--- a/mse/mse_test.go
+++ b/mse/mse_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	_ "github.com/anacrolix/envpprof"
-	"github.com/bradfitz/iter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -114,7 +113,7 @@ func TestHandshakeSelectPlaintext(t *testing.T) {
 }
 
 func BenchmarkHandshakeDefault(b *testing.B) {
-	for range iter.N(b.N) {
+	for i := 0; i < b.N; i++ {
 		allHandshakeTests(b, AllSupportedCrypto, DefaultCryptoSelector)
 	}
 }
@@ -171,7 +170,7 @@ func benchmarkStream(t *testing.B, crypto CryptoMethod) {
 	t.StopTimer()
 	t.SetBytes(int64(len(ia) + len(a) + len(b)))
 	t.ResetTimer()
-	for range iter.N(t.N) {
+	for i := 0; i < t.N; i++ {
 		ac, bc := net.Pipe()
 		ar := make([]byte, len(b))
 		br := make([]byte, len(ia)+len(a))
@@ -239,7 +238,7 @@ func BenchmarkPipeRC4(t *testing.B) {
 	b := make([]byte, len(a))
 	t.SetBytes(int64(len(a)))
 	t.ResetTimer()
-	for range iter.N(t.N) {
+	for i := 0; i < t.N; i++ {
 		n, _ = w.Write(a)
 		if n != len(a) {
 			t.FailNow()
@@ -256,7 +255,7 @@ func BenchmarkPipeRC4(t *testing.B) {
 
 func BenchmarkSkeysReceive(b *testing.B) {
 	var skeys [][]byte
-	for range iter.N(100000) {
+	for i := 0; i < 100000; i++ {
 		skeys = append(skeys, make([]byte, 20))
 	}
 	fillRand(b, skeys...)
@@ -264,7 +263,7 @@ func BenchmarkSkeysReceive(b *testing.B) {
 	//c := qt.New(b)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for range iter.N(b.N) {
+	for i := 0; i < b.N; i++ {
 		initiator, receiver := net.Pipe()
 		go func() {
 			_, _, err := InitiateHandshake(initiator, initSkey, nil, AllSupportedCrypto)

--- a/peer_protocol/decoder_test.go
+++ b/peer_protocol/decoder_test.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/bradfitz/iter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -46,7 +45,7 @@ func BenchmarkDecodePieces(t *testing.B) {
 			},
 		},
 	}
-	for range iter.N(t.N) {
+	for i := 0; i < t.N; i++ {
 		var msg Message
 		require.NoError(t, d.Decode(&msg))
 		// WWJD

--- a/peerconn_test.go
+++ b/peerconn_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/anacrolix/missinggo/pubsub"
-	"github.com/bradfitz/iter"
 	"github.com/frankban/quicktest"
 	"github.com/stretchr/testify/require"
 
@@ -129,7 +128,7 @@ func BenchmarkConnectionMainReadLoop(b *testing.B) {
 	go func() {
 		defer w.Close()
 		ts.writeSem.Lock()
-		for range iter.N(b.N) {
+		for i := 0; i < b.N; i++ {
 			cl.lock()
 			// The chunk must be written to storage everytime, to ensure the
 			// writeSem is unlocked.

--- a/rlreader_test.go
+++ b/rlreader_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bradfitz/iter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
@@ -59,7 +58,7 @@ func TestRateLimitReaders(t *testing.T) {
 	}
 	reads := make(chan read)
 	done := make(chan struct{})
-	for range iter.N(numReaders) {
+	for i := 0; i < numReaders; i++ {
 		r, w := io.Pipe()
 		ws = append(ws, w)
 		cs = append(cs, w)
@@ -99,7 +98,7 @@ func TestRateLimitReaders(t *testing.T) {
 	}()
 	written := 0
 	go func() {
-		for range iter.N(writeRounds) {
+		for i := 0; i < writeRounds; i++ {
 			err := writeN(ws, bytesPerRound)
 			if err != nil {
 				log.Printf("error writing: %s", err)

--- a/storage/sqlite/sqlite-storage.go
+++ b/storage/sqlite/sqlite-storage.go
@@ -18,7 +18,6 @@ import (
 
 	"crawshaw.io/sqlite"
 	"crawshaw.io/sqlite/sqlitex"
-	"github.com/anacrolix/missinggo/iter"
 	"github.com/anacrolix/missinggo/v2/resource"
 	"github.com/anacrolix/torrent/storage"
 )
@@ -333,7 +332,7 @@ func initPoolConns(ctx context.Context, pool ConnPool, opts ProviderOpts) (numIn
 			pool.Put(c)
 		}
 	}()
-	for range iter.N(opts.NumConns) {
+	for i := 0 ; i < opts.NumConns; i++ {
 		conn := pool.Get(ctx)
 		if conn == nil {
 			break
@@ -672,7 +671,7 @@ func (i instance) Put(reader io.Reader) (err error) {
 		return i.PutSized(&buf, int64(buf.Len()))
 	} else {
 		return i.withConn(func(_ context.Context, conn conn) error {
-			for range iter.N(10) {
+			for j := 0; j < 10; j++ {
 				err = sqlitex.Exec(conn,
 					"insert or replace into blob(name, data) values(?, cast(? as blob))",
 					nil,

--- a/storage/test/bench-resource-pieces.go
+++ b/storage/test/bench-resource-pieces.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/anacrolix/torrent/storage"
-	"github.com/bradfitz/iter"
 	qt "github.com/frankban/quicktest"
 )
 
@@ -32,7 +31,7 @@ func BenchmarkPieceMarkComplete(b *testing.B, ci storage.ClientImpl, pieceSize i
 	rand.Read(info.Pieces)
 	data := make([]byte, pieceSize)
 	oneIter := func() {
-		for pieceIndex := range iter.N(numPieces) {
+		for pieceIndex := 0; pieceIndex < numPieces; pieceIndex++ {
 			pi := ti.Piece(info.Piece(pieceIndex))
 			rand.Read(data)
 			var wg sync.WaitGroup
@@ -65,12 +64,12 @@ func BenchmarkPieceMarkComplete(b *testing.B, ci storage.ClientImpl, pieceSize i
 	}
 	// Fill the cache
 	if capacity > 0 {
-		for range iter.N(int((capacity + info.TotalLength() - 1) / info.TotalLength())) {
+		for i := 0; i < int((capacity + info.TotalLength() - 1) / info.TotalLength()); i++ {
 			oneIter()
 		}
 	}
 	b.ResetTimer()
-	for range iter.N(b.N) {
+	for i := 0; i < b.N; i++ {
 		oneIter()
 	}
 }

--- a/torrent.go
+++ b/torrent.go
@@ -26,7 +26,6 @@ import (
 	"github.com/anacrolix/dht/v2"
 	"github.com/anacrolix/log"
 	"github.com/anacrolix/missinggo"
-	"github.com/anacrolix/missinggo/iter"
 	"github.com/anacrolix/missinggo/perf"
 	"github.com/anacrolix/missinggo/pubsub"
 	"github.com/anacrolix/missinggo/slices"
@@ -2144,7 +2143,7 @@ func (t *Torrent) addWebSeed(url string) {
 		activeRequests: make(map[Request]webseed.Request, maxRequests),
 	}
 	ws.requesterCond.L = t.cl.locker()
-	for range iter.N(maxRequests) {
+	for i := 0; i < maxRequests; i++ {
 		go ws.requester()
 	}
 	for _, f := range t.callbacks().NewPeer {

--- a/torrent_test.go
+++ b/torrent_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/anacrolix/missinggo"
-	"github.com/bradfitz/iter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -90,7 +89,7 @@ func BenchmarkUpdatePiecePriorities(b *testing.B) {
 		Length:      pieceLength * numPieces,
 	}))
 	assert.EqualValues(b, 13410, t.numPieces())
-	for range iter.N(7) {
+	for i := 0; i < 7; i++ {
 		r := t.NewReader()
 		r.SetReadahead(32 << 20)
 		r.Seek(3500000, io.SeekStart)
@@ -100,7 +99,7 @@ func BenchmarkUpdatePiecePriorities(b *testing.B) {
 		t._completedPieces.Set(i, true)
 	}
 	t.DownloadPieces(0, t.numPieces())
-	for range iter.N(b.N) {
+	for i := 0; i < b.N; i++ {
 		t.updateAllPiecePriorities()
 	}
 }


### PR DESCRIPTION
The package [github.com/bradfitz/iter](https://pkg.go.dev/github.com/bradfitz/iter) was intended to be an educational joke when it was released in 2014.
It's not idiomatic to use the package and it doesn't add any significant value to readability.