### PR TITLE
Add customer headers when dialling WS connection to tracker

### DIFF
--- a/client.go
+++ b/client.go
@@ -297,9 +297,9 @@ func NewClient(cfg *ClientConfig) (cl *Client, err error) {
 			}
 			return t.announceRequest(event), nil
 		},
-		Proxy:                       cl.config.HTTPProxy,
-		WebtorrentTrackerHttpHeader: cl.config.WebtorrentTrackerHttpHeader,
-		DialContext:                 cl.config.TrackerDialContext,
+		Proxy:                      cl.config.HTTPProxy,
+		WebsocketTrackerHttpHeader: cl.config.WebsocketTrackerHttpHeader,
+		DialContext:                cl.config.TrackerDialContext,
 		OnConn: func(dc datachannel.ReadWriteCloser, dcc webtorrent.DataChannelContext) {
 			cl.lock()
 			defer cl.unlock()

--- a/client.go
+++ b/client.go
@@ -297,8 +297,9 @@ func NewClient(cfg *ClientConfig) (cl *Client, err error) {
 			}
 			return t.announceRequest(event), nil
 		},
-		Proxy:       cl.config.HTTPProxy,
-		DialContext: cl.config.TrackerDialContext,
+		Proxy:                       cl.config.HTTPProxy,
+		WebtorrentTrackerHttpHeader: cl.config.WebtorrentTrackerHttpHeader,
+		DialContext:                 cl.config.TrackerDialContext,
 		OnConn: func(dc datachannel.ReadWriteCloser, dcc webtorrent.DataChannelContext) {
 			cl.lock()
 			defer cl.unlock()

--- a/config.go
+++ b/config.go
@@ -119,7 +119,7 @@ type ClientConfig struct {
 	HttpRequestDirector func(*http.Request) error
 	// WebsocketTrackerHttpHeader returns a custom header to be used when dialing a websocket connection
 	// to the tracker. Useful for adding authentication headers
-	WebsocketTrackerHttpHeader func() (http.Header, error)
+	WebsocketTrackerHttpHeader func() http.Header
 	// Updated occasionally to when there's been some changes to client
 	// behaviour in case other clients are assuming anything of us. See also
 	// `bep20`.

--- a/config.go
+++ b/config.go
@@ -105,6 +105,9 @@ type ClientConfig struct {
 	// HttpRequestDirector modifies the request before it's sent.
 	// Useful for adding authentication headers, for example
 	HttpRequestDirector func(*http.Request) error
+	// WebtorrentTrackerHttpHeader returns a custom header to be used when dialing a websocket connection
+	// to the tracker. Useful for adding authentication headers
+	WebtorrentTrackerHttpHeader func() (http.Header, error)
 	// Updated occasionally to when there's been some changes to client
 	// behaviour in case other clients are assuming anything of us. See also
 	// `bep20`.

--- a/config.go
+++ b/config.go
@@ -117,9 +117,9 @@ type ClientConfig struct {
 	// HttpRequestDirector modifies the request before it's sent.
 	// Useful for adding authentication headers, for example
 	HttpRequestDirector func(*http.Request) error
-	// WebtorrentTrackerHttpHeader returns a custom header to be used when dialing a websocket connection
+	// WebsocketTrackerHttpHeader returns a custom header to be used when dialing a websocket connection
 	// to the tracker. Useful for adding authentication headers
-	WebtorrentTrackerHttpHeader func() (http.Header, error)
+	WebsocketTrackerHttpHeader func() (http.Header, error)
 	// Updated occasionally to when there's been some changes to client
 	// behaviour in case other clients are assuming anything of us. See also
 	// `bep20`.

--- a/webtorrent/tracker-client.go
+++ b/webtorrent/tracker-client.go
@@ -42,7 +42,7 @@ type TrackerClient struct {
 	stats          TrackerClientStats
 	pingTicker     *time.Ticker
 
-	WebtorrentTrackerHttpHeader func() (http.Header, error)
+	WebsocketTrackerHttpHeader func() (http.Header, error)
 }
 
 func (me *TrackerClient) Stats() TrackerClientStats {
@@ -91,9 +91,9 @@ func (tc *TrackerClient) doWebsocket() error {
 	tc.mu.Unlock()
 
 	var header http.Header
-	if tc.WebtorrentTrackerHttpHeader != nil {
+	if tc.WebsocketTrackerHttpHeader != nil {
 		var err error
-		header, err = tc.WebtorrentTrackerHttpHeader()
+		header, err = tc.WebsocketTrackerHttpHeader()
 		if err != nil {
 			err = fmt.Errorf("error creating webtorrent tracker HTTP header: %w", err)
 			return err

--- a/webtorrent/tracker-client.go
+++ b/webtorrent/tracker-client.go
@@ -42,7 +42,7 @@ type TrackerClient struct {
 	stats          TrackerClientStats
 	pingTicker     *time.Ticker
 
-	WebsocketTrackerHttpHeader func() (http.Header, error)
+	WebsocketTrackerHttpHeader func() http.Header
 }
 
 func (me *TrackerClient) Stats() TrackerClientStats {
@@ -92,12 +92,7 @@ func (tc *TrackerClient) doWebsocket() error {
 
 	var header http.Header
 	if tc.WebsocketTrackerHttpHeader != nil {
-		var err error
-		header, err = tc.WebsocketTrackerHttpHeader()
-		if err != nil {
-			err = fmt.Errorf("error creating webtorrent tracker HTTP header: %w", err)
-			return err
-		}
+		header = tc.WebsocketTrackerHttpHeader()
 	}
 
 	c, _, err := tc.Dialer.Dial(tc.Url, header)

--- a/wstracker.go
+++ b/wstracker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	netHttp "net/http"
 	"net/url"
 	"sync"
 
@@ -35,14 +36,15 @@ type refCountedWebtorrentTrackerClient struct {
 }
 
 type websocketTrackers struct {
-	PeerId             [20]byte
-	Logger             log.Logger
-	GetAnnounceRequest func(event tracker.AnnounceEvent, infoHash [20]byte) (tracker.AnnounceRequest, error)
-	OnConn             func(datachannel.ReadWriteCloser, webtorrent.DataChannelContext)
-	mu                 sync.Mutex
-	clients            map[string]*refCountedWebtorrentTrackerClient
-	Proxy              http.ProxyFunc
-	DialContext        func(ctx context.Context, network, addr string) (net.Conn, error)
+	PeerId                      [20]byte
+	Logger                      log.Logger
+	GetAnnounceRequest          func(event tracker.AnnounceEvent, infoHash [20]byte) (tracker.AnnounceRequest, error)
+	OnConn                      func(datachannel.ReadWriteCloser, webtorrent.DataChannelContext)
+	mu                          sync.Mutex
+	clients                     map[string]*refCountedWebtorrentTrackerClient
+	Proxy                       http.ProxyFunc
+	DialContext                 func(ctx context.Context, network, addr string) (net.Conn, error)
+	WebtorrentTrackerHttpHeader func() (netHttp.Header, error)
 }
 
 func (me *websocketTrackers) Get(url string, infoHash [20]byte) (*webtorrent.TrackerClient, func()) {
@@ -61,6 +63,7 @@ func (me *websocketTrackers) Get(url string, infoHash [20]byte) (*webtorrent.Tra
 				Logger: me.Logger.WithText(func(m log.Msg) string {
 					return fmt.Sprintf("tracker client for %q: %v", url, m)
 				}),
+				WebtorrentTrackerHttpHeader: me.WebtorrentTrackerHttpHeader,
 			},
 		}
 		value.TrackerClient.Start(func(err error) {

--- a/wstracker.go
+++ b/wstracker.go
@@ -44,7 +44,7 @@ type websocketTrackers struct {
 	clients                    map[string]*refCountedWebtorrentTrackerClient
 	Proxy                      httpTracker.ProxyFunc
 	DialContext                func(ctx context.Context, network, addr string) (net.Conn, error)
-	WebsocketTrackerHttpHeader func() (netHttp.Header, error)
+	WebsocketTrackerHttpHeader func() netHttp.Header
 }
 
 func (me *websocketTrackers) Get(url string, infoHash [20]byte) (*webtorrent.TrackerClient, func()) {

--- a/wstracker.go
+++ b/wstracker.go
@@ -36,15 +36,15 @@ type refCountedWebtorrentTrackerClient struct {
 }
 
 type websocketTrackers struct {
-	PeerId                      [20]byte
-	Logger                      log.Logger
-	GetAnnounceRequest          func(event tracker.AnnounceEvent, infoHash [20]byte) (tracker.AnnounceRequest, error)
-	OnConn                      func(datachannel.ReadWriteCloser, webtorrent.DataChannelContext)
-	mu                          sync.Mutex
-	clients                     map[string]*refCountedWebtorrentTrackerClient
-	Proxy                       httpTracker.ProxyFunc
-	DialContext                 func(ctx context.Context, network, addr string) (net.Conn, error)
-	WebtorrentTrackerHttpHeader func() (netHttp.Header, error)
+	PeerId                     [20]byte
+	Logger                     log.Logger
+	GetAnnounceRequest         func(event tracker.AnnounceEvent, infoHash [20]byte) (tracker.AnnounceRequest, error)
+	OnConn                     func(datachannel.ReadWriteCloser, webtorrent.DataChannelContext)
+	mu                         sync.Mutex
+	clients                    map[string]*refCountedWebtorrentTrackerClient
+	Proxy                      httpTracker.ProxyFunc
+	DialContext                func(ctx context.Context, network, addr string) (net.Conn, error)
+	WebsocketTrackerHttpHeader func() (netHttp.Header, error)
 }
 
 func (me *websocketTrackers) Get(url string, infoHash [20]byte) (*webtorrent.TrackerClient, func()) {
@@ -63,7 +63,7 @@ func (me *websocketTrackers) Get(url string, infoHash [20]byte) (*webtorrent.Tra
 				Logger: me.Logger.WithText(func(m log.Msg) string {
 					return fmt.Sprintf("tracker client for %q: %v", url, m)
 				}),
-				WebtorrentTrackerHttpHeader: me.WebtorrentTrackerHttpHeader,
+				WebsocketTrackerHttpHeader: me.WebsocketTrackerHttpHeader,
 			},
 		}
 		value.TrackerClient.Start(func(err error) {


### PR DESCRIPTION
Expose a `WebtorrentTrackerHttpHeader` field in Client.config to let users define a function that returns an `http.Header` to be used in `Dialer.Dial()` when establishing a connection. Useful for adding authentication headers when using a private tracker, for example.

Addresses #784.