### PR TITLE
Add metadata field to metainfo

### DIFF
--- a/metainfo/metadata.go
+++ b/metainfo/metadata.go
@@ -1,0 +1,8 @@
+package metainfo
+
+type Metadata struct {
+	CoverUrl    string   `bencode:"cover url,omitempty"`
+	Description string   `bencode:"description,omitempty"`
+	TagList     []string `bencode:"taglist,omitempty"`
+	Title       string   `bencode:"title,omitempty"`
+}

--- a/metainfo/metainfo.go
+++ b/metainfo/metainfo.go
@@ -17,11 +17,12 @@ type MetaInfo struct {
 	// Where's this specified? Mentioned at
 	// https://wiki.theory.org/index.php/BitTorrentSpecification: (optional) the creation time of
 	// the torrent, in standard UNIX epoch format (integer, seconds since 1-Jan-1970 00:00:00 UTC)
-	CreationDate int64   `bencode:"creation date,omitempty,ignore_unmarshal_type_error"`
-	Comment      string  `bencode:"comment,omitempty"`
-	CreatedBy    string  `bencode:"created by,omitempty"`
-	Encoding     string  `bencode:"encoding,omitempty"`
-	UrlList      UrlList `bencode:"url-list,omitempty"` // BEP 19
+	CreationDate int64    `bencode:"creation date,omitempty,ignore_unmarshal_type_error"`
+	Comment      string   `bencode:"comment,omitempty"`
+	CreatedBy    string   `bencode:"created by,omitempty"`
+	Encoding     string   `bencode:"encoding,omitempty"`
+	UrlList      UrlList  `bencode:"url-list,omitempty"` // BEP 19
+	Metadata     Metadata `bencode:"metadata,omitempty"` // Filed used by some private trackers to store additional metadata
 }
 
 // Load a MetaInfo from an io.Reader. Returns a non-nil error in case of


### PR DESCRIPTION
This pull request adds support for the "metadata" filed in the torrent's metainfo.

This field is not officially into any BEP, but it is commonly used by some private trackers to store additional information.