### PR TITLE
Set proxy of websocket tracker

### DIFF
--- a/client.go
+++ b/client.go
@@ -298,6 +298,7 @@ func NewClient(cfg *ClientConfig) (cl *Client, err error) {
 			}
 			return t.announceRequest(event), nil
 		},
+		Proxy: cl.config.HTTPProxy,
 		OnConn: func(dc datachannel.ReadWriteCloser, dcc webtorrent.DataChannelContext) {
 			cl.lock()
 			defer cl.unlock()

--- a/webtorrent/tracker_client.go
+++ b/webtorrent/tracker_client.go
@@ -28,6 +28,7 @@ type TrackerClient struct {
 	PeerId             [20]byte
 	OnConn             onDataChannelOpen
 	Logger             log.Logger
+	Dialer             *websocket.Dialer
 
 	mu             sync.Mutex
 	cond           sync.Cond
@@ -70,7 +71,7 @@ func (tc *TrackerClient) doWebsocket() error {
 	tc.mu.Lock()
 	tc.stats.Dials++
 	tc.mu.Unlock()
-	c, _, err := websocket.DefaultDialer.Dial(tc.Url, nil)
+	c, _, err := tc.Dialer.Dial(tc.Url, nil)
 	if err != nil {
 		return fmt.Errorf("dialing tracker: %w", err)
 	}

--- a/wstracker.go
+++ b/wstracker.go
@@ -2,10 +2,11 @@ package torrent
 
 import (
 	"fmt"
+	"github.com/anacrolix/log"
+	"github.com/anacrolix/torrent/tracker/http"
+	"github.com/gorilla/websocket"
 	"net/url"
 	"sync"
-
-	"github.com/anacrolix/log"
 
 	"github.com/anacrolix/torrent/tracker"
 	"github.com/anacrolix/torrent/webtorrent"
@@ -37,6 +38,7 @@ type websocketTrackers struct {
 	OnConn             func(datachannel.ReadWriteCloser, webtorrent.DataChannelContext)
 	mu                 sync.Mutex
 	clients            map[string]*refCountedWebtorrentTrackerClient
+	Proxy              http.ProxyFunc
 }
 
 func (me *websocketTrackers) Get(url string) (*webtorrent.TrackerClient, func()) {
@@ -44,8 +46,10 @@ func (me *websocketTrackers) Get(url string) (*webtorrent.TrackerClient, func())
 	defer me.mu.Unlock()
 	value, ok := me.clients[url]
 	if !ok {
+		dialer := &websocket.Dialer{Proxy: me.Proxy, HandshakeTimeout: websocket.DefaultDialer.HandshakeTimeout}
 		value = &refCountedWebtorrentTrackerClient{
 			TrackerClient: webtorrent.TrackerClient{
+				Dialer:             dialer,
 				Url:                url,
 				GetAnnounceRequest: me.GetAnnounceRequest,
 				PeerId:             me.PeerId,


### PR DESCRIPTION
I have a VPN provider that has audit rules for BitTorrent download. Setting `clientConfig.HTTPProxy` to nil works for UDP/HTTP trackers, but websocket trackers still use my environment variable and go through my VPN network.