### PR TITLE
Inlineable `(*File).BytesCompleted()`

### DIFF
--- a/file.go
+++ b/file.go
@@ -44,13 +44,14 @@ func (f *File) Length() int64 {
 
 // Number of bytes of the entire file we have completed. This is the sum of
 // completed pieces, and dirtied chunks of incomplete pieces.
-func (f *File) BytesCompleted() int64 {
+func (f *File) BytesCompleted() (n int64) {
 	f.t.cl.rLock()
-	defer f.t.cl.rUnlock()
-	return f.bytesCompleted()
+	n = f.bytesCompletedLocked()
+	f.t.cl.rUnlock()
+	return
 }
 
-func (f *File) bytesCompleted() int64 {
+func (f *File) bytesCompletedLocked() int64 {
 	return f.length - f.bytesLeft()
 }
 


### PR DESCRIPTION
Also renamed `bytesCompleted` to `bytesCompletedLocked` for a bit of self documentation. If this is a problem I'll change it back, but it doesn't seem like the function is used anywhere besides here anyway.