### PR TITLE
Create helper-type `readers` to hold `*reader`

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -48,6 +48,9 @@ type reader struct {
 	// required.
 	pieces pieceRange
 
+	// Internal identifier used to index a []*reader
+	idx uint32
+	
 	// Reads have been initiated since the last seek. This is used to prevent readaheads occurring
 	// after a seek or with a new reader at the starting position.
 	reading    bool

--- a/readers.go
+++ b/readers.go
@@ -1,0 +1,23 @@
+package torrent
+
+// Helper-type for holding multiple readers
+type readers []*reader
+
+// Add a new reader to readers
+func (rs *readers) Push(r *reader) {
+	rIdx := len(*rs)
+	*rs = append(*rs, r)
+	r.idx = uint32(rIdx)
+}
+
+// Remove reader from readers
+func (rs *readers) Delete(r *reader) {
+	rs.DeleteAt(r.idx)
+}
+
+// Remove reader at index
+func (rs *readers) DeleteAt(index uint32) {
+	(*rs)[index] = (*rs)[len(*rs)-1]
+	(*rs)[len(*rs)-1] = nil
+	*rs = (*rs)[:len(*rs)-1]
+}

--- a/t.go
+++ b/t.go
@@ -162,16 +162,13 @@ func (t *Torrent) Metainfo() metainfo.MetaInfo {
 
 func (t *Torrent) addReader(r *reader) {
 	t.cl.lock()
-	defer t.cl.unlock()
-	if t.readers == nil {
-		t.readers = make(map[*reader]struct{})
-	}
-	t.readers[r] = struct{}{}
+	t.readers.Push(r)
 	r.posChanged()
+	t.cl.unlock()
 }
 
 func (t *Torrent) deleteReader(r *reader) {
-	delete(t.readers, r)
+	t.readers.Delete(r)
 	t.readersChanged()
 }
 

--- a/torrent.go
+++ b/torrent.go
@@ -124,7 +124,7 @@ type Torrent struct {
 	// Closed when .Info is obtained.
 	gotMetainfoC chan struct{}
 
-	readers                map[*reader]struct{}
+	readers                readers
 	_readerNowPieces       bitmap.Bitmap
 	_readerReadaheadPieces bitmap.Bitmap
 
@@ -1143,8 +1143,9 @@ func (t *Torrent) byteRegionPieces(off, size int64) (begin, end pieceIndex) {
 // regions for all readers. The reader regions should not be merged as some
 // callers depend on this method to enumerate readers.
 func (t *Torrent) forReaderOffsetPieces(f func(begin, end pieceIndex) (more bool)) (all bool) {
-	for r := range t.readers {
-		p := r.pieces
+	rdrs := t.readers
+	for i := 0; i < len(rdrs); i += 1 {
+		p := rdrs[i].pieces
 		if p.begin >= p.end {
 			continue
 		}


### PR DESCRIPTION
Currently `*Torrent` uses a `map[*reader]struct{}` to store `reader`, which is unnecessary. A slice is all that's needed. We just need to add a field (e.g. `idx`) to `*reader` in order to mimic the `delete` functionality maps have.