### PR TITLE
Change `Private` field of `metainfo.Info` to `bool`

### DIFF
--- a/metainfo/info.go
+++ b/metainfo/info.go
@@ -17,10 +17,10 @@ type Info struct {
 	Pieces      []byte `bencode:"pieces"`            // BEP3
 	Name        string `bencode:"name"`              // BEP3
 	Length      int64  `bencode:"length,omitempty"`  // BEP3, mutually exclusive with Files
-	Private     *bool  `bencode:"private,omitempty"` // BEP27
 	// TODO: Document this field.
 	Source string     `bencode:"source,omitempty"`
 	Files  []FileInfo `bencode:"files,omitempty"` // BEP3, mutually exclusive with Length
+	Private bool      `bencode:"private,omitempty"` // BEP27
 }
 
 // The Info.Name field is "advisory". For multi-file torrents it's usually a suggested directory

--- a/tracker_scraper.go
+++ b/tracker_scraper.go
@@ -168,14 +168,13 @@ func (me *trackerScraper) announce(ctx context.Context, event tracker.AnnounceEv
 
 // Returns whether we can shorten the interval, and sets notify to a channel that receives when we
 // might change our mind, or leaves it if we won't.
-func (me *trackerScraper) canIgnoreInterval(notify *<-chan struct{}) bool {
+func (me *TrackerScraper) canIgnoreInterval(notify *<-chan struct{}) bool {
 	gotInfo := me.t.GotInfo()
 	select {
 	case <-gotInfo:
 		// Private trackers really don't like us announcing more than they specify. They're also
 		// tracking us very carefully, so it's best to comply.
-		private := me.t.info.Private
-		return private == nil || !*private
+		return !me.t.info.Private
 	default:
 		*notify = gotInfo
 		return false


### PR DESCRIPTION
Not sure why a pointer is used here since none of the other fields are pointers -- if "private" doesn't exist it's false as expected. This also saves a `nil` check.