### PR TITLE
bencode: use `*scanner` instead of `interface{...}`

### DIFF
--- a/bencode/decode.go
+++ b/bencode/decode.go
@@ -13,10 +13,7 @@ import (
 )
 
 type Decoder struct {
-	r interface {
-		io.ByteScanner
-		io.Reader
-	}
+	r *scanner
 	// Sum of bytes used to Decode values.
 	Offset int64
 	buf    bytes.Buffer


### PR DESCRIPTION
Since `r` is a private field, and `NewDecoder` constructs with a `&scanner{...}` anyway, we might as well just use a pointer and save 8 bytes of space. Better yet -- change `*scanner` to `scanner` instead . I would make this change (but it would require my last couple PRs to go in first).

EDIT: Nope, never mind. I'm wrong about this. Closing.