### PR TITLE
Correct `connIsIpv6`

### DIFF
--- a/client.go
+++ b/client.go
@@ -382,7 +382,7 @@ func (cl *Client) NewAnacrolixDhtServer(conn net.PacketConn) (s *dht.Server, err
 		Conn:           conn,
 		OnAnnouncePeer: cl.onDHTAnnouncePeer,
 		PublicIP: func() net.IP {
-			if connIsIpv6(conn) && cl.config.PublicIp6 != nil {
+			if connIsIpv6(conn.LocalAddr()) && cl.config.PublicIp6 != nil {
 				return cl.config.PublicIp6
 			}
 			return cl.config.PublicIp4
@@ -930,7 +930,7 @@ func (cl *Client) runHandshookConn(c *PeerConn, t *Torrent) error {
 	c.conn.SetWriteDeadline(time.Time{})
 	c.r = deadlineReader{c.conn, c.r}
 	completedHandshakeConnectionFlags.Add(c.connectionFlags(), 1)
-	if connIsIpv6(c.conn) {
+	if connIsIpv6(c.conn.LocalAddr()) {
 		torrent.Add("completed handshake over ipv6", 1)
 	}
 	if err := t.addPeerConn(c); err != nil {

--- a/misc.go
+++ b/misc.go
@@ -111,12 +111,8 @@ func connLessTrusted(l, r *Peer) bool {
 	return l.trust().Less(r.trust())
 }
 
-func connIsIpv6(nc interface {
-	LocalAddr() net.Addr
-}) bool {
-	ra := nc.LocalAddr()
-	rip := addrIpOrNil(ra)
-	return rip.To4() == nil && rip.To16() != nil
+func connIsIpv6(localAddr net.Addr) bool {
+	return strings.Count(localAddr.String(), ":") >= 2
 }
 
 func clamp(min, value, max int64) int64 {


### PR DESCRIPTION
Not sure if the current implementation works, or if it does what it's intended to do. Looks like it checks if an address is IPv6 -- if this is the case, then there is a less roundabout way of doing so.