### PR TITLE
Avoid heap allocation in GetRequestablePieces

### DIFF
--- a/request-strategy-impls.go
+++ b/request-strategy-impls.go
@@ -44,8 +44,15 @@ type requestStrategyTorrent struct {
 	t *Torrent
 }
 
-func (r requestStrategyTorrent) Piece(i int) request_strategy.Piece {
-	return requestStrategyPiece{r.t, i}
+func (r requestStrategyTorrent) IgnorePiece(i int) bool {
+	if r.t.ignorePieceForRequests(i) {
+		return true
+	}
+	if r.t.pieceNumPendingChunks(i) == 0 {
+		return true
+	}
+
+	return false
 }
 
 func (r requestStrategyTorrent) ChunksPerPiece() uint32 {

--- a/request-strategy/order.go
+++ b/request-strategy/order.go
@@ -54,7 +54,6 @@ func GetRequestablePieces(input Input, pro *PieceRequestOrder, f func(ih metainf
 	pro.tree.Scan(func(_i pieceRequestOrderItem) bool {
 		ih := _i.key.InfoHash
 		var t Torrent = input.Torrent(ih)
-		var piece Piece = t.Piece(_i.key.Index)
 		pieceLength := t.PieceLength()
 		if storageLeft != nil {
 			if *storageLeft < pieceLength {
@@ -62,7 +61,7 @@ func GetRequestablePieces(input Input, pro *PieceRequestOrder, f func(ih metainf
 			}
 			*storageLeft -= pieceLength
 		}
-		if !piece.Request() || piece.NumPendingChunks() == 0 {
+		if t.IgnorePiece(_i.key.Index) {
 			// TODO: Clarify exactly what is verified. Stuff that's being hashed should be
 			// considered unverified and hold up further requests.
 			return true

--- a/request-strategy/torrent.go
+++ b/request-strategy/torrent.go
@@ -1,7 +1,7 @@
 package request_strategy
 
 type Torrent interface {
-	Piece(int) Piece
+	IgnorePiece(int) bool
 	ChunksPerPiece() uint32
 	PieceLength() int64
 }


### PR DESCRIPTION
The calculation of whether we should ignore a piece in GetRequestablePieces ends up doing an allocation for every piece, when
all we really need to do is query the index in the torrent. Provide an IgnorePiece function instead, which avoids the need for a temporary allocation.

Observed to cut out 40% of object allocations in some workloads (large download, lots of seeds).

(I'm not clear why Go doesn't optimise this onto the stack, as it doesn't seem to escape, but it was turning up as an extremely hot allocation path in pprof flame graphs.)