### PR TITLE
Add `DisableInitialPieceCheck` option

### DIFF
--- a/client.go
+++ b/client.go
@@ -1195,6 +1195,7 @@ func (t *Torrent) MergeSpec(spec *TorrentSpec) error {
 	if spec.DisplayName != "" {
 		t.SetDisplayName(spec.DisplayName)
 	}
+	t.initialPieceCheckDisabled = spec.DisableInitialPieceCheck
 	if spec.InfoBytes != nil {
 		err := t.SetInfoBytes(spec.InfoBytes)
 		if err != nil {

--- a/spec.go
+++ b/spec.go
@@ -23,8 +23,9 @@ type TorrentSpec struct {
 	Sources []string
 
 	// The chunk size to use for outbound requests. Defaults to 16KiB if not set.
-	ChunkSize int
-	Storage   storage.ClientImpl
+	ChunkSize                int
+	DisableInitialPieceCheck bool
+	Storage                  storage.ClientImpl
 
 	// Whether to allow data download or upload
 	DisallowDataUpload   bool

--- a/torrent.go
+++ b/torrent.go
@@ -135,8 +135,9 @@ type Torrent struct {
 	// A cache of completed piece indices.
 	_completedPieces roaring.Bitmap
 	// Pieces that need to be hashed.
-	piecesQueuedForHash bitmap.Bitmap
-	activePieceHashes   int
+	piecesQueuedForHash       bitmap.Bitmap
+	activePieceHashes         int
+	initialPieceCheckDisabled bool
 
 	// A pool of piece priorities []int for assignment to new connections.
 	// These "inclinations" are used to give connections preference for
@@ -439,7 +440,7 @@ func (t *Torrent) onSetInfo() {
 		}
 		p.availability = int64(t.pieceAvailabilityFromPeers(i))
 		t.updatePieceCompletion(pieceIndex(i))
-		if !p.storageCompletionOk {
+		if !t.initialPieceCheckDisabled && !p.storageCompletionOk {
 			// t.logger.Printf("piece %s completion unknown, queueing check", p)
 			t.queuePieceCheck(pieceIndex(i))
 		}


### PR DESCRIPTION
This greatly reduces the startup time of large torrents, during which a bunch of zero pieces get hashed.

For a huge media torrent that requires a seek to the end for playback, this removes ~3 minutes of waiting for me.﻿
