### PR TITLE
PEX: fluid event log

### DIFF
--- a/peerconn.go
+++ b/peerconn.go
@@ -1634,7 +1634,7 @@ func (c *PeerConn) dialAddr() PeerRemoteAddr {
 func (c *PeerConn) pexEvent(t pexEventType) pexEvent {
 	f := c.pexPeerFlags()
 	addr := c.dialAddr()
-	return pexEvent{t, addr, f}
+	return pexEvent{t, addr, f, nil}
 }
 
 func (c *PeerConn) String() string {

--- a/peerconn_test.go
+++ b/peerconn_test.go
@@ -189,22 +189,22 @@ func TestConnPexEvent(t *testing.T) {
 		{
 			pexAdd,
 			&PeerConn{Peer: Peer{RemoteAddr: udpAddr, Network: udpAddr.Network()}},
-			pexEvent{pexAdd, udpAddr, pp.PexSupportsUtp},
+			pexEvent{pexAdd, udpAddr, pp.PexSupportsUtp, nil},
 		},
 		{
 			pexDrop,
 			&PeerConn{Peer: Peer{RemoteAddr: tcpAddr, Network: tcpAddr.Network(), outgoing: true, PeerListenPort: dialTcpAddr.Port}},
-			pexEvent{pexDrop, tcpAddr, pp.PexOutgoingConn},
+			pexEvent{pexDrop, tcpAddr, pp.PexOutgoingConn, nil},
 		},
 		{
 			pexAdd,
 			&PeerConn{Peer: Peer{RemoteAddr: tcpAddr, Network: tcpAddr.Network(), PeerListenPort: dialTcpAddr.Port}},
-			pexEvent{pexAdd, dialTcpAddr, 0},
+			pexEvent{pexAdd, dialTcpAddr, 0, nil},
 		},
 		{
 			pexDrop,
 			&PeerConn{Peer: Peer{RemoteAddr: udpAddr, Network: udpAddr.Network(), PeerListenPort: dialUdpAddr.Port}},
-			pexEvent{pexDrop, dialUdpAddr, pp.PexSupportsUtp},
+			pexEvent{pexDrop, dialUdpAddr, pp.PexSupportsUtp, nil},
 		},
 	}
 	for i, tc := range testcases {

--- a/pexconn.go
+++ b/pexconn.go
@@ -18,7 +18,7 @@ const (
 type pexConnState struct {
 	enabled bool
 	xid     pp.ExtensionNumber
-	seq     int
+	last    *pexEvent
 	timer   *time.Timer
 	gate    chan struct{}
 	readyfn func()
@@ -39,7 +39,7 @@ func (s *pexConnState) Init(c *PeerConn) {
 		return
 	}
 	s.xid = xid
-	s.seq = 0
+	s.last = nil
 	s.torrent = c.t
 	s.info = c.t.cl.logger.WithDefaultLevel(log.Info)
 	s.dbg = c.logger.WithDefaultLevel(log.Debug)
@@ -59,11 +59,11 @@ func (s *pexConnState) sched(delay time.Duration) {
 
 // generate next PEX message for the peer; returns nil if nothing yet to send
 func (s *pexConnState) genmsg() *pp.PexMsg {
-	tx, seq := s.torrent.pex.Genmsg(s.seq)
+	tx, last := s.torrent.pex.Genmsg(s.last)
 	if tx.Len() == 0 {
 		return nil
 	}
-	s.seq = seq
+	s.last = last
 	return &tx
 }
 


### PR DESCRIPTION
As discussed under #691 this implements the "_linked list_" approach:

> 2. replace t.ev slice with a linked list and track the "seen" events using pointers, relying on GC to reclaim the memory.

This is a complete implementation. Integration testing conducted in a docker-backed tracker-less swarm with 1 seeder and 50 downloaders with seeding on.

This also includes reworked the unit tests for less exposure to the internal details.

The unidirectional linked list is a bit unusual: we don't hold an explicit reference for its head, only for the tail. This means  that while the many Conn's are catching up on the events and advance their references, the preceding entries become inaccessible and, therefore, should qualify for garbage collection – that's the main idea here. This is why the list must stay unidirectional.

The benchmark (`go test -args -test.run '^$' -test.bench 'Bench.*Pex'`) shows no degradation:
* before: 
```
BenchmarkPexInitial4-8     	  290005	      4132 ns/op
BenchmarkPexInitial50-8    	   28602	     42608 ns/op
BenchmarkPexInitial100-8   	   14047	     84679 ns/op
BenchmarkPexInitial200-8   	    7135	    169237 ns/op
BenchmarkPexInitial400-8   	    3483	    339552 ns/op
```
* after:
```
BenchmarkPexInitial4-8     	  274759	      3990 ns/op
BenchmarkPexInitial50-8    	   29487	     40738 ns/op
BenchmarkPexInitial100-8   	   14570	     82505 ns/op
BenchmarkPexInitial200-8   	    7255	    166633 ns/op
BenchmarkPexInitial400-8   	    3615	    334424 ns/op
```

Long term effects on memory utilisation are yet to be observed – @anacrolix, mind running this with your workloads, please?

Hint for reviewers: first review with `*_tests.go` folded in UI.

This is an alternative to #692.

Fixes #691.
