### PR TITLE
Optimize (*Torrent).peersAsSlice()

### DIFF
--- a/torrent.go
+++ b/torrent.go
@@ -2062,9 +2062,16 @@ func (t *Torrent) clearPieceTouchers(pi pieceIndex) {
 }
 
 func (t *Torrent) peersAsSlice() (ret []*Peer) {
-	t.iterPeers(func(p *Peer) {
-		ret = append(ret, p)
-	})
+	ret = make([]*Peer, len(t.conns)+len(t.webSeeds))
+	i := 0
+	for pc := range t.conns {
+		ret[i] = &pc.Peer
+		i++
+	}
+	for _, ws := range t.webSeeds {
+		ret[i] = ws
+		i++
+	}
 	return
 }
 


### PR DESCRIPTION
Probably a controversial change; not expecting it to go in. But it does perform much better nonetheless -- it's just not used enough to be noticeable. I'm okay with leaving it out mainly because I don't use `writeStatus()` at the moment lol.