### PR TITLE
Simplify `(*Torrent).maxHalfOpen()`

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -142,26 +142,6 @@ func max(as ...int64) int64 {
 	return ret
 }
 
-func min(as ...int64) int64 {
-	ret := as[0]
-	for _, a := range as[1:] {
-		if a < ret {
-			ret = a
-		}
-	}
-	return ret
-}
-
-func minInt(as ...int) int {
-	ret := as[0]
-	for _, a := range as[1:] {
-		if a < ret {
-			ret = a
-		}
-	}
-	return ret
-}
-
 var unlimited = rate.NewLimiter(rate.Inf, 0)
 
 type (


### PR DESCRIPTION
Clean up some unnecessary functions that weren't inlined. `min` and `minInt` remain unused.