### PR TITLE
Optimize getIp() and make inlineable

### DIFF
--- a/tracker_scraper.go
+++ b/tracker_scraper.go
@@ -65,10 +65,12 @@ type trackerAnnounceResult struct {
 	Completed time.Time
 }
 
-func (me *trackerScraper) getIp() (ip net.IP, err error) {
+func (me *TrackerScraper) getIp() (ip net.IP, err error) {
 	switch ips, er := net.LookupIP(me.u.Hostname()); {
-	case er != nil:     return nil, er
-	case len(ips) == 0: return nil, errors.New("no ips")
+	case er != nil:
+		return nil, er
+	case len(ips) == 0:
+		return nil, errors.New("no ips")
 	default:
 		switch ipIsBlocked := me.t.cl.ipIsBlocked; me.u.Scheme {
 		case "udp4", "udp6":

--- a/tracker_scraper.go
+++ b/tracker_scraper.go
@@ -65,7 +65,7 @@ type trackerAnnounceResult struct {
 	Completed time.Time
 }
 
-func (me *TrackerScraper) getIp() (ip net.IP, err error) {
+func (me *trackerScraper) getIp() (ip net.IP, err error) {
 	switch ips, er := net.LookupIP(me.u.Hostname()); {
 	case er != nil:
 		return nil, er


### PR DESCRIPTION
A few changes that make things clearer and reduce chances of hitting another Go gotcha. Go also is pretty bad at moving loop-invariant code out of loops, so this should help thing in that front as well.