### PR TITLE
Tweak dropping torrents

### DIFF
--- a/t.go
+++ b/t.go
@@ -91,8 +91,8 @@ func (t *Torrent) PieceBytesMissing(piece int) int64 {
 // or connected peers.
 func (t *Torrent) Drop() {
 	t.cl.lock()
-	defer t.cl.unlock()
-	t.cl.dropTorrent(t.infoHash)
+	t.cl.dropTorrent(t.infoHash) // TODO: Check/panic on error?
+	t.cl.unlock()
 }
 
 // Number of bytes of the entire torrent we have completed. This is the sum of

--- a/torrent.go
+++ b/torrent.go
@@ -794,11 +794,11 @@ func (t *Torrent) close(wg *sync.WaitGroup) (err error) {
 	if t.storage != nil {
 		wg.Add(1)
 		go func() {
-			defer wg.Done()
-			t.storageLock.Lock()
-			defer t.storageLock.Unlock()
 			if f := t.storage.Close; f != nil {
+				t.storageLock.Lock()
 				err1 := f()
+				t.storageLock.Unlock()
+				wg.Done()
 				if err1 != nil {
 					t.logger.WithDefaultLevel(log.Warning).Printf("error closing storage: %v", err1)
 				}


### PR DESCRIPTION
Add inlineability, remove unnecessary use of `Errorf`, unlock `storageLock` and decrement WaitGroup as soon as possible