### PR TITLE
Improvements to AnnounceList methods

### DIFF
--- a/metainfo/announcelist.go
+++ b/metainfo/announcelist.go
@@ -2,34 +2,46 @@ package metainfo
 
 type AnnounceList [][]string
 
-func (al AnnounceList) Clone() (ret AnnounceList) {
-	for _, tier := range al {
-		ret = append(ret, append([]string(nil), tier...))
+func (al AnnounceList) Clone() (dup AnnounceList) {
+	dup = make([][]string, len(al))
+	for i := 0; i < len(al); i += 1 {
+		dup[i] = make([]string, len(al[i]))
+		copy(dup[i], al[i])
 	}
 	return
 }
 
 // Whether the AnnounceList should be preferred over a single URL announce.
-func (al AnnounceList) OverridesAnnounce(announce string) bool {
-	for _, tier := range al {
-		for _, url := range tier {
-			if url != "" || announce == "" {
+func (al AnnounceList) OverridesAnnounce(announce string) (b bool) {
+	if announce == "" {
+		return true
+	}
+	for tier := 0; tier < len(al); tier++ {
+		url, i := al[tier], 0
+		for i < len(url) {
+			if url[i] != "" {
 				return true
 			}
-		}
-	}
-	return false
-}
-
-func (al AnnounceList) DistinctValues() (ret []string) {
-	seen := make(map[string]struct{})
-	for _, tier := range al {
-		for _, v := range tier {
-			if _, ok := seen[v]; !ok {
-				seen[v] = struct{}{}
-				ret = append(ret, v)
-			}
+			i++
 		}
 	}
 	return
+}
+
+func (al AnnounceList) DistinctValues() []string {
+	seen := make(map[string]struct{})
+	for tier := range al {
+		for _, v := range al[tier] {
+			if _, ok := seen[v]; !ok {
+				seen[v] = struct{}{}
+			}
+		}
+	}
+	i := 0
+	ret := make([]string, len(seen))
+	for k := range seen {
+		ret[i] = k
+		i++
+	}
+	return ret
 }


### PR DESCRIPTION
- Make `Clone()` preallocate and inlineable; use make+copy optimization since Go 1.15 (https://github.com/golang/go/issues/26252)
- Make `OverridesAnnounce()` inlineable; hoist `announce` check out of loop.
- Preallocate return slice in `DistinctValues()`.