### PR TITLE
Move `AnnounceEvent` to tracker/shared

### DIFF
--- a/tracker/http/http.go
+++ b/tracker/http/http.go
@@ -42,7 +42,7 @@ func setAnnounceParams(_url *url.URL, ar *AnnounceRequest, opts AnnounceOpt) {
 	}
 	q.Set("left", strconv.FormatInt(left, 10))
 
-	if ar.Event != shared.None {
+	if ar.Event != shared.AnnounceEventNone {
 		q.Set("event", ar.Event.String())
 	}
 	// http://stackoverflow.com/questions/17418004/why-does-tracker-server-not-understand-my-request-bittorrent-protocol

--- a/tracker/shared/announceevent_string.go
+++ b/tracker/shared/announceevent_string.go
@@ -1,0 +1,23 @@
+// Code generated (partially) by "stringer -type=AnnounceEvent -trimprefix=AnnounceEvent -linecomment"; DO NOT EDIT.
+
+package shared
+
+const (
+	// "constant overflows uint" compiler error indicates constant values have changed.
+	// Re-run stringer to generate them again.
+	_ = -uint(AnnounceEventNone-0)
+	_ = -uint(AnnouncedEventCompleted-1)
+	_ = -uint(AnnounceEventStarted-2)
+	_ = -uint(AnnounceEventStopped-3)
+)
+
+const _AnnounceEvent_name = "completedstartedstopped"
+
+var _AnnounceEvent_index = [...]uint8{0, 0, 9, 16, 23}
+
+func (i AnnounceEvent) String() string {
+	if i < 0 || i >= AnnounceEvent(len(_AnnounceEvent_index)-1) {
+		panic("")
+	}
+	return _AnnounceEvent_name[_AnnounceEvent_index[i]:_AnnounceEvent_index[i+1]]
+}

--- a/tracker/shared/shared.go
+++ b/tracker/shared/shared.go
@@ -2,16 +2,18 @@ package shared
 
 type AnnounceEvent int32
 
-const (
-	AnnounceEventNone AnnounceEvent = iota      //
-	
-	// Local peer just completed the torrent.
-	AnnouncedEventCompleted                     // completed
-	// local peer has just resumed this torrent.
-	AnnounceEventStarted                        // started
-	// Local peer is leaving the swarm.
-	AnnounceEventStopped                        // stopped
-)
-
 // TODO: Incorporate use of stringer for AnnounceEvent:
 // go:generate stringer -type=AnnounceEvent -trimprefix=AnnounceEvent -linecomment
+
+// NOTE: the trailing comments are the strings used in generating the `String()` method.
+// See BEP 3, "event", and https://github.com/anacrolix/torrent/issues/416#issuecomment-751427001.
+const (
+	// Default event, equivalent to unspecified
+	AnnounceEventNone AnnounceEvent = iota //
+	// Local peer just completed the torrent.
+	AnnouncedEventCompleted // completed
+	// local peer has just resumed this torrent.
+	AnnounceEventStarted    // started
+	// Local peer is leaving the swarm.
+	AnnounceEventStopped    // stopped
+)

--- a/tracker/shared/shared.go
+++ b/tracker/shared/shared.go
@@ -1,10 +1,17 @@
 package shared
 
-import "github.com/anacrolix/torrent/tracker/udp"
+type AnnounceEvent int32
 
 const (
-	None      udp.AnnounceEvent = iota
-	Completed                   // The local peer just completed the torrent.
-	Started                     // The local peer has just resumed this torrent.
-	Stopped                     // The local peer is leaving the swarm.
+	AnnounceEventNone AnnounceEvent = iota      //
+	
+	// Local peer just completed the torrent.
+	AnnouncedEventCompleted                     // completed
+	// local peer has just resumed this torrent.
+	AnnounceEventStarted                        // started
+	// Local peer is leaving the swarm.
+	AnnounceEventStopped                        // stopped
 )
+
+// TODO: Incorporate use of stringer for AnnounceEvent:
+// go:generate stringer -type=AnnounceEvent -trimprefix=AnnounceEvent -linecomment

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -14,19 +14,18 @@ import (
 )
 
 const (
-	None      = shared.None
-	Started   = shared.Started
-	Stopped   = shared.Stopped
-	Completed = shared.Completed
+	None      = shared.AnnounceEventNone
+	Started   = shared.AnnounceEventStarted
+	Stopped   = shared.AnnounceEventStopped
+	Completed = shared.AnnouncedEventCompleted
 )
 
-type AnnounceRequest = udp.AnnounceRequest
-
-type AnnounceResponse = trHttp.AnnounceResponse
-
-type Peer = trHttp.Peer
-
-type AnnounceEvent = udp.AnnounceEvent
+type (
+	AnnounceRequest  = udp.AnnounceRequest
+	AnnounceResponse = trHttp.AnnounceResponse
+	Peer             = trHttp.Peer
+	AnnounceEvent    = shared.AnnounceEvent
+)
 
 var (
 	ErrBadScheme = errors.New("unknown scheme")

--- a/tracker/udp/announce.go
+++ b/tracker/udp/announce.go
@@ -4,30 +4,25 @@ import (
 	"encoding"
 
 	"github.com/anacrolix/dht/v2/krpc"
+	"github.com/anacrolix/torrent/tracker/shared"
 )
 
 // Marshalled as binary by the UDP client, so be careful making changes.
+// See https://www.libtorrent.org/udp_tracker_protocol.html
 type AnnounceRequest struct {
 	InfoHash   [20]byte
 	PeerId     [20]byte
 	Downloaded int64
 	Left       int64 // If less than 0, math.MaxInt64 will be used for HTTP trackers instead.
 	Uploaded   int64
-	// Apparently this is optional. None can be used for announces done at
+	// Apparently this is optional. AnnounceEventNone can be used for announces done at
 	// regular intervals.
-	Event     AnnounceEvent
+	Event     shared.AnnounceEvent
 	IPAddress uint32
 	Key       int32
 	NumWant   int32 // How many peer addresses are desired. -1 for default.
 	Port      uint16
-} // 82 bytes
-
-type AnnounceEvent int32
-
-func (e AnnounceEvent) String() string {
-	// See BEP 3, "event", and https://github.com/anacrolix/torrent/issues/416#issuecomment-751427001.
-	return []string{"", "completed", "started", "stopped"}[e]
-}
+} // 82 bytes + 6 bytes padding
 
 type AnnounceResponsePeers interface {
 	encoding.BinaryUnmarshaler


### PR DESCRIPTION
Changing this will probably help to eliminate the confusing type aliases and cleanup imports a bit. I don't think `AnnounceEvent` is best suited to be in tracker/udp.

I used golang.org/x/tools/cmd/stringer to generate the `String()` method, which is why it looks weird.