### PR TITLE
Preallocate torrentsAsSlice()

### DIFF
--- a/client.go
+++ b/client.go
@@ -1290,15 +1290,19 @@ func (cl *Client) WaitAll() bool {
 }
 
 // Returns handles to all the torrents loaded in the Client.
-func (cl *Client) Torrents() []*Torrent {
+func (cl *Client) Torrents() (ts []*Torrent) {
 	cl.lock()
-	defer cl.unlock()
-	return cl.torrentsAsSlice()
+	ts = cl.torrentsAsSlice()
+	cl.unlock()
+	return
 }
 
 func (cl *Client) torrentsAsSlice() (ret []*Torrent) {
+	ret = make([]*Torrent, len(cl.torrents))
+	i := 0
 	for _, t := range cl.torrents {
-		ret = append(ret, t)
+		ret[i] = t
+		i += 1
 	}
 	return
 }


### PR DESCRIPTION
Using `append` would be a better option if `torrentsAsSlice()` accepted a slice argument. I'd prefer that, but it would require some API changes probably. `make+copy` has better optimizations than `append` since Go 1.15, so it's best to use that and not make `append` do guesswork. Also saves a little work for the GC since extra pointers would be allocated.