### PR TITLE
Change `trackerScraper.lastAnnounce` to `atomic.Value`

### DIFF
--- a/tracker_scraper.go
+++ b/tracker_scraper.go
@@ -1,12 +1,16 @@
 package torrent
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"math"
 	"net"
 	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/anacrolix/dht/v2/krpc"

--- a/tracker_scraper.go
+++ b/tracker_scraper.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"net"
 	"net/url"
 	"strconv"


### PR DESCRIPTION
Temporary stand-in until we get something better (hopefully when generics come around).

Also fixed `(trackerScraper).URL()` to use a pointer receiver instead; don't know if original copying was intended (as it wasn't documented).