### PR TITLE
Drop bradfitz/iter dependency

### DIFF
--- a/bencode/bench_test.go
+++ b/bencode/bench_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/anacrolix/dht/v2/krpc"
-	"github.com/bradfitz/iter"
-
 	"github.com/anacrolix/torrent/bencode"
 )
 
@@ -40,7 +38,7 @@ func BenchmarkMarshalThenUnmarshalKrpcMsg(tb *testing.B) {
 	}
 	tb.ReportAllocs()
 	tb.ResetTimer()
-	for range iter.N(tb.N) {
+	for i := 0; i < tb.N; i += 1 {
 		marshalAndUnmarshal(tb, orig)
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -12,7 +12,6 @@ import (
 	"testing/iotest"
 	"time"
 
-	"github.com/bradfitz/iter"
 	"github.com/frankban/quicktest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -131,7 +130,7 @@ func TestAddDropManyTorrents(t *testing.T) {
 	cl, err := NewClient(TestingConfig(t))
 	require.NoError(t, err)
 	defer cl.Close()
-	for i := range iter.N(1000) {
+	for i := 0; i < 1000; i += 1 {
 		var spec TorrentSpec
 		binary.PutVarint(spec.InfoHash[:], int64(i))
 		tt, new, err := cl.AddTorrentSpec(&spec)
@@ -203,7 +202,7 @@ func BenchmarkAddLargeTorrent(b *testing.B) {
 	require.NoError(b, err)
 	defer cl.Close()
 	b.ReportAllocs()
-	for range iter.N(b.N) {
+	for i := 0; i < b.N; i += 1 {
 		t, err := cl.AddTorrentFromFile("testdata/bootstrap.dat.torrent")
 		if err != nil {
 			b.Fatal(err)
@@ -354,7 +353,7 @@ func TestTorrentDroppedBeforeGotInfo(t *testing.T) {
 }
 
 func writeTorrentData(ts *storage.Torrent, info metainfo.Info, b []byte) {
-	for i := range iter.N(info.NumPieces()) {
+	for i := 0; i < info.NumPieces(); i += 1 {
 		p := info.Piece(i)
 		ts.Piece(p).WriteAt(b[p.Offset():p.Offset()+p.Length()], 0)
 	}
@@ -609,7 +608,7 @@ func TestSetMaxEstablishedConn(t *testing.T) {
 	cfg := TestingConfig(t)
 	cfg.DisableAcceptRateLimiting = true
 	cfg.DropDuplicatePeerIds = true
-	for i := range iter.N(3) {
+	for i := 0; i < 3; i += 1 {
 		cl, err := NewClient(cfg)
 		require.NoError(t, err)
 		defer cl.Close()

--- a/cmd/torrent-metainfo-pprint/main.go
+++ b/cmd/torrent-metainfo-pprint/main.go
@@ -55,7 +55,7 @@ func processReader(r io.Reader) error {
 	}
 	if flags.PieceHashes {
 		d["PieceHashes"] = func() (ret []string) {
-			for i := range iter.N(info.NumPieces()) {
+			for i, numPieces := 0, info.NumPieces(); i < numPieces; i += 1 {
 				ret = append(ret, hex.EncodeToString(info.Pieces[i*20:(i+1)*20]))
 			}
 			return

--- a/cmd/torrent-metainfo-pprint/main.go
+++ b/cmd/torrent-metainfo-pprint/main.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/anacrolix/envpprof"
 	"github.com/anacrolix/tagflag"
-	"github.com/bradfitz/iter"
 
 	"github.com/anacrolix/torrent/metainfo"
 )

--- a/cmd/torrent-verify/main.go
+++ b/cmd/torrent-verify/main.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 
 	"github.com/anacrolix/tagflag"
-	"github.com/bradfitz/iter"
 	"github.com/edsrzf/mmap-go"
 
 	"github.com/anacrolix/torrent/metainfo"
@@ -47,7 +46,7 @@ func verifyTorrent(info *metainfo.Info, root string) error {
 		span.Append(mm)
 	}
 	span.InitIndex()
-	for i := range iter.N(info.NumPieces()) {
+	for i, numPieces := 0, info.NumPieces(); i < numPieces; i += 1 {
 		p := info.Piece(i)
 		hash := sha1.New()
 		_, err := io.Copy(hash, io.NewSectionReader(span, p.Offset(), p.Length()))

--- a/iplist/iplist_test.go
+++ b/iplist/iplist_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bradfitz/iter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/iplist/iplist_test.go
+++ b/iplist/iplist_test.go
@@ -41,7 +41,7 @@ func init() {
 
 func TestIPv4RangeLen(t *testing.T) {
 	ranges, _ := sampleRanges(t)
-	for i := range iter.N(3) {
+	for i := 0; i < 3; i += 1 {
 		if len(ranges[i].First) != 4 {
 			t.FailNow()
 		}

--- a/misc_test.go
+++ b/misc_test.go
@@ -25,7 +25,7 @@ func TestTorrentOffsetRequest(t *testing.T) {
 
 func BenchmarkIterBitmapsDistinct(t *testing.B) {
 	t.ReportAllocs()
-	for range iter.N(t.N) {
+	for i := 0; i < t.N; i += 1 {
 		var skip, first, second bitmap.Bitmap
 		skip.Add(1)
 		first.Add(1, 0, 3)

--- a/mse/mse_test.go
+++ b/mse/mse_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	_ "github.com/anacrolix/envpprof"
-	"github.com/bradfitz/iter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -114,7 +113,7 @@ func TestHandshakeSelectPlaintext(t *testing.T) {
 }
 
 func BenchmarkHandshakeDefault(b *testing.B) {
-	for range iter.N(b.N) {
+	for i := 0; i < b.N; i += 1 {
 		allHandshakeTests(b, AllSupportedCrypto, DefaultCryptoSelector)
 	}
 }
@@ -171,7 +170,7 @@ func benchmarkStream(t *testing.B, crypto CryptoMethod) {
 	t.StopTimer()
 	t.SetBytes(int64(len(ia) + len(a) + len(b)))
 	t.ResetTimer()
-	for range iter.N(t.N) {
+	for i := 0; i < t.N; i += 1 {
 		ac, bc := net.Pipe()
 		ar := make([]byte, len(b))
 		br := make([]byte, len(ia)+len(a))
@@ -239,7 +238,7 @@ func BenchmarkPipeRC4(t *testing.B) {
 	b := make([]byte, len(a))
 	t.SetBytes(int64(len(a)))
 	t.ResetTimer()
-	for range iter.N(t.N) {
+	for i := 0; i < t.N; i += 1 {
 		n, _ = w.Write(a)
 		if n != len(a) {
 			t.FailNow()
@@ -256,7 +255,7 @@ func BenchmarkPipeRC4(t *testing.B) {
 
 func BenchmarkSkeysReceive(b *testing.B) {
 	var skeys [][]byte
-	for range iter.N(100000) {
+	for i := 0; i < 100000; i += 1 {
 		skeys = append(skeys, make([]byte, 20))
 	}
 	fillRand(b, skeys...)
@@ -264,7 +263,7 @@ func BenchmarkSkeysReceive(b *testing.B) {
 	//c := qt.New(b)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for range iter.N(b.N) {
+	for i := 0; i < b.N; i += 1 {
 		initiator, receiver := net.Pipe()
 		go func() {
 			_, _, err := InitiateHandshake(initiator, initSkey, nil, AllSupportedCrypto)

--- a/peer_protocol/decoder_test.go
+++ b/peer_protocol/decoder_test.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/bradfitz/iter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -46,7 +45,7 @@ func BenchmarkDecodePieces(t *testing.B) {
 			},
 		},
 	}
-	for range iter.N(t.N) {
+	for i := 0; i < t.N; i += 1 {
 		var msg Message
 		require.NoError(t, d.Decode(&msg))
 		// WWJD

--- a/peerconn.go
+++ b/peerconn.go
@@ -784,9 +784,9 @@ func (cn *PeerConn) peerSentBitfield(bf []bool) error {
 func (cn *Peer) onPeerHasAllPieces() {
 	t := cn.t
 	if t.haveInfo() {
-		pp := cn.newPeerPieces()
-		for i := range iter.N(t.numPieces()) {
-			if !pp.Contains(bitmap.BitIndex(i)) {
+		npp, pc := cn.newPeerPieces(), t.numPieces()
+		for i := 0; i < pc; i += 1 {
+			if !npp.Contains(bitmap.BitIndex(i)) {
 				t.incPieceAvailability(i)
 			}
 		}

--- a/peerconn_test.go
+++ b/peerconn_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/anacrolix/missinggo/pubsub"
-	"github.com/bradfitz/iter"
 	"github.com/frankban/quicktest"
 	"github.com/stretchr/testify/require"
 
@@ -128,7 +127,7 @@ func BenchmarkConnectionMainReadLoop(b *testing.B) {
 	go func() {
 		defer w.Close()
 		ts.writeSem.Lock()
-		for range iter.N(b.N) {
+		for i := 0; i < b.N; i += 1 {
 			cl.lock()
 			// The chunk must be written to storage everytime, to ensure the
 			// writeSem is unlocked.

--- a/request-strategy/order_test.go
+++ b/request-strategy/order_test.go
@@ -4,7 +4,6 @@ import (
 	"math"
 	"testing"
 
-	"github.com/bradfitz/iter"
 	qt "github.com/frankban/quicktest"
 
 	pp "github.com/anacrolix/torrent/peer_protocol"
@@ -16,7 +15,7 @@ func r(i pieceIndex, begin int) Request {
 
 func chunkIterRange(end int) func(func(ChunkSpec)) {
 	return func(f func(ChunkSpec)) {
-		for offset := range iter.N(end) {
+		for offset := 0; offset < end; offset += 1 {
 			f(ChunkSpec{pp.Integer(offset), 1})
 		}
 	}

--- a/rlreader_test.go
+++ b/rlreader_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bradfitz/iter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
@@ -59,7 +58,7 @@ func TestRateLimitReaders(t *testing.T) {
 	}
 	reads := make(chan read)
 	done := make(chan struct{})
-	for range iter.N(numReaders) {
+	for i := 0; i < numReaders; i += 1 {
 		r, w := io.Pipe()
 		ws = append(ws, w)
 		cs = append(cs, w)
@@ -99,7 +98,7 @@ func TestRateLimitReaders(t *testing.T) {
 	}()
 	written := 0
 	go func() {
-		for range iter.N(writeRounds) {
+		for i := 0; i < writeRounds; i += 1 {
 			err := writeN(ws, bytesPerRound)
 			if err != nil {
 				log.Printf("error writing: %s", err)

--- a/storage/test/bench-piece-mark-complete.go
+++ b/storage/test/bench-piece-mark-complete.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/anacrolix/torrent/storage"
-	"github.com/bradfitz/iter"
 	qt "github.com/frankban/quicktest"
 )
 
@@ -41,7 +40,7 @@ func BenchmarkPieceMarkComplete(
 	readData := make([]byte, pieceSize)
 	b.SetBytes(int64(numPieces) * pieceSize)
 	oneIter := func() {
-		for pieceIndex := range iter.N(numPieces) {
+		for pieceIndex := 0; pieceIndex < numPieces; pieceIndex += 1 {
 			pi := tw.Piece(info.Piece(pieceIndex))
 			rand.Read(data)
 			b.StartTimer()
@@ -76,12 +75,13 @@ func BenchmarkPieceMarkComplete(
 	}
 	// Fill the cache
 	if capacity > 0 {
-		for range iter.N(int((capacity + info.TotalLength() - 1) / info.TotalLength())) {
+		iterN := int((capacity + info.TotalLength() - 1) / info.TotalLength())
+		for i := 0; i < iterN; i += 1 {
 			oneIter()
 		}
 	}
 	b.ResetTimer()
-	for range iter.N(b.N) {
+	for i := 0; i < b.N; i += 1 {
 		oneIter()
 	}
 }

--- a/torrent.go
+++ b/torrent.go
@@ -21,7 +21,6 @@ import (
 	"github.com/anacrolix/chansync"
 	"github.com/anacrolix/dht/v2"
 	"github.com/anacrolix/log"
-	"github.com/anacrolix/missinggo/iter"
 	"github.com/anacrolix/missinggo/perf"
 	"github.com/anacrolix/missinggo/pubsub"
 	"github.com/anacrolix/missinggo/slices"

--- a/torrent.go
+++ b/torrent.go
@@ -2237,7 +2237,7 @@ func (t *Torrent) addWebSeed(url string) {
 		activeRequests: make(map[Request]webseed.Request, maxRequests),
 	}
 	ws.requesterCond.L = t.cl.locker()
-	for range iter.N(maxRequests) {
+	for i := 0; i < maxRequests; i += 1 {
 		go ws.requester()
 	}
 	for _, f := range t.callbacks().NewPeer {

--- a/torrent_test.go
+++ b/torrent_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/anacrolix/missinggo/v2"
 	"github.com/anacrolix/missinggo/v2/bitmap"
-	"github.com/bradfitz/iter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -91,7 +90,7 @@ func BenchmarkUpdatePiecePriorities(b *testing.B) {
 		Length:      pieceLength * numPieces,
 	}))
 	assert.EqualValues(b, 13410, t.numPieces())
-	for range iter.N(7) {
+	for i := 0; i < 7; i += 1 {
 		r := t.NewReader()
 		r.SetReadahead(32 << 20)
 		r.Seek(3500000, io.SeekStart)
@@ -101,7 +100,7 @@ func BenchmarkUpdatePiecePriorities(b *testing.B) {
 		t._completedPieces.Add(bitmap.BitIndex(i))
 	}
 	t.DownloadPieces(0, t.numPieces())
-	for range iter.N(b.N) {
+	for i := 0; i < b.N; i += 1 {
 		t.updateAllPiecePriorities()
 	}
 }


### PR DESCRIPTION
`range iter.N` looks nice and doesn't allocate, but unfortunately using a `range` expression blocks a function from being inlined wherever it's used (for now). It's not that we need inlining in all cases, but I do think a C-style for loop looks just as nice and is probably clearer to the majority. There also aren't any clear disadvantages to changing (unless you just happen to dislike the look of C)