### PR TITLE
Revise `nominalMaxRequests()`

### DIFF
--- a/peerconn.go
+++ b/peerconn.go
@@ -463,7 +463,15 @@ func (cn *PeerConn) requestedMetadataPiece(index int) bool {
 
 // The actual value to use as the maximum outbound requests.
 func (cn *Peer) nominalMaxRequests() (ret maxRequests) {
-	return int(clamp(1, 2*int64(cn.maxPiecesReceivedBetweenRequestUpdates), int64(cn.PeerMaxRequests)))
+	const MIN = 1
+	switch ret = 2 * cn.maxPiecesReceivedBetweenRequestUpdates; {
+	default:
+		return
+	case ret > cn.PeerMaxRequests:
+		return cn.PeerMaxRequests
+	case ret < MIN:
+		return MIN
+	}
 }
 
 func (cn *Peer) totalExpectingTime() (ret time.Duration) {


### PR DESCRIPTION
Using a `switch` instead of a clamp function here is ultimately more readable and efficient. I put `default` first because maybe someday Go will make it useful for branch prediction (they allow default to be anywhere in the switch statement -- I can't think of any better reason why(.