### PR TITLE
PEX: use new NodeAddr search methods in krpc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/anacrolix/args v0.4.1-0.20211104085705-59f0fe94eb8f
 	github.com/anacrolix/chansync v0.3.0
 	github.com/anacrolix/confluence v1.9.0 // indirect
-	github.com/anacrolix/dht/v2 v2.13.0
+	github.com/anacrolix/dht/v2 v2.13.1-0.20211209181115-6ae2bd446b12
 	github.com/anacrolix/envpprof v1.1.1
 	github.com/anacrolix/fuse v0.2.0
 	github.com/anacrolix/go-libutp v1.0.5-0.20211117031120-2dac1c67ecc5

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/anacrolix/dht/v2 v2.10.5-0.20210902001729-06cc4fe90e53/go.mod h1:zHji
 github.com/anacrolix/dht/v2 v2.10.6-0.20211007004332-99263ec9c1c8/go.mod h1:WID4DexLrucfnwzv1OV8REzgoCpyVDwEczxIOrUeFrY=
 github.com/anacrolix/dht/v2 v2.13.0 h1:nhEXbbwVL2fFEDqWJby+lSD0LEB06CW/Tgj74O5Ty9g=
 github.com/anacrolix/dht/v2 v2.13.0/go.mod h1:zJgaiAU2yhzmchZE2mY8WyZ64LK/F/D9MAeN0ct73qQ=
+github.com/anacrolix/dht/v2 v2.13.1-0.20211209181115-6ae2bd446b12 h1:W0gso1vLz1b1G9HjxsSFAWZjLZwwlPZQD20BGhwz5YU=
+github.com/anacrolix/dht/v2 v2.13.1-0.20211209181115-6ae2bd446b12/go.mod h1:zJgaiAU2yhzmchZE2mY8WyZ64LK/F/D9MAeN0ct73qQ=
 github.com/anacrolix/envpprof v0.0.0-20180404065416-323002cec2fa/go.mod h1:KgHhUaQMc8cC0+cEflSgCFNFbKwi5h54gqtVn8yhP7c=
 github.com/anacrolix/envpprof v1.0.0/go.mod h1:KgHhUaQMc8cC0+cEflSgCFNFbKwi5h54gqtVn8yhP7c=
 github.com/anacrolix/envpprof v1.0.1/go.mod h1:My7T5oSqVfEn4MD4Meczkw/f5lSIndGAKu/0SM/rkf4=

--- a/pex.go
+++ b/pex.go
@@ -50,19 +50,6 @@ func (me *pexMsgFactory) addrKey(addr PeerRemoteAddr) addrKey {
 	return addrKey(addr.String())
 }
 
-func addrEqual(a, b *krpc.NodeAddr) bool {
-	return a.IP.Equal(b.IP) && a.Port == b.Port
-}
-
-func addrIndex(v []krpc.NodeAddr, a *krpc.NodeAddr) int {
-	for i := 0; i < len(v); i += 1 {
-		if addrEqual(&v[i], a) {
-			return i
-		}
-	}
-	return -1
-}
-
 // Returns whether the entry was added (we can check if we're cancelling out another entry and so
 // won't hit the limit consuming this event).
 func (me *pexMsgFactory) add(e pexEvent) {
@@ -81,7 +68,7 @@ func (me *pexMsgFactory) add(e pexEvent) {
 	switch {
 	case addr.IP.To4() != nil:
 		if _, ok := me.dropped[key]; ok {
-			if i := addrIndex(m.Dropped.NodeAddrs(), &addr); i >= 0 {
+			if i := m.Dropped.Index(addr); i >= 0 {
 				m.Dropped = append(m.Dropped[:i], m.Dropped[i+1:]...)
 			}
 			delete(me.dropped, key)
@@ -91,7 +78,7 @@ func (me *pexMsgFactory) add(e pexEvent) {
 		m.AddedFlags = append(m.AddedFlags, e.f)
 	case len(addr.IP) == net.IPv6len:
 		if _, ok := me.dropped[key]; ok {
-			if i := addrIndex(m.Dropped6.NodeAddrs(), &addr); i >= 0 {
+			if i := m.Dropped6.Index(addr); i >= 0 {
 				m.Dropped6 = append(m.Dropped6[:i], m.Dropped6[i+1:]...)
 			}
 			delete(me.dropped, key)
@@ -123,7 +110,7 @@ func (me *pexMsgFactory) drop(e pexEvent) {
 	switch {
 	case addr.IP.To4() != nil:
 		if _, ok := me.added[key]; ok {
-			if i := addrIndex(m.Added.NodeAddrs(), &addr); i >= 0 {
+			if i := m.Added.Index(addr); i >= 0 {
 				m.Added = append(m.Added[:i], m.Added[i+1:]...)
 				m.AddedFlags = append(m.AddedFlags[:i], m.AddedFlags[i+1:]...)
 			}
@@ -133,7 +120,7 @@ func (me *pexMsgFactory) drop(e pexEvent) {
 		m.Dropped = append(m.Dropped, addr)
 	case len(addr.IP) == net.IPv6len:
 		if _, ok := me.added[key]; ok {
-			if i := addrIndex(m.Added6.NodeAddrs(), &addr); i >= 0 {
+			if i := m.Added6.Index(addr); i >= 0 {
 				m.Added6 = append(m.Added6[:i], m.Added6[i+1:]...)
 				m.Added6Flags = append(m.Added6Flags[:i], m.Added6Flags[i+1:]...)
 			}


### PR DESCRIPTION
Drop local functions used to implement search on NodeAddr lists in favour of using the methods added under anacrolix/dht#53.
