### PR TITLE
Clarify maximum value of "metadata_size"

### DIFF
--- a/global.go
+++ b/global.go
@@ -10,6 +10,10 @@ import (
 const (
 	pieceHash        = crypto.SHA1
 	defaultChunkSize = 0x4000 // 16KiB
+	
+	// Arbitrary maximum of "metadata_size" (see https://www.bittorrent.org/beps/bep_0009.html)
+	// This value is 2x what libtorrent-rasterbar uses, which should be plenty
+	maxMetadataSize uint32 = 8*1024*1024
 )
 
 // These are our extended message IDs. Peers will use these values to

--- a/torrent.go
+++ b/torrent.go
@@ -481,19 +481,19 @@ func (t *Torrent) haveAllMetadataPieces() bool {
 }
 
 // TODO: Propagate errors to disconnect peer.
-func (t *Torrent) setMetadataSize(bytes int) (err error) {
+func (t *Torrent) setMetadataSize(size int) (err error) {
 	if t.haveInfo() {
 		// We already know the correct metadata size.
 		return
 	}
-	if bytes <= 0 || bytes > 10000000 { // 10MB, pulled from my ass.
+	if uint32(size) > maxMetadataSize {
 		return errors.New("bad size")
 	}
-	if t.metadataBytes != nil && len(t.metadataBytes) == int(bytes) {
+	if len(t.metadataBytes) == size {
 		return
 	}
-	t.metadataBytes = make([]byte, bytes)
-	t.metadataCompletedChunks = make([]bool, (bytes+(1<<14)-1)/(1<<14))
+	t.metadataBytes = make([]byte, size)
+	t.metadataCompletedChunks = make([]bool, (size+(1<<14)-1)/(1<<14))
 	t.metadataChanged.Broadcast()
 	for c := range t.conns {
 		c.requestPendingMetadata()


### PR DESCRIPTION
Not saying that https://github.com/arvidn/libtorrent has all the answers, but I think it's a good reference: https://github.com/arvidn/libtorrent/blob/95afba30e9acfd8411076a0b05f7ca69bf33b9bb/src/ut_metadata.cpp#L145-L151.

They use `4 * 1024 * 1024`, but we can double that to be safe. Note how they also use a multiple of 16*1024. I found another torrent client that used `2 * 1024 * 1024`, so we are on the high end regardless.

---

Had a nice chuckle at the comment next to 10MB.

Fixed a redundant check and future possible clash with `bytes` package name.