### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -221,9 +220,7 @@ func TestResponsive(t *testing.T) {
 	defer seeder.Close()
 	seederTorrent, _, _ := seeder.AddTorrentSpec(TorrentSpecFromMetaInfo(mi))
 	seederTorrent.VerifyData()
-	leecherDataDir, err := ioutil.TempDir("", "")
-	require.Nil(t, err)
-	defer os.RemoveAll(leecherDataDir)
+	leecherDataDir := t.TempDir()
 	cfg = TestingConfig(t)
 	cfg.DataDir = leecherDataDir
 	leecher, err := NewClient(cfg)
@@ -264,9 +261,7 @@ func TestTorrentDroppedDuringResponsiveRead(t *testing.T) {
 	defer seeder.Close()
 	seederTorrent, _, _ := seeder.AddTorrentSpec(TorrentSpecFromMetaInfo(mi))
 	seederTorrent.VerifyData()
-	leecherDataDir, err := ioutil.TempDir("", "")
-	require.Nil(t, err)
-	defer os.RemoveAll(leecherDataDir)
+	leecherDataDir := t.TempDir()
 	cfg = TestingConfig(t)
 	cfg.DataDir = leecherDataDir
 	leecher, err := NewClient(cfg)
@@ -359,9 +354,7 @@ func writeTorrentData(ts *storage.Torrent, info metainfo.Info, b []byte) {
 }
 
 func testAddTorrentPriorPieceCompletion(t *testing.T, alreadyCompleted bool, csf func(*filecache.Cache) storage.ClientImpl) {
-	fileCacheDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(fileCacheDir)
+	fileCacheDir := t.TempDir()
 	fileCache, err := filecache.NewCache(fileCacheDir)
 	require.NoError(t, err)
 	greetingDataTempDir, greetingMetainfo := testutil.GreetingTestTorrent()
@@ -456,9 +449,7 @@ func testDownloadCancel(t *testing.T, ps testDownloadCancelParams) {
 	defer testutil.ExportStatusWriter(seeder, "s", t)()
 	seederTorrent, _, _ := seeder.AddTorrentSpec(TorrentSpecFromMetaInfo(mi))
 	seederTorrent.VerifyData()
-	leecherDataDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(leecherDataDir)
+	leecherDataDir := t.TempDir()
 	fc, err := filecache.NewCache(leecherDataDir)
 	require.NoError(t, err)
 	if ps.SetLeecherStorageCapacity {

--- a/fs/torrentfs_test.go
+++ b/fs/torrentfs_test.go
@@ -62,11 +62,8 @@ func (tl *testLayout) Destroy() error {
 	return os.RemoveAll(tl.BaseDir)
 }
 
-func newGreetingLayout() (tl testLayout, err error) {
-	tl.BaseDir, err = ioutil.TempDir("", "torrentfs")
-	if err != nil {
-		return
-	}
+func newGreetingLayout(t *testing.T) (tl testLayout, err error) {
+	tl.BaseDir = t.TempDir()
 	tl.Completed = filepath.Join(tl.BaseDir, "completed")
 	os.Mkdir(tl.Completed, 0o777)
 	tl.MountDir = filepath.Join(tl.BaseDir, "mnt")
@@ -79,7 +76,7 @@ func newGreetingLayout() (tl testLayout, err error) {
 // Unmount without first killing the FUSE connection while there are FUSE
 // operations blocked inside the filesystem code.
 func TestUnmountWedged(t *testing.T) {
-	layout, err := newGreetingLayout()
+	layout, err := newGreetingLayout(t)
 	require.NoError(t, err)
 	defer func() {
 		err := layout.Destroy()
@@ -161,7 +158,7 @@ func TestUnmountWedged(t *testing.T) {
 }
 
 func TestDownloadOnDemand(t *testing.T) {
-	layout, err := newGreetingLayout()
+	layout, err := newGreetingLayout(t)
 	require.NoError(t, err)
 	defer layout.Destroy()
 	cfg := torrent.NewDefaultClientConfig()

--- a/issue97_test.go
+++ b/issue97_test.go
@@ -1,8 +1,6 @@
 package torrent
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/anacrolix/log"
@@ -13,9 +11,7 @@ import (
 )
 
 func TestHashPieceAfterStorageClosed(t *testing.T) {
-	td, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 	tt := &Torrent{
 		storageOpener: storage.NewClient(storage.NewFile(td)),
 		logger:        log.Default,

--- a/metainfo/metainfo_test.go
+++ b/metainfo/metainfo_test.go
@@ -85,9 +85,7 @@ func touchFile(path string) (err error) {
 }
 
 func TestBuildFromFilePathOrder(t *testing.T) {
-	td, err := ioutil.TempDir("", "anacrolix")
-	require.NoError(t, err)
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 	require.NoError(t, touchFile(filepath.Join(td, "b")))
 	require.NoError(t, touchFile(filepath.Join(td, "a")))
 	info := Info{

--- a/storage/bolt-piece-completion_test.go
+++ b/storage/bolt-piece-completion_test.go
@@ -1,8 +1,6 @@
 package storage
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,9 +10,7 @@ import (
 )
 
 func TestBoltPieceCompletion(t *testing.T) {
-	td, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
 	pc, err := NewBoltPieceCompletion(td)
 	require.NoError(t, err)

--- a/storage/file_test.go
+++ b/storage/file_test.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,9 +15,7 @@ import (
 )
 
 func TestShortFile(t *testing.T) {
-	td, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 	s := NewFile(td)
 	info := &metainfo.Info{
 		Name:        "a",

--- a/storage/issue95_test.go
+++ b/storage/issue95_test.go
@@ -1,8 +1,6 @@
 package storage
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/anacrolix/missinggo/v2/resource"
@@ -33,22 +31,15 @@ func testIssue95(t *testing.T, c ClientImpl) {
 }
 
 func TestIssue95File(t *testing.T) {
-	td, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 	testIssue95(t, NewFile(td))
 }
 
 func TestIssue95MMap(t *testing.T) {
-	td, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 	testIssue95(t, NewMMap(td))
 }
 
 func TestIssue95ResourcePieces(t *testing.T) {
-	td, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(td)
 	testIssue95(t, NewResourcePieces(resource.OSFileProvider{}))
 }

--- a/storage/issue96_test.go
+++ b/storage/issue96_test.go
@@ -1,8 +1,6 @@
 package storage
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,9 +9,7 @@ import (
 )
 
 func testMarkedCompleteMissingOnRead(t *testing.T, csf func(string) ClientImplCloser) {
-	td, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 	cs := NewClient(csf(td))
 	info := &metainfo.Info{
 		PieceLength: 1,

--- a/test/transfer_test.go
+++ b/test/transfer_test.go
@@ -397,9 +397,7 @@ func TestSeedAfterDownloading(t *testing.T) {
 
 	cfg = torrent.TestingConfig(t)
 	cfg.Seed = true
-	cfg.DataDir, err = ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(cfg.DataDir)
+	cfg.DataDir = t.TempDir()
 	leecher, err := torrent.NewClient(cfg)
 	require.NoError(t, err)
 	defer leecher.Close()
@@ -407,9 +405,7 @@ func TestSeedAfterDownloading(t *testing.T) {
 
 	cfg = torrent.TestingConfig(t)
 	cfg.Seed = false
-	cfg.DataDir, err = ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(cfg.DataDir)
+	cfg.DataDir = t.TempDir()
 	leecherLeecher, _ := torrent.NewClient(cfg)
 	require.NoError(t, err)
 	defer leecherLeecher.Close()

--- a/util/dirwatch/dirwatch_test.go
+++ b/util/dirwatch/dirwatch_test.go
@@ -1,19 +1,13 @@
 package dirwatch
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestDirwatch(t *testing.T) {
-	tempDirName, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDirName)
+	tempDirName := t.TempDir()
 	t.Logf("tempdir: %q", tempDirName)
 	dw, err := New(tempDirName)
 	require.NoError(t, err)


### PR DESCRIPTION
We can write less code by using the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir