### PR TITLE
Simplify (*Torrent).gotMetainfo

### DIFF
--- a/client.go
+++ b/client.go
@@ -1111,6 +1111,7 @@ func (cl *Client) newTorrent(ih metainfo.Hash, specStorage storage.ClientImpl) (
 			L: cl.locker(),
 		},
 		webSeeds: make(map[string]*Peer),
+		gotMetainfoC: make(chan struct{}),
 	}
 	t.networkingEnabled.Set()
 	t._pendingPieces.NewSet = priorityBitmapStableNewSet

--- a/t.go
+++ b/t.go
@@ -15,18 +15,20 @@ func (t *Torrent) InfoHash() metainfo.Hash {
 }
 
 // Returns a channel that is closed when the info (.Info()) for the torrent has become available.
-func (t *Torrent) GotInfo() <-chan struct{} {
+func (t *Torrent) GotInfo() (ret <-chan struct{}) {
 	// TODO: We shouldn't need to lock to take a channel here, if the event is only ever set.
-	t.cl.lock()
-	defer t.cl.unlock()
-	return t.gotMetainfo.C()
+	t.nameMu.RLock()
+	ret = t.gotMetainfoC
+	t.nameMu.RUnlock()
+	return
 }
 
 // Returns the metainfo info dictionary, or nil if it's not yet available.
-func (t *Torrent) Info() *metainfo.Info {
-	t.cl.lock()
-	defer t.cl.unlock()
-	return t.info
+func (t *Torrent) Info() (info *metainfo.Info) {
+	t.nameMu.RLock()
+	info = t.info
+	t.nameMu.RUnlock()
+	return
 }
 
 // Returns a Reader bound to the torrent's data. All read calls block until the data requested is


### PR DESCRIPTION
Data races shouldn't be an issue since `missinggo.Event` didn't originally use a lock anyway. As far as I can tell `missinggo.Event` simply provides insurance that the channel isn't closed more than once. If we are careful about keeping the channel initialized on the construction of the torrent, as well as making sure to re-`make` the `gotMetainfo` channel when setting `.info = nil`, then the double close issue shouldn't be encountered.

