### PR TITLE
Update methods to support pointer receiver

### DIFF
--- a/cmd/torrent-infohash/main.go
+++ b/cmd/torrent-infohash/main.go
@@ -20,6 +20,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf("%s: %s\n", mi.HashInfoBytes().HexString(), arg)
+		hashInfoBytes := mi.HashInfoBytes()
+		fmt.Printf("%s: %s\n", hashInfoBytes.HexString(), arg)
 	}
 }

--- a/cmd/torrent-metainfo-pprint/main.go
+++ b/cmd/torrent-metainfo-pprint/main.go
@@ -36,11 +36,12 @@ func processReader(r io.Reader) error {
 		fmt.Printf("%s\n", info.Name)
 		return nil
 	}
+	hashInfoBytes := metainfo.HashInfoBytes()
 	d := map[string]interface{}{
 		"Name":         info.Name,
 		"NumPieces":    info.NumPieces(),
 		"PieceLength":  info.PieceLength,
-		"InfoHash":     metainfo.HashInfoBytes().HexString(),
+		"InfoHash":     hashInfoBytes.HexString(),
 		"NumFiles":     len(info.UpvertedFiles()),
 		"TotalLength":  info.TotalLength(),
 		"Announce":     metainfo.Announce,

--- a/storage/piece-resource.go
+++ b/storage/piece-resource.go
@@ -256,7 +256,8 @@ func (s piecePerResourcePiece) getChunks() (chunks chunks) {
 }
 
 func (s piecePerResourcePiece) completedInstancePath() string {
-	return path.Join("completed", s.mp.Hash().HexString())
+	h := s.mp.Hash()
+	return path.Join("completed", h.HexString())
 }
 
 func (s piecePerResourcePiece) completed() resource.Instance {
@@ -267,8 +268,9 @@ func (s piecePerResourcePiece) completed() resource.Instance {
 	return i
 }
 
-func (s piecePerResourcePiece) incompleteDirPath() string {
-	return path.Join("incompleted", s.mp.Hash().HexString())
+func (s piecePerResourcePiece) incompleteDirPath() string 
+	h := s.mp.Hash()
+	return path.Join("incompleted", h.HexString())
 }
 
 func (s piecePerResourcePiece) incompleteDir() resource.DirInstance {

--- a/storage/sqlite/direct.go
+++ b/storage/sqlite/direct.go
@@ -48,8 +48,9 @@ type torrent struct {
 }
 
 func (t torrent) Piece(p metainfo.Piece) storage.PieceImpl {
+	h := p.Hash()
 	ret := piece{
-		sb: t.c.OpenWithLength(p.Hash().HexString(), p.Length()),
+		sb: t.c.OpenWithLength(h.HexString(), p.Length()),
 	}
 	ret.ReaderAt = &ret.sb
 	ret.WriterAt = &ret.sb

--- a/torrent_test.go
+++ b/torrent_test.go
@@ -68,7 +68,8 @@ func TestAppendToCopySlice(t *testing.T) {
 
 func TestTorrentString(t *testing.T) {
 	tor := &Torrent{}
-	s := tor.InfoHash().HexString()
+	h := tor.InfoHash()
+	s := h.HexString()
 	if s != "0000000000000000000000000000000000000000" {
 		t.FailNow()
 	}


### PR DESCRIPTION
`(*metainfo.Hash).HexString()` currently uses a value receiver, which allows for chaining method calls (e.g. `.Hash().HexString()`). This is nice, but I've been doing some testing with pointer receiver methods -- such methods disallow can't be called on immediately returned values.

To maintain compatibility with both pointer and value receiver methods, a local variable needs to be created. This shouldn't be a big deal, but it helps a lot with code refactoring.