### PR TITLE
Optimize `parseNetworkString()`

### DIFF
--- a/networks.go
+++ b/networks.go
@@ -29,15 +29,22 @@ func (n network) String() (ret string) {
 	return
 }
 
-func parseNetworkString(network string) (ret network) {
-	c := func(s string) bool {
-		return strings.Contains(network, s)
+func parseNetworkString(netw string) (ret network) {
+	switch netw {
+	case "udp4":
+		return network{Udp: true, Ipv4: true}
+	case "udp6":
+		return network{Udp: true, Ipv6: true}
+	case "tcp4":
+		return network{Tcp: true, Ipv4: true}
+	case "tcp6":
+		return network{Tcp: true, Ipv6: true}
+	case "udp":
+		return network{Udp: true}
+	case "tcp":
+		return network{Tcp: true}
 	}
-	ret.Ipv4 = c("4")
-	ret.Ipv6 = c("6")
-	ret.Udp = c("udp")
-	ret.Tcp = c("tcp")
-	return
+	panic("")
 }
 
 func peerNetworkEnabled(n network, cfg *ClientConfig) bool {

--- a/networks.go
+++ b/networks.go
@@ -1,7 +1,5 @@
 package torrent
 
-import "strings"
-
 var allPeerNetworks = func() (ret []network) {
 	for _, s := range []string{"tcp4", "tcp6", "udp4", "udp6"} {
 		ret = append(ret, parseNetworkString(s))


### PR DESCRIPTION
Eliminate function call to `strings.Index` and possible unwanted cases.