### PR TITLE
Clarify ownership of (*Torrent).chunkPool

### DIFF
--- a/peerconn.go
+++ b/peerconn.go
@@ -1030,7 +1030,7 @@ func (c *PeerConn) mainReadLoop() (err error) {
 	decoder := pp.Decoder{
 		R:         bufio.NewReaderSize(c.r, 1<<17),
 		MaxLength: 256 * 1024,
-		Pool:      t.chunkPool,
+		Pool:      &t.chunkPool,
 	}
 	for {
 		var msg pp.Message

--- a/torrent.go
+++ b/torrent.go
@@ -66,7 +66,8 @@ type Torrent struct {
 	// The size of chunks to request from peers over the wire. This is
 	// normally 16KiB by convention these days.
 	chunkSize pp.Integer
-	chunkPool *sync.Pool
+	chunkPool 
+	sync.Pool
 	// Total length of the torrent in bytes. Stored because it's not O(1) to
 	// get this from the info dict.
 	length *int64
@@ -233,7 +234,7 @@ func (t *Torrent) KnownSwarm() (ks []PeerInfo) {
 
 func (t *Torrent) setChunkSize(size pp.Integer) {
 	t.chunkSize = size
-	t.chunkPool = &sync.Pool{
+	t.chunkPool = sync.Pool{
 		New: func() interface{} {
 			b := make([]byte, size)
 			return &b

--- a/torrent.go
+++ b/torrent.go
@@ -66,8 +66,7 @@ type Torrent struct {
 	// The size of chunks to request from peers over the wire. This is
 	// normally 16KiB by convention these days.
 	chunkSize pp.Integer
-	chunkPool 
-	sync.Pool
+	chunkPool sync.Pool
 	// Total length of the torrent in bytes. Stored because it's not O(1) to
 	// get this from the info dict.
 	length *int64


### PR DESCRIPTION
Basically bind the lifetime of chunkPool to the torrent by using `sync.Pool` in lieu of `*sync.Pool`. Gives the GC ever so slightly less work to do.