### PR TITLE
Inlineable `(*Torrent).BytesMissing()`

### DIFF
--- a/torrent.go
+++ b/torrent.go
@@ -734,10 +734,12 @@ func (t *Torrent) newMetaInfo() metainfo.MetaInfo {
 	}
 }
 
-func (t *Torrent) BytesMissing() int64 {
+// Get bytes left
+func (t *Torrent) BytesMissing() (n int64) {
 	t.cl.rLock()
-	defer t.cl.rUnlock()
-	return t.bytesMissingLocked()
+	n = t.bytesMissingLocked()
+	t.cl.rUnlock()
+	return
 }
 
 func (t *Torrent) bytesMissingLocked() int64 {


### PR DESCRIPTION
Honestly a name like `BytesLeft` would have been more suitable, but it's too late for that I guess.