### PR TITLE
Add WebRTC peer connection transport stats

### DIFF
--- a/peerconn.go
+++ b/peerconn.go
@@ -27,7 +27,7 @@ import (
 	"github.com/anacrolix/torrent/mse"
 	pp "github.com/anacrolix/torrent/peer_protocol"
 	request_strategy "github.com/anacrolix/torrent/request-strategy"
-	"github.com/anacrolix/torrent/typed-roaring"
+	typedRoaring "github.com/anacrolix/torrent/typed-roaring"
 )
 
 type PeerSource string

--- a/torrent.go
+++ b/torrent.go
@@ -32,6 +32,7 @@ import (
 	"github.com/anacrolix/sync"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pion/datachannel"
+	"github.com/pion/webrtc/v3"
 
 	"github.com/anacrolix/torrent/bencode"
 	"github.com/anacrolix/torrent/common"
@@ -2539,6 +2540,19 @@ func (t *Torrent) iterUndirtiedRequestIndexesInPiece(
 		pieceRequestIndexOffset, pieceRequestIndexOffset+t.pieceNumChunks(piece),
 		f,
 	)
+}
+
+type webRtcStatsReports []webrtc.StatsReport
+
+func (t *Torrent) GetWebRtcPeerConnStats() map[string]webRtcStatsReports {
+	stats := make(map[string]webRtcStatsReports)
+	trackersMap := t.cl.websocketTrackers.clients
+	for i, trackerClient := range trackersMap {
+		ts := trackerClient.TransportStats()
+		stats[i] = ts
+	}
+
+	return stats
 }
 
 type requestState struct {

--- a/webtorrent/transport.go
+++ b/webtorrent/transport.go
@@ -39,14 +39,33 @@ type wrappedPeerConnection struct {
 	pproffd.CloseWrapper
 	span trace.Span
 	ctx  context.Context
+
+	onCloseHandler func()
 }
 
 func (me *wrappedPeerConnection) Close() error {
 	me.closeMu.Lock()
 	defer me.closeMu.Unlock()
+
+	me.onClose()
+
 	err := me.CloseWrapper.Close()
 	me.span.End()
 	return err
+}
+
+func (me *wrappedPeerConnection) OnClose(f func()) {
+	me.closeMu.Lock()
+	defer me.closeMu.Unlock()
+	me.onCloseHandler = f
+}
+
+func (me *wrappedPeerConnection) onClose() {
+	handler := me.onCloseHandler
+
+	if handler != nil {
+		handler()
+	}
 }
 
 func newPeerConnection(logger log.Logger) (*wrappedPeerConnection, error) {


### PR DESCRIPTION
Looks like there is still some timing issue, whereby sometimes `tc.transportStats` may be `null` if the file transfer is too short (small file on same machine, for example).
For larger file transfers, there is a high variability in the number of peer connections being created during the transfer (i.e. `len(tc.transportStats)`). Is this real or again a timing issue when appending new stats to the slice?

Still in draft for now.