### PR TITLE
Drop xerrors and missinggo/slices dependency for Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -142,7 +142,7 @@ func (cl *Client) WriteStatus(_w io.Writer) {
 	})
 	spew.Fdump(w, &cl.stats)
 	torrentsSlice := cl.torrentsAsSlice()
-	fmt.Fprintf(w, "# Torrents: %d\n", len(torrentsAsSlice))
+	fmt.Fprintf(w, "# Torrents: %d\n", len(torrentsSlice))
 	fmt.Fprintln(w)
 	sort.Slice(torrentsSlice, func(l, r int) bool {
 		return torrentsSlice[l].infoHash.AsString() < torrentsSlice[r].infoHash.AsString()

--- a/client.go
+++ b/client.go
@@ -147,8 +147,7 @@ func (cl *Client) WriteStatus(_w io.Writer) {
 	sort.Slice(torrentsSlice, func(l, r int) bool {
 		return torrentsSlice[l].infoHash.AsString() < torrentsSlice[r].infoHash.AsString()
 	})
-	for i := 0; i < len(torrentsSlice); i += 1 {
-		t := torrentsSlice[i]
+	for _, t := range torrentsSlice {
 		if t.name() == "" {
 			fmt.Fprint(w, "<unknown name>")
 		} else {
@@ -703,7 +702,7 @@ func (cl *Client) establishOutgoingConnEx(t *Torrent, addr PeerRemoteAddr, obfus
 	nc := dr.Conn
 	if nc == nil {
 		if dialCtx.Err() != nil {
-			return nil, xerrors.Errorf("dialing: %w", dialCtx.Err())
+			return nil, fmt.Errorf("dialing: %w", dialCtx.Err())
 		}
 		return nil, errors.New("dial failed")
 	}

--- a/client.go
+++ b/client.go
@@ -850,13 +850,14 @@ func (cl *Client) receiveHandshakes(c *PeerConn) (t *Torrent, err error) {
 		err = errors.New("connection does not have required header obfuscation")
 		return
 	}
-	if ih, err := cl.connBtHandshake(c, nil); err == nil {
-		cl.lock()
-		t = cl.torrents[ih]
-		cl.unlock()
-		return
+	ih, err := cl.connBtHandshake(c, nil)
+	if err != nil {
+		return nil, fmt.Errorf("during bt handshake: %w", err)
 	}
-	return nil, fmt.Errorf("during bt handshake: %w", err)
+	cl.lock()
+	t = cl.torrents[ih]
+	cl.unlock()
+	return
 }
 
 func (cl *Client) connBtHandshake(c *PeerConn, ih *metainfo.Hash) (ret metainfo.Hash, err error) {

--- a/client.go
+++ b/client.go
@@ -855,7 +855,7 @@ func (cl *Client) receiveHandshakes(c *PeerConn) (t *Torrent, err error) {
 		cl.lock()
 		t = cl.torrents[ih]
 		cl.unlock()
-		return t, nil
+		return
 	}
 	return nil, fmt.Errorf("during bt handshake: %w", err)
 }


### PR DESCRIPTION
Made `BadPeerIPs` inlineable since I changed `badPeerIPsLocked` anyway. Also eliminated an extra torrentsAsSlice copy since Go wasn't smart enough to figure it out.