### PR TITLE
Reorder fields to reduce padding in reader

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -30,26 +30,29 @@ type pieceRange struct {
 }
 
 type reader struct {
-	t          *Torrent
-	responsive bool
+	t   *Torrent
 	// Adjust the read/seek window to handle Readers locked to File extents and the like.
 	offset, length int64
-
-	// Required when modifying pos and readahead, or reading them without opMu.
-	mu  sync.Locker
-	pos int64
-	// Reads have been initiated since the last seek. This is used to prevent readahead occuring
-	// after a seek or with a new reader at the starting position.
-	reading   bool
-	readahead int64
+	
 	// Function to dynamically calculate readahead. If nil, readahead is static.
 	readaheadFunc func() int64
+	
+	// Required when modifying pos and readahead.
+	mu  sync.Locker
+
+	readahead, pos int64
 	// Position that reads have continued contiguously from.
 	contiguousReadStartPos int64
 	// The cached piece range this reader wants downloaded. The zero value corresponds to nothing.
 	// We cache this so that changes can be detected, and bubbled up to the Torrent only as
 	// required.
 	pieces pieceRange
+
+	// Reads have been initiated since the last seek. This is used to prevent readaheads occurring
+	// after a seek or with a new reader at the starting position.
+	reading    bool
+	responsive bool
+
 }
 
 var _ io.ReadSeekCloser = (*reader)(nil)


### PR DESCRIPTION
Reorder some of the fields to reduce the size of `reader`. Not much of a change -- original size was 104 bytes, with changes (moving bool's to the end) the size is 96 bytes. There's also the whole cache-friendly bit -- I tried reordering fields to help here, but I doubt it makes much of a difference.

Some other notes: `sync.Locker` is a 16 byte field. I suggest changing this to something like `*sync.RWMutex` or `*lockWithDeferreds`. This would not only reduce size but would allow access to `RLock`/`RUnlock`.
`pieceRange` could also be shrunk to 8 bytes, but I feel like I'm probably asking for too much lol.