### PR TITLE
Add ability to set DialContext/ListenPacket for tracker announcements

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package torrent
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"net/url"
@@ -90,6 +91,10 @@ type ClientConfig struct {
 	// Defines proxy for HTTP requests, such as for trackers. It's commonly set from the result of
 	// "net/http".ProxyURL(HTTPProxy).
 	HTTPProxy func(*http.Request) (*url.URL, error)
+	// Defines DialContext func to use for HTTP tracker announcements
+	TrackerDialContext func(ctx context.Context, network, addr string) (net.Conn, error)
+	// Defines ListenPacket func to use for UDP tracker announcements
+	TrackerListenPacket func(network, addr string) (net.PacketConn, error)
 	// Takes a tracker's hostname and requests DNS A and AAAA records.
 	// Used in case DNS lookups require a special setup (i.e., dns-over-https)
 	LookupTrackerIp func(*url.URL) ([]net.IP, error)

--- a/tracker/client.go
+++ b/tracker/client.go
@@ -2,6 +2,7 @@ package tracker
 
 import (
 	"context"
+	"net"
 	"net/url"
 
 	"github.com/anacrolix/log"
@@ -19,8 +20,9 @@ type AnnounceOpt = trHttp.AnnounceOpt
 type NewClientOpts struct {
 	Http trHttp.NewClientOpts
 	// Overrides the network in the scheme. Probably a legacy thing.
-	UdpNetwork string
-	Logger     log.Logger
+	UdpNetwork   string
+	Logger       log.Logger
+	ListenPacket func(network, addr string) (net.PacketConn, error)
 }
 
 func NewClient(urlStr string, opts NewClientOpts) (Client, error) {
@@ -37,9 +39,10 @@ func NewClient(urlStr string, opts NewClientOpts) (Client, error) {
 			network = opts.UdpNetwork
 		}
 		cc, err := udp.NewConnClient(udp.NewConnClientOpts{
-			Network: network,
-			Host:    _url.Host,
-			Logger:  opts.Logger,
+			Network:      network,
+			Host:         _url.Host,
+			Logger:       opts.Logger,
+			ListenPacket: opts.ListenPacket,
 		})
 		if err != nil {
 			return nil, err

--- a/tracker/http/client.go
+++ b/tracker/http/client.go
@@ -1,7 +1,9 @@
 package http
 
 import (
+	"context"
 	"crypto/tls"
+	"net"
 	"net/http"
 	"net/url"
 )
@@ -12,9 +14,11 @@ type Client struct {
 }
 
 type ProxyFunc func(*http.Request) (*url.URL, error)
+type DialContextFunc func(ctx context.Context, network, addr string) (net.Conn, error)
 
 type NewClientOpts struct {
 	Proxy          ProxyFunc
+	DialContext    DialContextFunc
 	ServerName     string
 	AllowKeepAlive bool
 }
@@ -24,6 +28,7 @@ func NewClient(url_ *url.URL, opts NewClientOpts) Client {
 		url_: url_,
 		hc: &http.Client{
 			Transport: &http.Transport{
+				DialContext: opts.DialContext,
 				Proxy: opts.Proxy,
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: true,

--- a/tracker_scraper.go
+++ b/tracker_scraper.go
@@ -156,17 +156,19 @@ func (me *trackerScraper) announce(ctx context.Context, event tracker.AnnounceEv
 	defer cancel()
 	me.t.logger.WithDefaultLevel(log.Debug).Printf("announcing to %q: %#v", me.u.String(), req)
 	res, err := tracker.Announce{
-		Context:    ctx,
-		HTTPProxy:  me.t.cl.config.HTTPProxy,
-		UserAgent:  me.t.cl.config.HTTPUserAgent,
-		TrackerUrl: me.trackerUrl(ip),
-		Request:    req,
-		HostHeader: me.u.Host,
-		ServerName: me.u.Hostname(),
-		UdpNetwork: me.u.Scheme,
-		ClientIp4:  krpc.NodeAddr{IP: me.t.cl.config.PublicIp4},
-		ClientIp6:  krpc.NodeAddr{IP: me.t.cl.config.PublicIp6},
-		Logger:     me.t.logger,
+		Context:      ctx,
+		HTTPProxy:    me.t.cl.config.HTTPProxy,
+		DialContext:  me.t.cl.config.TrackerDialContext,
+		ListenPacket: me.t.cl.config.TrackerListenPacket,
+		UserAgent:    me.t.cl.config.HTTPUserAgent,
+		TrackerUrl:   me.trackerUrl(ip),
+		Request:      req,
+		HostHeader:   me.u.Host,
+		ServerName:   me.u.Hostname(),
+		UdpNetwork:   me.u.Scheme,
+		ClientIp4:    krpc.NodeAddr{IP: me.t.cl.config.PublicIp4},
+		ClientIp6:    krpc.NodeAddr{IP: me.t.cl.config.PublicIp6},
+		Logger:       me.t.logger,
 	}.Do()
 	me.t.logger.WithDefaultLevel(log.Debug).Printf("announce to %q returned %#v: %v", me.u.String(), res, err)
 	if err != nil {


### PR DESCRIPTION
I have had this branch lying around for a while, but decided to pick it back up, make it work with the latest master, and offer it as a PR.

Currently, this library has the ability to configure an HTTPProxy for HTTP tracker announcements. This is useful for a simple proxy, but it is somewhat limited if you want to do anything more advanced. Likewise, there is currently no way to proxy UDP tracker announcements.

This PR introduces two new configuration properties for `TrackerDialContext` and `TrackerListenPacket`. When they are defined they will take precedence over the default `http.Transport` options and `net.ListenPacket`.

Typically these would not be required since most people probably use a VPN at a lower level to prevent IP leaks, but these changes allow you to, for example, route all tracker requests through a remote wireguard server even if your computer is not connected to a VPN.