### PR TITLE
Refactor `types` (Request, ChunkSpec, piecePriority)

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -3,6 +3,7 @@ package torrent
 import (
 	"github.com/anacrolix/torrent/mse"
 	pp "github.com/anacrolix/torrent/peer_protocol"
+	"github.com/anacrolix/torrent/types"
 )
 
 // These are called synchronously, and do not pass ownership of arguments (do not expect to retain
@@ -36,5 +37,5 @@ type PeerMessageEvent struct {
 
 type PeerRequestEvent struct {
 	Peer *Peer
-	Request
+	types.Request
 }

--- a/client_test.go
+++ b/client_test.go
@@ -12,6 +12,7 @@ import (
 	"testing/iotest"
 	"time"
 
+	"github.com/anacrolix/torrent/types"
 	"github.com/bradfitz/iter"
 	"github.com/frankban/quicktest"
 	"github.com/stretchr/testify/assert"
@@ -98,7 +99,7 @@ func TestTorrentInitialState(t *testing.T) {
 	tor.cl.lock()
 	assert.EqualValues(t, 3, tor.pieceNumPendingChunks(0))
 	tor.cl.unlock()
-	assert.EqualValues(t, ChunkSpec{4, 1}, chunkIndexSpec(2, tor.pieceLength(0), tor.chunkSize))
+	assert.EqualValues(t, types.ChunkSpec{4, 1}, chunkIndexSpec(2, tor.pieceLength(0), tor.chunkSize))
 }
 
 func TestReducedDialTimeout(t *testing.T) {

--- a/file.go
+++ b/file.go
@@ -145,7 +145,7 @@ func (f *File) NewReader() Reader {
 }
 
 // Sets the minimum priority for pieces in the File.
-func (f *File) SetPriority(prio piecePriority) {
+func (f *File) SetPriority(prio PiecePriority) {
 	f.t.cl.lock()
 	if prio != f.prio {
 		f.prio = prio
@@ -155,7 +155,7 @@ func (f *File) SetPriority(prio piecePriority) {
 }
 
 // Returns the priority per File.SetPriority.
-func (f *File) Priority() (prio piecePriority) {
+func (f *File) Priority() (prio PiecePriority) {
 	f.t.cl.lock()
 	prio = f.prio
 	f.t.cl.unlock()

--- a/file.go
+++ b/file.go
@@ -5,7 +5,7 @@ import (
 	"github.com/anacrolix/missinggo/v2/bitmap"
 
 	"github.com/anacrolix/torrent/metainfo"
-	. "github.com/anacrolix/torrent/types"
+	"github.com/anacrolix/torrent/types"
 )
 
 // Provides access to regions of torrent data that correspond to its files.
@@ -16,7 +16,7 @@ type File struct {
 	length      int64
 	fi          metainfo.FileInfo
 	displayPath string
-	prio        PiecePriority
+	prio        types.PiecePriority
 }
 
 func (f *File) Torrent() *Torrent {
@@ -126,7 +126,7 @@ func (f *File) State() (ret []FilePieceState) {
 
 // Requests that all pieces containing data in the file be downloaded.
 func (f *File) Download() {
-	f.SetPriority(PiecePriorityNormal)
+	f.SetPriority(types.PiecePriorityNormal)
 }
 
 func byteRegionExclusivePieces(off, size, pieceSize int64) (begin, end int) {
@@ -137,7 +137,7 @@ func byteRegionExclusivePieces(off, size, pieceSize int64) (begin, end int) {
 
 // Deprecated: Use File.SetPriority.
 func (f *File) Cancel() {
-	f.SetPriority(PiecePriorityNone)
+	f.SetPriority(types.PiecePriorityNone)
 }
 
 func (f *File) NewReader() Reader {
@@ -145,7 +145,7 @@ func (f *File) NewReader() Reader {
 }
 
 // Sets the minimum priority for pieces in the File.
-func (f *File) SetPriority(prio PiecePriority) {
+func (f *File) SetPriority(prio types.PiecePriority) {
 	f.t.cl.lock()
 	if prio != f.prio {
 		f.prio = prio
@@ -155,7 +155,7 @@ func (f *File) SetPriority(prio PiecePriority) {
 }
 
 // Returns the priority per File.SetPriority.
-func (f *File) Priority() (prio PiecePriority) {
+func (f *File) Priority() (prio types.PiecePriority) {
 	f.t.cl.lock()
 	prio = f.prio
 	f.t.cl.unlock()

--- a/file.go
+++ b/file.go
@@ -5,6 +5,7 @@ import (
 	"github.com/anacrolix/missinggo/v2/bitmap"
 
 	"github.com/anacrolix/torrent/metainfo"
+	. "github.com/anacrolix/torrent/types"
 )
 
 // Provides access to regions of torrent data that correspond to its files.
@@ -15,7 +16,7 @@ type File struct {
 	length      int64
 	fi          metainfo.FileInfo
 	displayPath string
-	prio        piecePriority
+	prio        PiecePriority
 }
 
 func (f *File) Torrent() *Torrent {

--- a/misc.go
+++ b/misc.go
@@ -5,19 +5,18 @@ import (
 	"net"
 
 	"github.com/anacrolix/missinggo/v2"
-	"github.com/anacrolix/torrent/types"
 	"golang.org/x/time/rate"
 
 	"github.com/anacrolix/torrent/metainfo"
 	pp "github.com/anacrolix/torrent/peer_protocol"
-	.  "github.com/anacrolix/torrent/types"
+	"github.com/anacrolix/torrent/types"
 )
 
-func newRequest(index, begin, length pp.Integer) Request {
-	return Request{index, ChunkSpec{begin, length}}
+func newRequest(index, begin, length pp.Integer) types.Request {
+	return types.Request{index, types.ChunkSpec{begin, length}}
 }
 
-func newRequestFromMessage(msg *pp.Message) Request {
+func newRequestFromMessage(msg *pp.Message) types.Request {
 	switch msg.Type {
 	case pp.Request, pp.Cancel, pp.Reject:
 		return newRequest(msg.Index, msg.Begin, msg.Length)
@@ -41,7 +40,7 @@ func metadataPieceSize(totalSize int, piece int) int {
 func torrentOffsetRequest(
 	torrentLength, pieceSize, chunkSize, offset int64,
 ) (
-	r Request, ok bool,
+	r types.Request, ok bool,
 ) {
 	if offset < 0 || offset >= torrentLength {
 		return
@@ -61,7 +60,7 @@ func torrentOffsetRequest(
 	return
 }
 
-func torrentRequestOffset(torrentLength, pieceSize int64, r Request) (off int64) {
+func torrentRequestOffset(torrentLength, pieceSize int64, r types.Request) (off int64) {
 	off = int64(r.Index)*pieceSize + int64(r.Begin)
 	if off < 0 || off >= torrentLength {
 		panic("invalid Request")
@@ -85,8 +84,8 @@ func validateInfo(info *metainfo.Info) error {
 	return nil
 }
 
-func chunkIndexSpec(index pp.Integer, pieceLength, chunkSize pp.Integer) ChunkSpec {
-	ret := ChunkSpec{pp.Integer(index) * chunkSize, chunkSize}
+func chunkIndexSpec(index pp.Integer, pieceLength, chunkSize pp.Integer) types.ChunkSpec {
+	ret := types.ChunkSpec{pp.Integer(index) * chunkSize, chunkSize}
 	if ret.Begin+ret.Length > pieceLength {
 		ret.Length = pieceLength - ret.Begin
 	}

--- a/misc.go
+++ b/misc.go
@@ -10,21 +10,7 @@ import (
 
 	"github.com/anacrolix/torrent/metainfo"
 	pp "github.com/anacrolix/torrent/peer_protocol"
-)
-
-type (
-	Request       = types.Request
-	ChunkSpec     = types.ChunkSpec
-	piecePriority = types.PiecePriority
-)
-
-const (
-	PiecePriorityNormal    = types.PiecePriorityNormal
-	PiecePriorityNone      = types.PiecePriorityNone
-	PiecePriorityNow       = types.PiecePriorityNow
-	PiecePriorityReadahead = types.PiecePriorityReadahead
-	PiecePriorityNext      = types.PiecePriorityNext
-	PiecePriorityHigh      = types.PiecePriorityHigh
+	.  "github.com/anacrolix/torrent/types"
 )
 
 func newRequest(index, begin, length pp.Integer) Request {

--- a/misc_test.go
+++ b/misc_test.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/anacrolix/missinggo/iter"
 	"github.com/anacrolix/missinggo/v2/bitmap"
+	"github.com/anacrolix/torrent/types"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestTorrentOffsetRequest(t *testing.T) {
-	check := func(tl, ps, off int64, expected Request, ok bool) {
+	check := func(tl, ps, off int64, expected types.Request, ok bool) {
 		req, _ok := torrentOffsetRequest(tl, ps, defaultChunkSize, off)
 		assert.Equal(t, _ok, ok)
 		assert.Equal(t, req, expected)
@@ -20,7 +21,7 @@ func TestTorrentOffsetRequest(t *testing.T) {
 	check(13, 5, 0, newRequest(0, 0, 5), true)
 	check(13, 5, 3, newRequest(0, 0, 5), true)
 	check(13, 5, 11, newRequest(2, 0, 3), true)
-	check(13, 5, 13, Request{}, false)
+	check(13, 5, 13, types.Request{}, false)
 }
 
 func BenchmarkIterBitmapsDistinct(t *testing.B) {

--- a/peer-impl.go
+++ b/peer-impl.go
@@ -2,6 +2,7 @@ package torrent
 
 import (
 	"github.com/anacrolix/torrent/metainfo"
+	"github.com/anacrolix/torrent/types"
 )
 
 // Contains implementation details that differ between peer types, like Webseeds and regular
@@ -14,8 +15,8 @@ type peerImpl interface {
 
 	// Neither of these return buffer room anymore, because they're currently both posted. There's
 	// also PeerConn.writeBufferFull for when/where it matters.
-	_cancel(Request) bool
-	_request(Request) bool
+	_cancel(types.Request) bool
+	_request(types.Request) bool
 
 	connectionFlags() string
 	onClose()

--- a/peerconn.go
+++ b/peerconn.go
@@ -25,6 +25,7 @@ import (
 	"github.com/anacrolix/torrent/mse"
 	pp "github.com/anacrolix/torrent/peer_protocol"
 	request_strategy "github.com/anacrolix/torrent/request-strategy"
+	. "github.com/anacrolix/torrent/types"
 )
 
 type PeerSource string

--- a/peerconn_test.go
+++ b/peerconn_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/anacrolix/torrent/metainfo"
 	pp "github.com/anacrolix/torrent/peer_protocol"
 	"github.com/anacrolix/torrent/storage"
+	"github.com/anacrolix/torrent/types"
 )
 
 // Ensure that no race exists between sending a bitfield, and a subsequent
@@ -106,7 +107,7 @@ func BenchmarkConnectionMainReadLoop(b *testing.B) {
 		PieceLength: 1 << 20,
 	}))
 	t.setChunkSize(defaultChunkSize)
-	t._pendingPieces.Set(0, PiecePriorityNormal.BitmapPriority())
+	t._pendingPieces.Set(0, types.PiecePriorityNormal.BitmapPriority())
 	r, w := net.Pipe()
 	cn := cl.newConnection(r, true, r.RemoteAddr(), r.RemoteAddr().Network(), regularNetConnPeerConnConnString(r))
 	cn.setTorrent(t)
@@ -133,7 +134,7 @@ func BenchmarkConnectionMainReadLoop(b *testing.B) {
 			// The chunk must be written to storage everytime, to ensure the
 			// writeSem is unlocked.
 			t.pieces[0]._dirtyChunks.Clear()
-			cn.validReceiveChunks = map[Request]int{newRequestFromMessage(&msg): 1}
+			cn.validReceiveChunks = map[types.Request]int{newRequestFromMessage(&msg): 1}
 			cl.unlock()
 			n, err := w.Write(wb)
 			require.NoError(b, err)

--- a/piece.go
+++ b/piece.go
@@ -10,6 +10,7 @@ import (
 	"github.com/anacrolix/torrent/metainfo"
 	pp "github.com/anacrolix/torrent/peer_protocol"
 	"github.com/anacrolix/torrent/storage"
+	. "github.com/anacrolix/torrent/types"
 )
 
 type Piece struct {
@@ -30,7 +31,7 @@ type Piece struct {
 	storageCompletionOk bool
 
 	publicPieceState PieceState
-	priority         piecePriority
+	priority         PiecePriority
 	availability     int64
 
 	// This can be locked when the Client lock is taken, but probably not vice versa.
@@ -184,14 +185,14 @@ func (p *Piece) torrentEndOffset() int64 {
 	return p.torrentBeginOffset() + int64(p.length())
 }
 
-func (p *Piece) SetPriority(prio piecePriority) {
+func (p *Piece) SetPriority(prio PiecePriority) {
 	p.t.cl.lock()
 	defer p.t.cl.unlock()
 	p.priority = prio
 	p.t.updatePiecePriority(p.index)
 }
 
-func (p *Piece) purePriority() (ret piecePriority) {
+func (p *Piece) purePriority() (ret PiecePriority) {
 	for _, f := range p.files {
 		ret.Raise(f.prio)
 	}
@@ -208,7 +209,7 @@ func (p *Piece) purePriority() (ret piecePriority) {
 	return
 }
 
-func (p *Piece) uncachedPriority() (ret piecePriority) {
+func (p *Piece) uncachedPriority() (ret PiecePriority) {
 	if p.t.pieceComplete(p.index) || p.t.pieceQueuedForHash(p.index) || p.t.hashingPiece(p.index) {
 		return PiecePriorityNone
 	}

--- a/piecestate.go
+++ b/piecestate.go
@@ -2,11 +2,12 @@ package torrent
 
 import (
 	"github.com/anacrolix/torrent/storage"
+	. "github.com/anacrolix/torrent/types"
 )
 
 // The current state of a piece.
 type PieceState struct {
-	Priority piecePriority
+	Priority PiecePriority
 	storage.Completion
 	// The piece is being hashed, or is queued for hash. Deprecated: Use those fields instead.
 	Checking bool

--- a/piecestate.go
+++ b/piecestate.go
@@ -2,12 +2,12 @@ package torrent
 
 import (
 	"github.com/anacrolix/torrent/storage"
-	. "github.com/anacrolix/torrent/types"
+	"github.com/anacrolix/torrent/types"
 )
 
 // The current state of a piece.
 type PieceState struct {
-	Priority PiecePriority
+	Priority types.PiecePriority
 	storage.Completion
 	// The piece is being hashed, or is queued for hash. Deprecated: Use those fields instead.
 	Checking bool

--- a/protocol.go
+++ b/protocol.go
@@ -2,8 +2,9 @@ package torrent
 
 import (
 	pp "github.com/anacrolix/torrent/peer_protocol"
+	"github.com/anacrolix/torrent/types"
 )
 
-func makeCancelMessage(r Request) pp.Message {
+func makeCancelMessage(r types.Request) pp.Message {
 	return pp.MakeCancelMessage(r.Index, r.Begin, r.Length)
 }

--- a/requesting.go
+++ b/requesting.go
@@ -56,7 +56,7 @@ func (cl *Client) doRequests() {
 				Length:           int64(p.length()),
 				NumPendingChunks: int(t.pieceNumPendingChunks(i)),
 				IterPendingChunks: func(f func(types.ChunkSpec)) {
-					p.iterUndirtiedChunks(func(cs ChunkSpec) bool {
+					p.iterUndirtiedChunks(func(cs types.ChunkSpec) bool {
 						f(cs)
 						return true
 					})

--- a/t.go
+++ b/t.go
@@ -231,7 +231,7 @@ func (t *Torrent) initFiles() {
 			fi.Length,
 			fi,
 			dp,
-			PiecePriorityNone,
+			types.PiecePriorityNone,
 		})
 		offset += fi.Length
 	}

--- a/t.go
+++ b/t.go
@@ -202,10 +202,10 @@ func (t *Torrent) CancelPieces(begin, end pieceIndex) {
 func (t *Torrent) cancelPiecesLocked(begin, end pieceIndex) {
 	for i := begin; i < end; i++ {
 		p := &t.pieces[i]
-		if p.priority == PiecePriorityNone {
+		if p.priority == types.PiecePriorityNone {
 			continue
 		}
-		p.priority = PiecePriorityNone
+		p.priority = types.PiecePriorityNone
 		t.updatePiecePriority(i)
 	}
 }

--- a/t.go
+++ b/t.go
@@ -8,6 +8,7 @@ import (
 	"github.com/anacrolix/sync"
 
 	"github.com/anacrolix/torrent/metainfo"
+	"github.com/anacrolix/torrent/types"
 )
 
 // The Torrent's infohash. This is fixed and cannot change. It uniquely identifies a torrent.
@@ -186,7 +187,7 @@ func (t *Torrent) DownloadPieces(begin, end pieceIndex) {
 
 func (t *Torrent) downloadPiecesLocked(begin, end pieceIndex) {
 	for i := begin; i < end; i++ {
-		if t.pieces[i].priority.Raise(PiecePriorityNormal) {
+		if t.pieces[i].priority.Raise(types.PiecePriorityNormal) {
 			t.updatePiecePriority(i)
 		}
 	}

--- a/torrent.go
+++ b/torrent.go
@@ -30,7 +30,6 @@ import (
 	"github.com/anacrolix/missinggo/v2/prioritybitmap"
 	"github.com/anacrolix/multiless"
 	"github.com/anacrolix/sync"
-	"github.com/anacrolix/torrent"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pion/datachannel"
 

--- a/torrent.go
+++ b/torrent.go
@@ -40,6 +40,7 @@ import (
 	"github.com/anacrolix/torrent/segments"
 	"github.com/anacrolix/torrent/storage"
 	"github.com/anacrolix/torrent/tracker"
+	. "github.com/anacrolix/torrent/types"
 	"github.com/anacrolix/torrent/webseed"
 	"github.com/anacrolix/torrent/webtorrent"
 )
@@ -1156,7 +1157,7 @@ func (t *Torrent) forReaderOffsetPieces(f func(begin, end pieceIndex) (more bool
 	return true
 }
 
-func (t *Torrent) piecePriority(piece pieceIndex) piecePriority {
+func (t *Torrent) piecePriority(piece pieceIndex) PiecePriority {
 	prio, ok := t._pendingPieces.GetPriority(piece)
 	if !ok {
 		return PiecePriorityNone
@@ -1164,7 +1165,7 @@ func (t *Torrent) piecePriority(piece pieceIndex) piecePriority {
 	if prio > 0 {
 		panic(prio)
 	}
-	ret := piecePriority(-prio)
+	ret := PiecePriority(-prio)
 	if ret == PiecePriorityNone {
 		panic(piece)
 	}

--- a/torrent_test.go
+++ b/torrent_test.go
@@ -19,26 +19,27 @@ import (
 	"github.com/anacrolix/torrent/metainfo"
 	pp "github.com/anacrolix/torrent/peer_protocol"
 	"github.com/anacrolix/torrent/storage"
+	"github.com/anacrolix/torrent/types"
 )
 
-func r(i, b, l pp.Integer) Request {
-	return Request{i, ChunkSpec{b, l}}
+func r(i, b, l pp.Integer) types.Request {
+	return types.Request{i, types.ChunkSpec{b, l}}
 }
 
 // Check the given request is correct for various torrent offsets.
 func TestTorrentRequest(t *testing.T) {
 	const s = 472183431 // Length of torrent.
 	for _, _case := range []struct {
-		off int64   // An offset into the torrent.
-		req Request // The expected request. The zero value means !ok.
+		off int64         // An offset into the torrent.
+		req types.Request // The expected request. The zero value means !ok.
 	}{
 		// Invalid offset.
-		{-1, Request{}},
+		{-1, types.Request{}},
 		{0, r(0, 0, 16384)},
 		// One before the end of a piece.
 		{1<<18 - 1, r(0, 1<<18-16384, 16384)},
 		// Offset beyond torrent length.
-		{472 * 1 << 20, Request{}},
+		{472 * 1 << 20, types.Request{}},
 		// One before the end of the torrent. Complicates the chunk length.
 		{s - 1, r((s-1)/(1<<18), (s-1)%(1<<18)/(16384)*(16384), 12935)},
 		{1, r(0, 0, 16384)},
@@ -48,7 +49,7 @@ func TestTorrentRequest(t *testing.T) {
 		{16384, r(0, 16384, 16384)},
 	} {
 		req, ok := torrentOffsetRequest(472183431, 1<<18, 16384, _case.off)
-		if (_case.req == Request{}) == ok {
+		if (_case.req == types.Request{}) == ok {
 			t.Fatalf("expected %v, got %v", _case.req, req)
 		}
 		if req != _case.req {


### PR DESCRIPTION
Time to start getting rid of those type aliases; use them for gradual code refactoring.