### PR TITLE
DoOnClose() function and Build Tags

### DIFF
--- a/client.go
+++ b/client.go
@@ -116,6 +116,13 @@ func writeDhtServerStatus(w io.Writer, s DhtServer) {
 	spew.Fdump(w, dhtStats)
 }
 
+// Passed Function will be executed when the Client Closes
+func (cl *Client) DoOnClose(f func()) {
+	cl.rLock()
+	defer cl.rUnlock()
+	cl.onClose = append(cl.onClose, f)
+}
+
 // Writes out a human readable status of the client, such as for writing to a
 // HTTP status page.
 func (cl *Client) WriteStatus(_w io.Writer) {

--- a/storage/boltPieceCompletion.go
+++ b/storage/boltPieceCompletion.go
@@ -1,3 +1,5 @@
+// +build !noboltdb
+
 package storage
 
 import (

--- a/storage/bolt_piece.go
+++ b/storage/bolt_piece.go
@@ -1,3 +1,5 @@
+// +build !noboltdb
+
 package storage
 
 import (

--- a/storage/boltdb.go
+++ b/storage/boltdb.go
@@ -1,3 +1,5 @@
+// +build !noboltdb
+
 package storage
 
 import (

--- a/storage/boltpc_test.go
+++ b/storage/boltpc_test.go
@@ -1,3 +1,5 @@
+// +build !noboltdb
+
 package storage
 
 import (

--- a/storage/sqlite-piece-completion.go
+++ b/storage/sqlite-piece-completion.go
@@ -1,4 +1,4 @@
-// +build cgo
+// +build cgo,!nosqlite3
 
 package storage
 


### PR DESCRIPTION
Hello @anacrolix ,

1) I added DoOnClose() function which accepts function and appends it to Client's onClose array. I needed to append function to Client's onClose and now I can do it.

2) so, I analyzed my binary with goweight and realized that crawshaw.io/sqlite3 contributed to 13 MB of binary size. Simply it is optional dependency and we should be able to not build them if necessary . 

I added 3 build tags. `noboltdb` tag doesn't build boltdb piececompletion. `nosqlite3` doesn't build crawshaw.io/sqlite3 . These tags are don't affect normal workflow and only helps when you want to disable them.