### PR TITLE
bencode: get type of `big.Int` without creating instance

### DIFF
--- a/bencode/encode.go
+++ b/bencode/encode.go
@@ -96,7 +96,7 @@ func (e *Encoder) reflectMarshaler(v reflect.Value) bool {
 	return true
 }
 
-var bigIntType = reflect.TypeOf(big.Int{})
+var bigIntType = reflect.TypeOf((*big.Int)(nil)).Elem()
 
 func (e *Encoder) reflectValue(v reflect.Value) {
 


### PR DESCRIPTION
Nope, it doesn't really matter. But anyway, see https://github.com/golang/crypto/blob/c084706c2272f3d44b722e988e70d4a58e60e7f4/cryptobyte/asn1.go#L267