### PR TITLE
Pool readers and create default constructor

### DIFF
--- a/t.go
+++ b/t.go
@@ -37,15 +37,9 @@ func (t *Torrent) NewReader() Reader {
 }
 
 func (t *Torrent) newReader(offset, length int64) Reader {
-	r := reader{
-		mu:     t.cl.locker(),
-		t:      t,
-		offset: offset,
-		length: length,
-	}
-	r.readaheadFunc = r.defaultReadaheadFunc
-	t.addReader(&r)
-	return &r
+	r := newReader(t, offset, length, 0, 0, false)
+	t.addReader(r)
+	return r
 }
 
 type PieceStateRuns []PieceStateRun


### PR DESCRIPTION
I was hesitant to make this request before, but it now seems like a pretty obvious choice as the `reader` struct begins to get more fields. Torrents with thousands of files would easily benefit from this. On the hand, if a user only creates a single reader for a torrent -- there would likely be no benefit.

But the added bonus is that it goes along nicely with constructors! The constructor here is obviously `newReader`