### PR TITLE
call decrementPendingWrites() first to free storageLock, before obtai…

### DIFF
--- a/piece.go
+++ b/piece.go
@@ -107,6 +107,12 @@ func (p *Piece) waitNoPendingWrites() {
 	p.pendingWritesMutex.Unlock()
 }
 
+func (p *Piece) isNoPendingWrites() bool {
+	p.pendingWritesMutex.Lock()
+	defer p.pendingWritesMutex.Unlock()
+	return p.pendingWrites == 0
+}
+
 func (p *Piece) chunkIndexDirty(chunk pp.Integer) bool {
 	return p._dirtyChunks.Contains(bitmap.BitIndex(chunk))
 }


### PR DESCRIPTION
It will get a deadlock happened if torrent.Drop() and torrent.pieceHasher() execute at the same time. 

torrent.Drop() is holding _Client.Lock_ and want to obtain _Torrent.storageLock_, but torrent.pieceHasher() already take _Torrent.storageLock_ and wait to check pending writes by waitNoPendingWrites().  

On the other side, incrementPendingWrites() is called in receiveChunk(),  but decrementPendingWrites() will not be called before get _Client.Lock_ , which is held by torrent.Drop(). 

So we could call decrementPendingWrites() first before obtain Client.Lock, and it should be called anyway if writeChunk() is done.