### PR TITLE
Retrive file via HTTP URL in `metainfo.go`

### DIFF
--- a/cmd/torrent/metainfo.go
+++ b/cmd/torrent/metainfo.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
+	"net/http"
 
 	"github.com/anacrolix/bargle"
 	"github.com/anacrolix/torrent/metainfo"
@@ -27,7 +29,18 @@ func metainfoCmd() (cmd bargle.Command) {
 			Value: &bargle.String{Target: &metainfoPath},
 			AfterParseFunc: func(ctx bargle.Context) error {
 				ctx.AfterParse(func() (err error) {
-					mi, err = metainfo.LoadFromFile(metainfoPath)
+					if strings.HasPrefix(metainfoPath, "http://") || strings.HasPrefix(metainfoPath, "https://") {
+						response, err := http.Get(metainfoPath)
+						if err != nil {
+							return nil
+						}
+						mi, err = metainfo.Load(response.Body)
+						if err != nil {
+							return nil
+						}
+					} else {
+						mi, err = metainfo.LoadFromFile(metainfoPath)
+					}
 					return
 				})
 				return nil


### PR DESCRIPTION
I just thought it would be neat.

Example usage:
```
$ torrent metainfo https://archive.org/download/night_of_the_living_dead/night_of_the_living_dead_archive.torrent magnet
magnet:?xt=urn:btih:bba0e98f114a1414eb808bdd2ce86e852afefdc2&dn=night_of_the_living_dead&tr=http%3A%2F%2Fbt1.archive.org%3A6969%2Fannounce&tr=http%3A%2F%2Fbt2.archive.org%3A6969%2Fannounce&ws=http%3A%2F%2Farchive.org%2Fdownload%2F&ws=http%3A%2F%2Fia600301.us.archive.org%2F22%2Fitems&ws=http%3A%2F%2Fia700301.us.archive.org%2F22%2Fitems
```