### PR TITLE
Remove reflection dependency in `ConnStats.Copy()`

### DIFF
--- a/conn_stats.go
+++ b/conn_stats.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"reflect"
 	"sync/atomic"
 
 	pp "github.com/anacrolix/torrent/peer_protocol"
@@ -41,11 +40,21 @@ type ConnStats struct {
 }
 
 func (me *ConnStats) Copy() (ret ConnStats) {
-	for i := 0; i < reflect.TypeOf(ConnStats{}).NumField(); i++ {
-		n := reflect.ValueOf(me).Elem().Field(i).Addr().Interface().(*Count).Int64()
-		reflect.ValueOf(&ret).Elem().Field(i).Addr().Interface().(*Count).Add(n)
+	return ConnStats{
+		Count{atomic.LoadInt64(&me.BytesWritten.n)},
+		Count{atomic.LoadInt64(&me.BytesWrittenData.n)},
+		Count{atomic.LoadInt64(&me.BytesRead.n)},
+		Count{atomic.LoadInt64(&me.BytesReadData.n)},
+		Count{atomic.LoadInt64(&me.BytesReadUsefulData.n)},
+		Count{atomic.LoadInt64(&me.BytesReadUsefulIntendedData.n)},
+		Count{atomic.LoadInt64(&me.ChunksWritten.n)},
+		Count{atomic.LoadInt64(&me.ChunksRead.n)},
+		Count{atomic.LoadInt64(&me.ChunksReadUseful.n)},
+		Count{atomic.LoadInt64(&me.ChunksReadWasted.n)},
+		Count{atomic.LoadInt64(&me.MetadataChunksRead.n)},
+		Count{atomic.LoadInt64(&me.PiecesDirtiedGood.n)},
+		Count{atomic.LoadInt64(&me.PiecesDirtiedBad.n)},
 	}
-	return
 }
 
 type Count struct {


### PR DESCRIPTION
Sucks that reflection has so much overhead. Hygienic macros would definitely have helped here. Note I didn't use keys for the struct initialization -- this is to ensure that you don't forget to add any future added members to `ConnStats`

---
[Godbolt](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DBUpJfWQE8Ayo3QBhVLQCuLBnrsAZPA0wA5VwAjTGIQADYATlIAB1QFQmsGRxc3PVj4qwFvXwCWYNDIs0wLTIYhAiZiAmTXdy4iksTyyoJs/yCQ8KiFCqqa1Pqelrbc/K6ASjNUZ2Jkdg5opmQAayZgTABqImJiRgIAUg0AQUOjvBZYqo2IU8OI/YAmB92qEseH2417p4UATwZkAB6JhEFh4ZDvU7jT5HQGAjYANUq1mcCg2aAYvksiQAtPQAG7FDZsAjEcEKAB0GyOBC2CE2ABUSLtBBsCUSCPSlBtKps1sBdsAQZhKRt7AhnAxlmjecSRQo1iLTnCNgB3QgIDboEFMDaLX60VBMdCigAiOo2eBllmcYi2zL26NkjvVnOmtMMvw2qEJxHpxqpikwVGctEtaIUqBJCB8wDVmGV8N8mCw6DZqFEtFov0DDFVhgIKfDG0j0dj8a1eHQDDAHA9CmWG34xGugWctJYTC9PToYeCG1RwdD4ypAHUyQRCwxw4m6bGI46iHTNtFMCFSDyGGmAEqYY3FnrOKhUDa7OZ4QlpqjEKPLlhU03OTZLzmbc7RehsQQgxLeqizxxJQIDcWFRWl%2BzEPBgF8NMBBLKMVwMAhmxYBQQA2IQ1w2BBJ2iNC4WADVnECCk0BYYFmGQG9aDwVRAW2FkCEBK0FCfBRAQeMIHgpU4CF%2BVcxQEMoKgICNSWcSwNn2AB2AAhT4IhVJkKj7X5CzRODXzVPBdipABJAEXCwNEEEME1TOWEVNzTRgqP40oeOOO5ZLUkVx0IKcNi8rzAMEBSXPU9zJ0Yc0KkEoCYWc1yFF3fdvPihLEt8g4nK%2BAKRVi9BQt1RLcvCvzUoidKYr3dAgxDWhsry/KUpONLosy8rQwMqdUyq5LIq%2BcVJWlILPI61K6oibqpRKuKEoGoaRulRqlAqmqFOmsb0FHJgeiLSaFIAWUwCptQqJbMoWwa7hVUYQj/PU8EwOY0X23V8zRVUJ08ogN05EES2IpQAEcn0EbM9TWpQ019PAaFEByFOUa7btNHSrBTABxVAMGOoazo6FtUBPaJYas%2B61TWtUXsYe13tM2lWMCX7/oIQGqCYOgizBiGfwEKk/FQQs6U%2BpgFJVDEsVKYkuw2BhuewphCQ2YIya0yN6ErKpruxk9dTxm7MEcoaYa1hR4ZVlNZP3TbpNNGEQwBa42A2AAqRxMWaUTxkE6JfggV2IF2WlHeEkEFFdmT5MK5tLQ2EB9gAZlNDYNGj2Tw%2Bj%2BxT2DEoKQZfjMAAeSoCA/edhRg5k00R1yAAxa7aHQT2E8tR55IeRPi8Ku5p0jmPU9eG6CApJEXBzvO2BHbBP09ilK%2BKGu8BHI50HQYhx5akJGbmceIAd6ZBBHFqwkkWvW6%2BF50/7p9c5uTifZHseR0n6uIBnik54XpfBBXpZMHXzegNn%2BeIAYaErdzYKQUj7GYDBbjAMGlbZANtNibydiJQObtfgPE9tcH2glEEByDnJUBu1wFYP9qJFuQ07gdTkiCKM4IKSeCNOgXe%2B9HhhDYBSYqfVGAUgASXUgICupbwOJQ0ENC6HGkYRfFh2t2GkwYNlLh0Jza8MPsNARwcqFgmQLQ%2Bh4jmGsOKpleRPC%2BEqIikI6hmjREMMEHvCReiGqlTkdwxRxiKEm2ERY7R1imGcTsepWaQ5Ko6kMc45Rrj1EiM8QQGxuipH2ONE1Wgy8twpkcQo00SiyH8NMW48xWixFeNsdrJaHCGDBPSS41RZiNF5KsVE7xkiKSHVKmUjJdxyGVJydUyxOifFFIlKNfxFUWkVOyeEjx%2BS6mFMaf0mapVVrrXQMM0JHSxk1J6Q0nae0dRNIDE48pyzRnuLWQUmJFI9ZwwRtddAKMMBLMySYvyVSIkTOib0s5%2BMDaXONrstJrSvgl0gRbE6xw%2BICWSiWcSklSFt0tF4wFltJSwIgLbb%2B29qR/2nD4OpuCQ5DVWc/dZrCGAbm4U5KBdUjgwLgfbZKrtxGuyxXvKSeDCpgOINOVZ3STlvNJScc2HBJi0E4AAVl4O4DgWhSCoE4CjeCMw5hSQeFHHgpACCaAFZMZYIAo5RwpDq/VBrDVhH0JwSQYr1VSs4LwNCGhVXqsmHAWASAyJ43oGQCgEAXXM1CMAWgXAuDSVtTQWghZiBoQgIEC1gQfCVF%2BJwFVZEvwEGzgwbMFqsCdiMOICVvB8BnisISNCObSCYFUDdds8wVVYuKBamigRiCxscFgC1pJzjxoFXwAwwAFAImuqqbOq5xUqv4IIEQYh2BSBkIIIMagLW6HqAYIwIATD6DwDTeAkxUDRFKEWnELBo6mgeNa4oPdEi2C3P0OoJatwjCxmkOICQBCXvvRkRIt68idEGCe7EAhmh9CcLUPQ5hT2/t6K0Hw7QP2hEGGB59MHhgQfOtByYkZ5UTtVbsStHahUcFFaQcVkrpUcFYOgJlwBYFcApAG64KMNy4EICQRVyqNyOAuN6pjXBxi8DVTm8YmrtW6sNUJ/VxqcNmvwxaoj1qQC2p41oB1MBEAgHdNEds5BKBerdR4fA2w9AjuEJmCd0h9MzvUMW0ka522kGekwaI7bBUivNcWoj2d2yqdpDjHkLBSOSA2ORjYlHqP5yjK6i6jxlVcbtbx/jOq9XCaEyajg4mCO8Ck2YGTUX5MOY4EeiTzmrWZY1aQX08QbCSCAA%3D%3D). Note original function cost of 759 and new version cost is 119. Still not inlineable but it compiles to a lot less code.