### PR TITLE
Create default constructor for Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -182,32 +182,35 @@ func (cl *Client) announceKey() int32 {
 	return int32(binary.BigEndian.Uint32(cl.peerID[16:20]))
 }
 
+// Initializes a bare minimum Client. *Client and *ClientConfig must not be nil.
+func (cl *Client) init(cfg *ClientConfig) {
+	cl.config = cfg
+	cl.dopplegangerAddrs = make(map[string]struct{})
+	cl.torrents = make(map[metainfo.Hash]*Torrent)
+	cl.dialRateLimiter = rate.NewLimiter(10, 10)
+	cl.activeAnnounceLimiter.SlotsPerKey = 2
+	
+	cl.event.L = cl.locker()
+	cl.ipBlockList = cfg.IPBlocklist
+}
+
 func NewClient(cfg *ClientConfig) (cl *Client, err error) {
 	if cfg == nil {
 		cfg = NewDefaultClientConfig()
 		cfg.ListenPort = 0
 	}
-	defer func() {
-		if err != nil {
-			cl = nil
-		}
-	}()
-	cl = &Client{
-		config:            cfg,
-		dopplegangerAddrs: make(map[string]struct{}),
-		torrents:          make(map[metainfo.Hash]*Torrent),
-		dialRateLimiter:   rate.NewLimiter(10, 10),
-	}
-	cl.activeAnnounceLimiter.SlotsPerKey = 2
+	var client Client
+	client.init(cfg)
+	cl = &client
 	go cl.acceptLimitClearer()
 	cl.initLogger()
 	defer func() {
-		if err == nil {
-			return
+		if err != nil {
+			cl.Close()
+			cl = nil
 		}
-		cl.Close()
 	}()
-	cl.event.L = cl.locker()
+	
 	storageImpl := cfg.DefaultStorage
 	if storageImpl == nil {
 		// We'd use mmap by default but HFS+ doesn't support sparse files.
@@ -220,9 +223,6 @@ func NewClient(cfg *ClientConfig) (cl *Client, err error) {
 		storageImpl = storageImplCloser
 	}
 	cl.defaultStorage = storage.NewClient(storageImpl)
-	if cfg.IPBlocklist != nil {
-		cl.ipBlockList = cfg.IPBlocklist
-	}
 
 	if cfg.PeerID != "" {
 		missinggo.CopyExact(&cl.peerID, cfg.PeerID)

--- a/client_test.go
+++ b/client_test.go
@@ -76,9 +76,8 @@ func TestPieceHashSize(t *testing.T) {
 func TestTorrentInitialState(t *testing.T) {
 	dir, mi := testutil.GreetingTestTorrent()
 	defer os.RemoveAll(dir)
-	cl := &Client{
-		config: TestingConfig(t),
-	}
+	var cl Client
+	cl.init(TestingConfig(t))
 	cl.initLogger()
 	tor := cl.newTorrent(
 		mi.HashInfoBytes(),

--- a/pexconn_test.go
+++ b/pexconn_test.go
@@ -12,9 +12,8 @@ import (
 )
 
 func TestPexConnState(t *testing.T) {
-	cl := Client{
-		config: TestingConfig(t),
-	}
+	var cl Client
+	cl.init(TestingConfig(t))
 	cl.initLogger()
 	torrent := cl.newTorrent(metainfo.Hash{}, nil)
 	addr := &net.TCPAddr{IP: net.IPv6loopback, Port: 4747}
@@ -23,7 +22,9 @@ func TestPexConnState(t *testing.T) {
 	c.PeerExtensionIDs[pp.ExtensionNamePex] = pexExtendedId
 	c.messageWriter.mu.Lock()
 	c.setTorrent(torrent)
-	torrent.addPeerConn(c)
+	if err := torrent.addPeerConn(c); err != nil {
+		t.Log(err)
+	}
 
 	c.pex.Init(c)
 	require.True(t, c.pex.IsEnabled(), "should get enabled")


### PR DESCRIPTION
Allow for certain values to always be properly initialized on construction -- namely the maps for now. I'm currently working on a change that requires a baseline constructor; this change would make the use of `chansync.BroadcastCond` and `chansync.SetOnce` obsolete -- i.e. one can have channel members without worrying about proper initialization/destruction of a `chan struct{}`.

As for why `makeClient` returns a value instead of a pointer: returning a value gives us more options -- you can always take a pointer from a value later on cheaply, and have things moved to the heap if they weren't already. The same can't be said about getting a value back from a pointer. GC also could potentially have less work to do. Plus I personally find ownership to be an important concept (semi-borrowed from rust) -- use of values make ownership clear.

~~NOTE: various changes to the tests (in `_test.go` files) still need changing to use this new constructor (instead of their current usage of `Client{...}` or `&Client{...}`)~~