### PR TITLE
Simplify haveDhtServers()

### DIFF
--- a/client.go
+++ b/client.go
@@ -997,11 +997,8 @@ func (cl *Client) dhtPort() (ret uint16) {
 	return
 }
 
-func (cl *Client) haveDhtServer() (ret bool) {
-	cl.eachDhtServer(func(_ DhtServer) {
-		ret = true
-	})
-	return
+func (cl *Client) haveDhtServer() bool {
+	return len(cl.dhtServers) > 0
 }
 
 // Process incoming ut_metadata message.


### PR DESCRIPTION
A bit too much functional programming, lol.

Don't get me wrong, I'm a fan of functional programming myself. But Go isn't a functional language, and it just adds too much overhead since Go's compiler isn't that smart. Plus there's basically no immutability in the language, which IMO is pretty important for real functional programming. I'll also mention that Go only just reached the point where functions with closures are inline-able -- with the release of Go 1.17.

Take a look at the best comment of this reddit post: https://www.reddit.com/r/golang/comments/nlh1kj/the_future_of_functional_programming_in_go_118/gziryo3/

If this project were written in Rust -- functional programming would work. Doesn't even matter that Rust isn't a functional language.

That being said, `eachDhtServer` and `eachListener` ought to go. Especially `eachListener`, which is actually a misnomer. 