### PR TITLE
[trackerscraper] Add custom DNS lookup function

### DIFF
--- a/bencode/fuzz_test.go
+++ b/bencode/fuzz_test.go
@@ -1,4 +1,5 @@
 //go:build go1.18
+// +build go1.18
 
 package bencode
 

--- a/client-nowasm_test.go
+++ b/client-nowasm_test.go
@@ -1,4 +1,5 @@
 //go:build !wasm
+// +build !wasm
 
 package torrent
 

--- a/config.go
+++ b/config.go
@@ -90,6 +90,9 @@ type ClientConfig struct {
 	// Defines proxy for HTTP requests, such as for trackers. It's commonly set from the result of
 	// "net/http".ProxyURL(HTTPProxy).
 	HTTPProxy func(*http.Request) (*url.URL, error)
+	// Takes a tracker's hostname and requests DNS A and AAAA records.
+	// Used in case DNS lookups require a special setup (i.e., dns-over-https)
+	TrackerIpFetcher func(*url.URL) ([]net.IP, error)
 	// HTTPUserAgent changes default UserAgent for HTTP requests
 	HTTPUserAgent string
 	// Updated occasionally to when there's been some changes to client

--- a/config.go
+++ b/config.go
@@ -92,7 +92,7 @@ type ClientConfig struct {
 	HTTPProxy func(*http.Request) (*url.URL, error)
 	// Takes a tracker's hostname and requests DNS A and AAAA records.
 	// Used in case DNS lookups require a special setup (i.e., dns-over-https)
-	TrackerIpFetcher func(*url.URL) ([]net.IP, error)
+	LookupTrackerIp func(*url.URL) ([]net.IP, error)
 	// HTTPUserAgent changes default UserAgent for HTTP requests
 	HTTPUserAgent string
 	// Updated occasionally to when there's been some changes to client

--- a/iplist/packed.go
+++ b/iplist/packed.go
@@ -1,4 +1,5 @@
 //go:build !wasm
+// +build !wasm
 
 package iplist
 

--- a/issue211_test.go
+++ b/issue211_test.go
@@ -1,4 +1,5 @@
 //go:build !wasm
+// +build !wasm
 
 package torrent
 

--- a/metainfo/fuzz_test.go
+++ b/metainfo/fuzz_test.go
@@ -1,4 +1,5 @@
 //go:build go1.18
+// +build go1.18
 
 package metainfo
 

--- a/peer_protocol/fuzz_test.go
+++ b/peer_protocol/fuzz_test.go
@@ -1,4 +1,5 @@
 //go:build go1.18
+// +build go1.18
 
 package peer_protocol
 

--- a/storage/bolt-piece-completion.go
+++ b/storage/bolt-piece-completion.go
@@ -1,4 +1,5 @@
 //go:build !noboltdb && !wasm
+// +build !noboltdb,!wasm
 
 package storage
 

--- a/storage/bolt-piece.go
+++ b/storage/bolt-piece.go
@@ -1,4 +1,5 @@
 //go:build !noboltdb && !wasm
+// +build !noboltdb,!wasm
 
 package storage
 

--- a/storage/bolt.go
+++ b/storage/bolt.go
@@ -1,4 +1,5 @@
 //go:build !noboltdb && !wasm
+// +build !noboltdb,!wasm
 
 package storage
 

--- a/storage/default-dir-piece-completion-sqlite.go
+++ b/storage/default-dir-piece-completion-sqlite.go
@@ -1,4 +1,5 @@
 //go:build cgo && !nosqlite
+// +build cgo,!nosqlite
 
 package storage
 

--- a/storage/mmap.go
+++ b/storage/mmap.go
@@ -1,4 +1,5 @@
 //go:build !wasm
+// +build !wasm
 
 package storage
 

--- a/storage/sqlite-piece-completion.go
+++ b/storage/sqlite-piece-completion.go
@@ -1,4 +1,5 @@
 //go:build cgo && !nosqlite
+// +build cgo,!nosqlite
 
 package storage
 

--- a/storage/sqlite/direct.go
+++ b/storage/sqlite/direct.go
@@ -1,4 +1,5 @@
 //go:build cgo
+// +build cgo
 
 package sqliteStorage
 

--- a/storage/sqlite/sqlite-storage_test.go
+++ b/storage/sqlite/sqlite-storage_test.go
@@ -1,4 +1,5 @@
 //go:build cgo
+// +build cgo
 
 package sqliteStorage
 

--- a/torrent.go
+++ b/torrent.go
@@ -1577,9 +1577,9 @@ func (t *Torrent) startScrapingTracker(_url string) {
 			}
 		}
 		newAnnouncer := &trackerScraper{
-			u:         *u,
-			t:         t,
-			ipFetcher: t.cl.config.TrackerIpFetcher,
+			u:               *u,
+			t:               t,
+			lookupTrackerIp: t.cl.config.LookupTrackerIp,
 		}
 		go newAnnouncer.Run()
 		return newAnnouncer

--- a/torrent.go
+++ b/torrent.go
@@ -1577,8 +1577,9 @@ func (t *Torrent) startScrapingTracker(_url string) {
 			}
 		}
 		newAnnouncer := &trackerScraper{
-			u: *u,
-			t: t,
+			u:         *u,
+			t:         t,
+			ipFetcher: t.cl.config.TrackerIpFetcher,
 		}
 		go newAnnouncer.Run()
 		return newAnnouncer

--- a/torrent_mmap_test.go
+++ b/torrent_mmap_test.go
@@ -1,4 +1,5 @@
 //go:build !wasm
+// +build !wasm
 
 package torrent
 

--- a/tracker_scraper.go
+++ b/tracker_scraper.go
@@ -21,6 +21,7 @@ type trackerScraper struct {
 	u            url.URL
 	t            *Torrent
 	lastAnnounce trackerAnnounceResult
+	ipFetcher    func(*url.URL) ([]net.IP, error)
 }
 
 type torrentTrackerAnnouncer interface {
@@ -66,7 +67,13 @@ type trackerAnnounceResult struct {
 }
 
 func (me *trackerScraper) getIp() (ip net.IP, err error) {
-	ips, err := net.LookupIP(me.u.Hostname())
+	var ips []net.IP
+	if me.ipFetcher != nil {
+		ips, err = me.ipFetcher(&me.u)
+	} else {
+		// Do a regular dns lookup
+		ips, err = net.LookupIP(me.u.Hostname())
+	}
 	if err != nil {
 		return
 	}

--- a/tracker_scraper.go
+++ b/tracker_scraper.go
@@ -18,10 +18,10 @@ import (
 // Announces a torrent to a tracker at regular intervals, when peers are
 // required.
 type trackerScraper struct {
-	u            url.URL
-	t            *Torrent
-	lastAnnounce trackerAnnounceResult
-	ipFetcher    func(*url.URL) ([]net.IP, error)
+	u               url.URL
+	t               *Torrent
+	lastAnnounce    trackerAnnounceResult
+	lookupTrackerIp func(*url.URL) ([]net.IP, error)
 }
 
 type torrentTrackerAnnouncer interface {
@@ -68,8 +68,8 @@ type trackerAnnounceResult struct {
 
 func (me *trackerScraper) getIp() (ip net.IP, err error) {
 	var ips []net.IP
-	if me.ipFetcher != nil {
-		ips, err = me.ipFetcher(&me.u)
+	if me.lookupTrackerIp != nil {
+		ips, err = me.lookupTrackerIp(&me.u)
 	} else {
 		// Do a regular dns lookup
 		ips, err = net.LookupIP(me.u.Hostname())

--- a/utp_libutp.go
+++ b/utp_libutp.go
@@ -1,9 +1,10 @@
 //go:build cgo && !disable_libutp
+// +build cgo,!disable_libutp
 
 package torrent
 
 import (
-	utp "github.com/anacrolix/go-libutp"
+	"github.com/anacrolix/go-libutp"
 )
 
 func NewUtpSocket(network, addr string, fc firewallCallback) (utpSocket, error) {


### PR DESCRIPTION
Allows tracker_scraper to have a custom function to do DNS lookups. This allows things like dns-over-https.

I also reverted `// +build` build tags along with every `// go:build` line to support Go 1.16.
- for Go 1.17, it can handle both
- for Go 1.16, it **must** have both, else you'll get an error while building:

      peer-store.go:5:2: //go:build comment without // +build comment

  - You can repro this by downgrading Go to 1.16 and just running `go build ./...` on anacrolix/torrent's [current master](https://github.com/afjoseph/torrent/commit/8b368b3832ca87f19c703ab48ba355e625190b2b) without the changes in this PR
  - For my use case, I can't update to Go 1.17 yet since [some projects](https://issueexplorer.com/issue/filecoin-project/lily/679) downright panic when upgrading

@anacrolix lemme know if you want a test for this. Many thanks for the great project :heart: