### PR TITLE
PEX: remove workaround for krpc marshaller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/anacrolix/args v0.4.1-0.20211104085705-59f0fe94eb8f
 	github.com/anacrolix/chansync v0.3.0
 	github.com/anacrolix/confluence v1.9.0 // indirect
-	github.com/anacrolix/dht/v2 v2.13.0
+	github.com/anacrolix/dht/v2 v2.13.1-0.20211209181115-6ae2bd446b12
 	github.com/anacrolix/envpprof v1.1.1
 	github.com/anacrolix/fuse v0.2.0
 	github.com/anacrolix/go-libutp v1.0.5-0.20211117031120-2dac1c67ecc5

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/anacrolix/dht/v2 v2.10.5-0.20210902001729-06cc4fe90e53/go.mod h1:zHji
 github.com/anacrolix/dht/v2 v2.10.6-0.20211007004332-99263ec9c1c8/go.mod h1:WID4DexLrucfnwzv1OV8REzgoCpyVDwEczxIOrUeFrY=
 github.com/anacrolix/dht/v2 v2.13.0 h1:nhEXbbwVL2fFEDqWJby+lSD0LEB06CW/Tgj74O5Ty9g=
 github.com/anacrolix/dht/v2 v2.13.0/go.mod h1:zJgaiAU2yhzmchZE2mY8WyZ64LK/F/D9MAeN0ct73qQ=
+github.com/anacrolix/dht/v2 v2.13.1-0.20211209181115-6ae2bd446b12 h1:W0gso1vLz1b1G9HjxsSFAWZjLZwwlPZQD20BGhwz5YU=
+github.com/anacrolix/dht/v2 v2.13.1-0.20211209181115-6ae2bd446b12/go.mod h1:zJgaiAU2yhzmchZE2mY8WyZ64LK/F/D9MAeN0ct73qQ=
 github.com/anacrolix/envpprof v0.0.0-20180404065416-323002cec2fa/go.mod h1:KgHhUaQMc8cC0+cEflSgCFNFbKwi5h54gqtVn8yhP7c=
 github.com/anacrolix/envpprof v1.0.0/go.mod h1:KgHhUaQMc8cC0+cEflSgCFNFbKwi5h54gqtVn8yhP7c=
 github.com/anacrolix/envpprof v1.0.1/go.mod h1:My7T5oSqVfEn4MD4Meczkw/f5lSIndGAKu/0SM/rkf4=

--- a/pex.go
+++ b/pex.go
@@ -165,15 +165,7 @@ func (me *pexMsgFactory) PexMsg() pp.PexMsg {
 func nodeAddr(addr PeerRemoteAddr) (krpc.NodeAddr, bool) {
 	ipport, _ := tryIpPortFromNetAddr(addr)
 	ok := ipport.IP != nil
-	return krpc.NodeAddr{IP: shortestIP(ipport.IP), Port: ipport.Port}, ok
-}
-
-// mainly for the krpc marshallers
-func shortestIP(ip net.IP) net.IP {
-	if ip4 := ip.To4(); ip4 != nil {
-		return ip4
-	}
-	return ip
+	return krpc.NodeAddr{IP: ipport.IP, Port: ipport.Port}, ok
 }
 
 // Per-torrent PEX state


### PR DESCRIPTION
anacrolix/dht#54 fixes the marshaller — the workaround can be removed.