### PR TITLE
Update tidwall/btree (0.7.2 -> 1.3.1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
 	github.com/stretchr/testify v1.7.1
-	github.com/tidwall/btree v0.7.2-0.20211211132910-4215444137fc
+	github.com/tidwall/btree v1.3.1
 	go.etcd.io/bbolt v1.3.6
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 )

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tidwall/btree v0.7.2-0.20211211132910-4215444137fc h1:THtJVe/QBctKEe8kjnXwt7RAlvHNtUjFJOEmgZkN05w=
-github.com/tidwall/btree v0.7.2-0.20211211132910-4215444137fc/go.mod h1:LGm8L/DZjPLmeWGjv5kFrY8dL4uVhMmzmmLYmsObdKE=
+github.com/tidwall/btree v1.3.1 h1:636+tdVDs8Hjcf35Di260W2xCW4KuoXOKyk9QWOvCpA=
+github.com/tidwall/btree v1.3.1/go.mod h1:LGm8L/DZjPLmeWGjv5kFrY8dL4uVhMmzmmLYmsObdKE=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tinylib/msgp v1.1.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=

--- a/request-strategy/tidwall-btree.go
+++ b/request-strategy/tidwall-btree.go
@@ -5,7 +5,7 @@ import (
 )
 
 type tidwallBtree struct {
-	tree     *btree.BTree[pieceRequestOrderItem]
+	tree     *btree.Generic[pieceRequestOrderItem]
 	PathHint *btree.PathHint
 }
 
@@ -15,7 +15,7 @@ func (me *tidwallBtree) Scan(f func(pieceRequestOrderItem) bool) {
 
 func NewTidwallBtree() *tidwallBtree {
 	return &tidwallBtree{
-		tree: btree.NewOptions(
+		tree: btree.NewGenericOptions(
 			func(a, b pieceRequestOrderItem) bool {
 				return a.Less(&b)
 			},


### PR DESCRIPTION
[Mabel](https://github.com/smmr-software/mabel) does not compile after running `go get -u .` due to breaking changes in the `tidwall/btree` package, a dependency of this project.

This PR pulls in the latest changes to `tidwall/btree`.