### PR TITLE
Rework metainfo.Hash

### DIFF
--- a/cmd/torrent-infohash/main.go
+++ b/cmd/torrent-infohash/main.go
@@ -20,6 +20,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf("%s: %s\n", mi.HashInfoBytes().HexString(), arg)
+		hib := mi.HashInfoBytes()
+		fmt.Printf("%s: %s\n", hib.HexString(), arg)
 	}
 }

--- a/cmd/torrent-metainfo-pprint/main.go
+++ b/cmd/torrent-metainfo-pprint/main.go
@@ -36,11 +36,12 @@ func processReader(r io.Reader) error {
 		fmt.Printf("%s\n", info.Name)
 		return nil
 	}
+	hibs := metainfo.HashInfoBytes()
 	d := map[string]interface{}{
 		"Name":         info.Name,
 		"NumPieces":    info.NumPieces(),
 		"PieceLength":  info.PieceLength,
-		"InfoHash":     metainfo.HashInfoBytes().HexString(),
+		"InfoHash":     hibs.HexString(),
 		"NumFiles":     len(info.UpvertedFiles()),
 		"TotalLength":  info.TotalLength(),
 		"Announce":     metainfo.Announce,

--- a/cmd/torrent-verify/main.go
+++ b/cmd/torrent-verify/main.go
@@ -54,11 +54,12 @@ func verifyTorrent(info *metainfo.Info, root string) error {
 		if err != nil {
 			return err
 		}
-		good := bytes.Equal(hash.Sum(nil), p.Hash().Bytes())
+		h := p.Hash()
+		good := bytes.Equal(hash.Sum(nil), h.Bytes())
 		if !good {
 			return fmt.Errorf("hash mismatch at piece %d", i)
 		}
-		fmt.Printf("%d: %v: %v\n", i, p.Hash(), good)
+		fmt.Printf("%d: %v: %v\n", i, h, good)
 	}
 	return nil
 }

--- a/fs/torrentfs_test.go
+++ b/fs/torrentfs_test.go
@@ -177,7 +177,8 @@ func TestDownloadOnDemand(t *testing.T) {
 	defer testutil.ExportStatusWriter(seeder, "s", t)()
 	// Just to mix things up, the seeder starts with the data, but the leecher
 	// starts with the metainfo.
-	seederTorrent, err := seeder.AddMagnet(fmt.Sprintf("magnet:?xt=urn:btih:%s", layout.Metainfo.HashInfoBytes().HexString()))
+	hib := layout.Metainfo.HashInfoBytes()
+	seederTorrent, err := seeder.AddMagnet(fmt.Sprintf("magnet:?xt=urn:btih:%s", hib.HexString()))
 	require.NoError(t, err)
 	go func() {
 		// Wait until we get the metainfo, then check for the data.

--- a/metainfo/hash.go
+++ b/metainfo/hash.go
@@ -4,76 +4,125 @@ import (
 	"crypto/sha1"
 	"encoding"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"reflect"
+	"strconv"
+	"unsafe"
 )
 
-const HashSize = 20
+const (
+	HashSize = sha1.Size
+
+	// HashEncodedLen is the size of the hex encoded hash.
+	// Equivalent to hex.EncodedLen(HashSize)
+	HashEncodedLen = 2*HashSize
+)
 
 // 20-byte SHA1 hash used for info and pieces.
 type Hash [HashSize]byte
 
-var _ fmt.Formatter = (*Hash)(nil)
+var (
+	_ fmt.Formatter = (*Hash)(nil)
+	_ fmt.Stringer = (*Hash)(nil)
+	_ encoding.TextUnmarshaler = (*Hash)(nil)
+	_ encoding.TextMarshaler   = (*Hash)(nil)
+)
 
-func (h Hash) Format(f fmt.State, c rune) {
-	// TODO: I can't figure out a nice way to just override the 'x' rune, since it's meaningless
-	// with the "default" 'v', or .String() already returning the hex.
-	f.Write([]byte(h.HexString()))
+func (h *Hash) Format(f fmt.State, c rune) {
+	bs := h.hexBytes()
+	switch c {
+	case 's', 'v', 'x': break
+	case 'X':
+		for i := 0; i < len(bs); i += 1 {
+			if bs[i] >= 'a' {
+				bs[i] -= 'a' - 'A'
+			}
+		}
+	default:
+		// TODO: handle other verbs and flags?
+	}
+	f.Write(bs)
 }
 
-func (h Hash) Bytes() []byte {
-	return h[:]
-}
-
-func (h Hash) AsString() string {
-	return string(h[:])
-}
-
-func (h Hash) String() string {
+func (h *Hash) String() string {
 	return h.HexString()
 }
 
-func (h Hash) HexString() string {
-	return fmt.Sprintf("%x", h[:])
+func (h *Hash) UnmarshalText(b []byte) error {
+	if len(b) != HashEncodedLen {
+		return errors.New(hex.ErrLength.Error() + ": " + strconv.Itoa(len(b)))
+	}
+	return h.decodeBytesFrom(b)
+}
+
+func (h *Hash) MarshalText() (text []byte, err error) {
+	return h.hexBytes(), nil
+}
+
+// Bytes copies the Hash into a new byte slice
+func (h *Hash) Bytes() []byte {
+	h2 := *h
+	return h2[:]
+}
+
+// AsString copies the *Hash without hex encoding into a string of length HashSize
+func (h *Hash) AsString() string {
+	return string(h[:])
+}
+
+// HexString hex encodes *Hash to a new string
+func (h *Hash) HexString() string {
+	bs := h.hexBytes()
+	// We created a new byte slice which we own. Thus, we can safely transfer
+	// ownership of its data to a string without additional allocations
+	// using the same technique as strings.Builder's String() method
+	return *(*string)(unsafe.Pointer(&bs))
 }
 
 func (h *Hash) FromHexString(s string) (err error) {
-	if len(s) != 2*HashSize {
-		err = fmt.Errorf("hash hex string has bad length: %d", len(s))
-		return
+	if len(s) != HashEncodedLen {
+		return errors.New(hex.ErrLength.Error() + ": " + strconv.Itoa(len(s)))
 	}
-	n, err := hex.Decode(h[:], []byte(s))
-	if err != nil {
-		return
-	}
-	if n != HashSize {
-		panic(n)
-	}
-	return
+	// Strings are immutable in Go, so we can C-style cast the string to a byte slice
+	// without worrying about external modifications of the data.
+	// However, in order to uphold this immutability we must guarantee that the resulting slice
+	// is READ-ONLY. This is easy to do provided that the slice does not escape.
+	// Go's lack of immutability prevents it from providing these types of optimizations for us.
+	bs := (*[HashEncodedLen]byte)(unsafe.Pointer((*reflect.StringHeader)(unsafe.Pointer(&s)).Data))[:]
+	return h.decodeBytesFrom(bs)
 }
 
-var (
-	_ encoding.TextUnmarshaler = (*Hash)(nil)
-	_ encoding.TextMarshaler   = Hash{}
-)
-
-func (h *Hash) UnmarshalText(b []byte) error {
-	return h.FromHexString(string(b))
-}
-func (h Hash) MarshalText() (text []byte, err error) {
-	return []byte(h.HexString()), nil
-}
-
+// NewHashFromHex creates a Hash from hex-encoded string of length HashEncodedLen
+// Panics on error.
 func NewHashFromHex(s string) (h Hash) {
-	err := h.FromHexString(s)
-	if err != nil {
+	if err := h.FromHexString(s); err != nil {
 		panic(err)
 	}
 	return
 }
 
-func HashBytes(b []byte) (ret Hash) {
-	hasher := sha1.New()
-	hasher.Write(b)
-	copy(ret[:], hasher.Sum(nil))
+// HashBytes returns the SHA-1 checksum of data as a Hash
+func HashBytes(data []byte) (ret Hash) {
+	return sha1.Sum(data)
+}
+
+
+// hex.Decode src []byte into *Hash. The src []byte will not be mutated.
+// Caller should ensure that src is at least HashEncodedLen long.
+func (h *Hash) decodeBytesFrom(src []byte) (err error) {
+	_, err = hex.Decode(h[:], src)
 	return
+}
+
+// hex.Encode *Hash into a new array of length HashEncodedLen
+func (h *Hash) hexEncodeToArray() (dst [HashEncodedLen]byte) {
+	hex.Encode(dst[:], h[:])
+	return
+}
+
+// hex.Encode *Hash into a new slice
+func (h *Hash) hexBytes() []byte {
+	dst := h.hexEncodeToArray()
+	return dst[:]
 }

--- a/storage/piece-resource.go
+++ b/storage/piece-resource.go
@@ -256,7 +256,8 @@ func (s piecePerResourcePiece) getChunks() (chunks chunks) {
 }
 
 func (s piecePerResourcePiece) completedInstancePath() string {
-	return path.Join("completed", s.mp.Hash().HexString())
+	h := s.mp.Hash()
+	return path.Join("completed", h.HexString())
 }
 
 func (s piecePerResourcePiece) completed() resource.Instance {
@@ -268,7 +269,8 @@ func (s piecePerResourcePiece) completed() resource.Instance {
 }
 
 func (s piecePerResourcePiece) incompleteDirPath() string {
-	return path.Join("incompleted", s.mp.Hash().HexString())
+	h := s.mp.Hash()
+	return path.Join("incompleted", h.HexString())
 }
 
 func (s piecePerResourcePiece) incompleteDir() resource.DirInstance {

--- a/storage/sqlite/direct.go
+++ b/storage/sqlite/direct.go
@@ -48,8 +48,9 @@ type torrent struct {
 }
 
 func (t torrent) Piece(p metainfo.Piece) storage.PieceImpl {
+	h := p.Hash()
 	ret := piece{
-		sb: t.c.OpenWithLength(p.Hash().HexString(), p.Length()),
+		sb: t.c.OpenWithLength(h.HexString(), p.Length()),
 	}
 	ret.ReaderAt = &ret.sb
 	ret.WriterAt = &ret.sb

--- a/torrent_test.go
+++ b/torrent_test.go
@@ -68,7 +68,8 @@ func TestAppendToCopySlice(t *testing.T) {
 
 func TestTorrentString(t *testing.T) {
 	tor := &Torrent{}
-	s := tor.InfoHash().HexString()
+	h := tor.InfoHash()
+	s := h.HexString()
 	if s != "0000000000000000000000000000000000000000" {
 		t.FailNow()
 	}


### PR DESCRIPTION
Various changes. Changed methods to use pointer receiver consistently. Most changes are around reducing unnecessary copies and allocations. Also reordered functions into interface implementations, public methods, and then private ones. Hopefully this isn't a problem. Use of `unsafe` is explained in comments. Changed HashBytes to call `sha1.Sum` directly, and more.

~~Requires https://github.com/anacrolix/torrent/pull/578 in order to change methods to be compatible with pointer receivers.~~
