### PR TITLE
Discard webrtc logs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -60,7 +60,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/go-common
     - name: Some packages compile for WebAssembly
-      run: GOOS=js GOARCH=wasm go build -v . ./storage ./tracker/...
+      run: GOOS=js GOARCH=wasm go build . ./storage ./tracker/...
 
   torrentfs:
     runs-on: ubuntu-latest

--- a/webtorrent/setting-engine.go
+++ b/webtorrent/setting-engine.go
@@ -1,0 +1,24 @@
+// These build constraints are copied from webrtc's settingengine.go.
+//go:build !js
+// +build !js
+
+package webtorrent
+
+import (
+	"io"
+
+	"github.com/pion/logging"
+	"github.com/pion/webrtc/v3"
+)
+
+var s = webrtc.SettingEngine{
+	// This could probably be done with better integration into anacrolix/log, but I'm not sure if
+	// it's worth the effort.
+	LoggerFactory: discardLoggerFactory{},
+}
+
+type discardLoggerFactory struct{}
+
+func (discardLoggerFactory) NewLogger(scope string) logging.LeveledLogger {
+	return logging.NewDefaultLeveledLoggerForScope(scope, logging.LogLevelInfo, io.Discard)
+}

--- a/webtorrent/setting-engine_js.go
+++ b/webtorrent/setting-engine_js.go
@@ -1,0 +1,13 @@
+// These build constraints are copied from webrtc's settingengine_js.go.
+//go:build js && wasm
+// +build js,wasm
+
+package webtorrent
+
+import (
+	"github.com/pion/webrtc/v3"
+)
+
+// I'm not sure what to do for logging for JS. See
+// https://gophers.slack.com/archives/CAK2124AG/p1649651943947579.
+var s = webrtc.SettingEngine{}

--- a/webtorrent/transport.go
+++ b/webtorrent/transport.go
@@ -8,24 +8,13 @@ import (
 
 	"github.com/anacrolix/missinggo/v2/pproffd"
 	"github.com/pion/datachannel"
-	"github.com/pion/logging"
-
 	"github.com/pion/webrtc/v3"
 )
-
-type DiscardLoggerFactory struct{}
-
-func (f *DiscardLoggerFactory) NewLogger(scope string) logging.LeveledLogger {
-	return logging.NewDefaultLeveledLoggerForScope(scope, logging.LogLevelInfo, io.Discard)
-}
 
 var (
 	metrics = expvar.NewMap("webtorrent")
 	api     = func() *webrtc.API {
 		// Enable the detach API (since it's non-standard but more idiomatic).
-		s := webrtc.SettingEngine{
-			LoggerFactory: &DiscardLoggerFactory{},
-		}
 		s.DetachDataChannels()
 		return webrtc.NewAPI(webrtc.WithSettingEngine(s))
 	}()

--- a/webtorrent/transport.go
+++ b/webtorrent/transport.go
@@ -8,15 +8,24 @@ import (
 
 	"github.com/anacrolix/missinggo/v2/pproffd"
 	"github.com/pion/datachannel"
+	"github.com/pion/logging"
 
 	"github.com/pion/webrtc/v3"
 )
+
+type DiscardLoggerFactory struct{}
+
+func (f *DiscardLoggerFactory) NewLogger(scope string) logging.LeveledLogger {
+	return logging.NewDefaultLeveledLoggerForScope(scope, logging.LogLevelInfo, io.Discard)
+}
 
 var (
 	metrics = expvar.NewMap("webtorrent")
 	api     = func() *webrtc.API {
 		// Enable the detach API (since it's non-standard but more idiomatic).
-		s := webrtc.SettingEngine{}
+		s := webrtc.SettingEngine{
+			LoggerFactory: &DiscardLoggerFactory{},
+		}
 		s.DetachDataChannels()
 		return webrtc.NewAPI(webrtc.WithSettingEngine(s))
 	}()


### PR DESCRIPTION
Problem:
- Now user can see logs like: `mux ERROR: 2022/04/09 13:41:02 mux: ending readLoop dispatch error io: read/write on closed pipe` (when restart the app), but can't do anything with this logs (filter/format).

Probably it's bad solution (to discard logs), but It's unclear for me - how to integrate pion logger with anacrolix logger: 
- api *webrtc.API - is the global variable initialized way before i creating configuration of anacrolix


