### PR TITLE
Added build tags to disable few packages if necessary

### DIFF
--- a/storage/bolt-piece-completion.go
+++ b/storage/bolt-piece-completion.go
@@ -1,3 +1,6 @@
+//go:build !noboltdb
+// +build !noboltdb
+
 package storage
 
 import (

--- a/storage/bolt-piece.go
+++ b/storage/bolt-piece.go
@@ -1,3 +1,6 @@
+//go:build !noboltdb
+// +build !noboltdb
+
 package storage
 
 import (

--- a/storage/bolt.go
+++ b/storage/bolt.go
@@ -1,3 +1,6 @@
+//go:build !noboltdb
+// +build !noboltdb
+
 package storage
 
 import (

--- a/storage/default-dir-piece-completion-boltdb.go
+++ b/storage/default-dir-piece-completion-boltdb.go
@@ -1,5 +1,5 @@
-//go:build !cgo
-// +build !cgo
+//go:build !cgo && !noboltdb
+// +build !cgo,!noboltdb
 
 package storage
 

--- a/storage/default-dir-piece-completion-sqlite.go
+++ b/storage/default-dir-piece-completion-sqlite.go
@@ -1,5 +1,5 @@
-//go:build cgo
-// +build cgo
+//go:build cgo && !nosqlite
+// +build cgo,!nosqlite
 
 package storage
 

--- a/storage/sqlite-piece-completion.go
+++ b/storage/sqlite-piece-completion.go
@@ -1,5 +1,5 @@
-//go:build cgo
-// +build cgo
+//go:build cgo && !nosqlite
+// +build cgo,!nosqlite
 
 package storage
 


### PR DESCRIPTION
This adds 2 buildtags. `noboltdb` doesn't build boltdb and `nosqlite` doesn't build sqlite3 . This helps in decreasing size of binaries.