### PR TITLE
Inlineable `(*Torrent).SetDisplayName()`

### DIFF
--- a/t.go
+++ b/t.go
@@ -130,15 +130,14 @@ func (t *Torrent) Seeding() bool {
 	return t.seeding()
 }
 
-// Clobbers the torrent display name. The display name is used as the torrent
-// name if the metainfo is not available.
+// Clobbers the torrent display name if metainfo is unavailable.
+// The display name is used as the torrent name while the metainfo is unavailable.
 func (t *Torrent) SetDisplayName(dn string) {
 	t.nameMu.Lock()
-	defer t.nameMu.Unlock()
-	if t.haveInfo() {
-		return
+	if !t.haveInfo() {
+		t.displayName = dn
 	}
-	t.displayName = dn
+	t.nameMu.Unlock()
 }
 
 // The current working name for the torrent. Either the name in the info dict,


### PR DESCRIPTION
Changed doc to note that `SetDisplayName()` doesn't clobber `.displayName` if metainfo is available. Should this function be changed so that it always clobbers?