### PR TITLE
Avoid allocating memory when checking interface

### DIFF
--- a/metainfo/nodes.go
+++ b/metainfo/nodes.go
@@ -11,7 +11,7 @@ import (
 type Node string
 
 var (
-	_ bencode.Unmarshaler = new(Node)
+	_ bencode.Unmarshaler = (*Node)(nil)
 )
 
 func (n *Node) UnmarshalBencode(b []byte) (err error) {


### PR DESCRIPTION
Not a big deal, but there isn't a need to allocate an object to check that `*Node` satisfies `bencode.Unmarshaler`.