### PR TITLE
Pass client logger to anacrolix/go-libutp sockets

### DIFF
--- a/client.go
+++ b/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/anacrolix/chansync/events"
 	"github.com/anacrolix/dht/v2"
 	"github.com/anacrolix/dht/v2/krpc"
+	utp "github.com/anacrolix/go-libutp"
 	"github.com/anacrolix/log"
 	"github.com/anacrolix/missinggo/perf"
 	"github.com/anacrolix/missinggo/pubsub"
@@ -246,7 +247,7 @@ func NewClient(cfg *ClientConfig) (cl *Client, err error) {
 		}
 	}
 
-	sockets, err := listenAll(cl.listenNetworks(), cl.config.ListenHost, cl.config.ListenPort, cl.firewallCallback)
+	sockets, err := listenAll(cl.listenNetworks(), cl.config.ListenHost, cl.config.ListenPort, cl.firewallCallback, utp.WithLogger(cl.logger))
 	if err != nil {
 		return
 	}

--- a/client.go
+++ b/client.go
@@ -20,7 +20,6 @@ import (
 	"github.com/anacrolix/chansync/events"
 	"github.com/anacrolix/dht/v2"
 	"github.com/anacrolix/dht/v2/krpc"
-	utp "github.com/anacrolix/go-libutp"
 	"github.com/anacrolix/log"
 	"github.com/anacrolix/missinggo/perf"
 	"github.com/anacrolix/missinggo/pubsub"
@@ -247,7 +246,7 @@ func NewClient(cfg *ClientConfig) (cl *Client, err error) {
 		}
 	}
 
-	sockets, err := listenAll(cl.listenNetworks(), cl.config.ListenHost, cl.config.ListenPort, cl.firewallCallback, utp.WithLogger(cl.logger))
+	sockets, err := listenAll(cl.listenNetworks(), cl.config.ListenHost, cl.config.ListenPort, cl.firewallCallback, cl.logger)
 	if err != nil {
 		return
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/anacrolix/log"
+
 	"github.com/anacrolix/dht/v2"
 	"github.com/anacrolix/missinggo/v2"
 	"github.com/anacrolix/missinggo/v2/filecache"
@@ -741,7 +743,7 @@ func TestObfuscatedHeaderFallbackSeederRequiresLeecherPrefersNot(t *testing.T) {
 }
 
 func TestClientAddressInUse(t *testing.T) {
-	s, _ := NewUtpSocket("udp", ":50007", nil)
+	s, _ := NewUtpSocket("udp", ":50007", nil, log.Default)
 	if s != nil {
 		defer s.Close()
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/anacrolix/dht/v2 v2.15.2-0.20220123034220-0538803801cb
 	github.com/anacrolix/envpprof v1.1.1
 	github.com/anacrolix/fuse v0.2.0
-	github.com/anacrolix/go-libutp v1.1.0
+	github.com/anacrolix/go-libutp v1.2.0
 	github.com/anacrolix/log v0.10.1-0.20220123034749-3920702c17f8
 	github.com/anacrolix/missinggo v1.3.0
 	github.com/anacrolix/missinggo/perf v1.0.0
@@ -40,9 +40,6 @@ require (
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 	zombiezen.com/go/sqlite v0.8.0
 )
-
-// https://gitlab.com/cznic/sqlite/-/issues/77#note_744477407
-require modernc.org/sqlite v1.14.2-0.20211125151325-d4ed92c0a70f // indirect
 
 retract (
 	// Doesn't signal interest to peers if choked when piece priorities change.

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,9 @@ github.com/anacrolix/fuse v0.2.0/go.mod h1:Kfu02xBwnySDpH3N23BmrP3MDfwAQGRLUCj6X
 github.com/anacrolix/go-libutp v0.0.0-20180522111405-6baeb806518d/go.mod h1:beQSaSxwH2d9Eeu5ijrEnHei5Qhk+J6cDm1QkWFru4E=
 github.com/anacrolix/go-libutp v1.0.2/go.mod h1:uIH0A72V++j0D1nnmTjjZUiH/ujPkFxYWkxQ02+7S0U=
 github.com/anacrolix/go-libutp v1.0.4/go.mod h1:8vSGX5g0b4eebsDBNVQHUXSCwYaN18Lnkse0hUW8/5w=
-github.com/anacrolix/go-libutp v1.1.0 h1:89XK+0NBTaKgSoG/v5OfDK0yoyrt2HInfg46I1BaT2E=
 github.com/anacrolix/go-libutp v1.1.0/go.mod h1:so9zroOUhFPGnIkddyflaCCl+xdTsRSq97/AOQ2/Hjk=
+github.com/anacrolix/go-libutp v1.2.0 h1:sjxoB+/ARiKUR7IK/6wLWyADIBqGmu1fm0xo+8Yy7u0=
+github.com/anacrolix/go-libutp v1.2.0/go.mod h1:RrJ3KcaDcf9Jqp33YL5V/5CBEc6xMc7aJL8wXfuWL50=
 github.com/anacrolix/log v0.0.0-20180412014343-2323884b361d/go.mod h1:sf/7c2aTldL6sRQj/4UKyjgVZBu2+M2z9wf7MmwPiew=
 github.com/anacrolix/log v0.3.0/go.mod h1:lWvLTqzAnCWPJA08T2HCstZi0L1y2Wyvm3FJgwU9jwU=
 github.com/anacrolix/log v0.3.1-0.20190913000754-831e4ffe0174/go.mod h1:lWvLTqzAnCWPJA08T2HCstZi0L1y2Wyvm3FJgwU9jwU=

--- a/network_test.go
+++ b/network_test.go
@@ -4,6 +4,8 @@ import (
 	"net"
 	"testing"
 
+	"github.com/anacrolix/log"
+
 	"github.com/anacrolix/missinggo/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,7 +25,7 @@ func testListenerNetwork(
 }
 
 func listenUtpListener(net, addr string) (l net.Listener, err error) {
-	l, err = NewUtpSocket(net, addr, nil)
+	l, err = NewUtpSocket(net, addr, nil, log.Default)
 	return
 }
 

--- a/socket.go
+++ b/socket.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"strconv"
 
-	utp "github.com/anacrolix/go-libutp"
+	"github.com/anacrolix/log"
 	"github.com/anacrolix/missinggo/perf"
 	"github.com/anacrolix/missinggo/v2"
 	"github.com/pkg/errors"
@@ -25,12 +25,12 @@ type socket interface {
 	Close() error
 }
 
-func listen(n network, addr string, f firewallCallback, opts ...utp.NewSocketOpt) (socket, error) {
+func listen(n network, addr string, f firewallCallback, logger log.Logger) (socket, error) {
 	switch {
 	case n.Tcp:
 		return listenTcp(n.String(), addr)
 	case n.Udp:
-		return listenUtp(n.String(), addr, f, opts...)
+		return listenUtp(n.String(), addr, f, logger)
 	default:
 		panic(n)
 	}
@@ -52,7 +52,7 @@ type tcpSocket struct {
 	NetworkDialer
 }
 
-func listenAll(networks []network, getHost func(string) string, port int, f firewallCallback, opts ...utp.NewSocketOpt) ([]socket, error) {
+func listenAll(networks []network, getHost func(string) string, port int, f firewallCallback, logger log.Logger) ([]socket, error) {
 	if len(networks) == 0 {
 		return nil, nil
 	}
@@ -61,7 +61,7 @@ func listenAll(networks []network, getHost func(string) string, port int, f fire
 		nahs = append(nahs, networkAndHost{n, getHost(n.String())})
 	}
 	for {
-		ss, retry, err := listenAllRetry(nahs, port, f, opts...)
+		ss, retry, err := listenAllRetry(nahs, port, f, logger)
 		if !retry {
 			return ss, err
 		}
@@ -73,10 +73,10 @@ type networkAndHost struct {
 	Host    string
 }
 
-func listenAllRetry(nahs []networkAndHost, port int, f firewallCallback, opts ...utp.NewSocketOpt) (ss []socket, retry bool, err error) {
+func listenAllRetry(nahs []networkAndHost, port int, f firewallCallback, logger log.Logger) (ss []socket, retry bool, err error) {
 	ss = make([]socket, 1, len(nahs))
 	portStr := strconv.FormatInt(int64(port), 10)
-	ss[0], err = listen(nahs[0].Network, net.JoinHostPort(nahs[0].Host, portStr), f, opts...)
+	ss[0], err = listen(nahs[0].Network, net.JoinHostPort(nahs[0].Host, portStr), f, logger)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "first listen")
 	}
@@ -90,7 +90,7 @@ func listenAllRetry(nahs []networkAndHost, port int, f firewallCallback, opts ..
 	}()
 	portStr = strconv.FormatInt(int64(missinggo.AddrPort(ss[0].Addr())), 10)
 	for _, nah := range nahs[1:] {
-		s, err := listen(nah.Network, net.JoinHostPort(nah.Host, portStr), f, opts...)
+		s, err := listen(nah.Network, net.JoinHostPort(nah.Host, portStr), f, logger)
 		if err != nil {
 			return ss,
 				missinggo.IsAddrInUse(err) && port == 0,
@@ -104,8 +104,8 @@ func listenAllRetry(nahs []networkAndHost, port int, f firewallCallback, opts ..
 // This isn't aliased from go-libutp since that assumes CGO.
 type firewallCallback func(net.Addr) bool
 
-func listenUtp(network, addr string, fc firewallCallback, opts ...utp.NewSocketOpt) (socket, error) {
-	us, err := NewUtpSocket(network, addr, fc, opts...)
+func listenUtp(network, addr string, fc firewallCallback, logger log.Logger) (socket, error) {
+	us, err := NewUtpSocket(network, addr, fc, logger)
 	return utpSocketSocket{us, network}, err
 }
 

--- a/socket.go
+++ b/socket.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"strconv"
 
+	utp "github.com/anacrolix/go-libutp"
 	"github.com/anacrolix/missinggo/perf"
 	"github.com/anacrolix/missinggo/v2"
 	"github.com/pkg/errors"
@@ -24,12 +25,12 @@ type socket interface {
 	Close() error
 }
 
-func listen(n network, addr string, f firewallCallback) (socket, error) {
+func listen(n network, addr string, f firewallCallback, opts ...utp.NewSocketOpt) (socket, error) {
 	switch {
 	case n.Tcp:
 		return listenTcp(n.String(), addr)
 	case n.Udp:
-		return listenUtp(n.String(), addr, f)
+		return listenUtp(n.String(), addr, f, opts...)
 	default:
 		panic(n)
 	}
@@ -51,7 +52,7 @@ type tcpSocket struct {
 	NetworkDialer
 }
 
-func listenAll(networks []network, getHost func(string) string, port int, f firewallCallback) ([]socket, error) {
+func listenAll(networks []network, getHost func(string) string, port int, f firewallCallback, opts ...utp.NewSocketOpt) ([]socket, error) {
 	if len(networks) == 0 {
 		return nil, nil
 	}
@@ -60,7 +61,7 @@ func listenAll(networks []network, getHost func(string) string, port int, f fire
 		nahs = append(nahs, networkAndHost{n, getHost(n.String())})
 	}
 	for {
-		ss, retry, err := listenAllRetry(nahs, port, f)
+		ss, retry, err := listenAllRetry(nahs, port, f, opts...)
 		if !retry {
 			return ss, err
 		}
@@ -72,10 +73,10 @@ type networkAndHost struct {
 	Host    string
 }
 
-func listenAllRetry(nahs []networkAndHost, port int, f firewallCallback) (ss []socket, retry bool, err error) {
+func listenAllRetry(nahs []networkAndHost, port int, f firewallCallback, opts ...utp.NewSocketOpt) (ss []socket, retry bool, err error) {
 	ss = make([]socket, 1, len(nahs))
 	portStr := strconv.FormatInt(int64(port), 10)
-	ss[0], err = listen(nahs[0].Network, net.JoinHostPort(nahs[0].Host, portStr), f)
+	ss[0], err = listen(nahs[0].Network, net.JoinHostPort(nahs[0].Host, portStr), f, opts...)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "first listen")
 	}
@@ -89,7 +90,7 @@ func listenAllRetry(nahs []networkAndHost, port int, f firewallCallback) (ss []s
 	}()
 	portStr = strconv.FormatInt(int64(missinggo.AddrPort(ss[0].Addr())), 10)
 	for _, nah := range nahs[1:] {
-		s, err := listen(nah.Network, net.JoinHostPort(nah.Host, portStr), f)
+		s, err := listen(nah.Network, net.JoinHostPort(nah.Host, portStr), f, opts...)
 		if err != nil {
 			return ss,
 				missinggo.IsAddrInUse(err) && port == 0,
@@ -103,8 +104,8 @@ func listenAllRetry(nahs []networkAndHost, port int, f firewallCallback) (ss []s
 // This isn't aliased from go-libutp since that assumes CGO.
 type firewallCallback func(net.Addr) bool
 
-func listenUtp(network, addr string, fc firewallCallback) (socket, error) {
-	us, err := NewUtpSocket(network, addr, fc)
+func listenUtp(network, addr string, fc firewallCallback, opts ...utp.NewSocketOpt) (socket, error) {
+	us, err := NewUtpSocket(network, addr, fc, opts...)
 	return utpSocketSocket{us, network}, err
 }
 

--- a/utp_go.go
+++ b/utp_go.go
@@ -4,10 +4,11 @@
 package torrent
 
 import (
+	"github.com/anacrolix/log"
 	"github.com/anacrolix/utp"
 )
 
-func NewUtpSocket(network, addr string, _ firewallCallback) (utpSocket, error) {
+func NewUtpSocket(network, addr string, _ firewallCallback, _ log.Logger) (utpSocket, error) {
 	s, err := utp.NewSocket(network, addr)
 	if s == nil {
 		return nil, err

--- a/utp_libutp.go
+++ b/utp_libutp.go
@@ -7,8 +7,8 @@ import (
 	utp "github.com/anacrolix/go-libutp"
 )
 
-func NewUtpSocket(network, addr string, fc firewallCallback) (utpSocket, error) {
-	s, err := utp.NewSocket(network, addr)
+func NewUtpSocket(network, addr string, fc firewallCallback, opts ...utp.NewSocketOpt) (utpSocket, error) {
+	s, err := utp.NewSocket(network, addr, opts...)
 	if s == nil {
 		return nil, err
 	}

--- a/utp_libutp.go
+++ b/utp_libutp.go
@@ -5,10 +5,11 @@ package torrent
 
 import (
 	utp "github.com/anacrolix/go-libutp"
+	"github.com/anacrolix/log"
 )
 
-func NewUtpSocket(network, addr string, fc firewallCallback, opts ...utp.NewSocketOpt) (utpSocket, error) {
-	s, err := utp.NewSocket(network, addr, opts...)
+func NewUtpSocket(network, addr string, fc firewallCallback, logger log.Logger) (utpSocket, error) {
+	s, err := utp.NewSocket(network, addr, utp.WithLogger(logger))
 	if s == nil {
 		return nil, err
 	}

--- a/utp_test.go
+++ b/utp_test.go
@@ -3,11 +3,13 @@ package torrent
 import (
 	"testing"
 
+	"github.com/anacrolix/log"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewUtpSocketErrorNilInterface(t *testing.T) {
-	s, err := NewUtpSocket("fix", "your:language", nil)
+	s, err := NewUtpSocket("fix", "your:language", nil, log.Default)
 	assert.Error(t, err)
 	if s != nil {
 		t.Fatalf("expected nil, got %#v", s)


### PR DESCRIPTION
I'm opening this as a draft for now, because I'm not certain I like the use of `utp.NewSocketOpt` all the way up the chain in `listenAll`.

I'd love your input, @anacrolix, but I was thinking of perhaps defining a `socket` interface in addition to the `utpSocket` interface in `utp.go`, and then a `socketOpt` type which could be used for configuring sockets more generally.

Closes #676.