### PR TITLE
Simplify no-copy conversion of []byte to string

### DIFF
--- a/bencode/misc.go
+++ b/bencode/misc.go
@@ -18,13 +18,5 @@ var unmarshalerType = reflect.TypeOf(func() *Unmarshaler {
 }()).Elem()
 
 func bytesAsString(b []byte) string {
-	if len(b) == 0 {
-		return ""
-	}
-	// See https://github.com/golang/go/issues/40701.
-	var s string
-	hdr := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	hdr.Data = uintptr(unsafe.Pointer(&b[0]))
-	hdr.Len = len(b)
-	return s
+	return *(*string)(unsafe.Pointer(&b))
 }


### PR DESCRIPTION
This is a pretty well-tested method currently in use by `strings.Builder`. It's a one-liner so there's no need to worry about the GC interfering. Messing with `*reflect.StringHeader` is often error-prone and might require a `runtime.KeepAlive` in some cases. Honestly pleased me to see that this project even attempts to make these kinds of optimizations 😄 