### PR TITLE
Remove unecessary completion "set"

### DIFF
--- a/storage/file-piece.go
+++ b/storage/file-piece.go
@@ -28,20 +28,25 @@ func (fs *filePieceImpl) Completion() Completion {
 		c.Ok = false
 		return c
 	}
+
+	verified := true
 	if c.Complete {
 		// If it's allegedly complete, check that its constituent files have the necessary length.
 		for _, fi := range extentCompleteRequiredLengths(fs.p.Info, fs.p.Offset(), fs.p.Length()) {
 			s, err := os.Stat(fs.files[fi.fileIndex].path)
 			if err != nil || s.Size() < fi.length {
-				c.Complete = false
+				verified = false
 				break
 			}
 		}
 	}
-	if !c.Complete {
+
+	if !verified {
 		// The completion was wrong, fix it.
+		c.Complete = false
 		fs.completion.Set(fs.pieceKey(), false)
 	}
+
 	return c
 }
 


### PR DESCRIPTION
If the file has never been downloaded, complete will naturally be false. It's
not necessary to then set it false again unless it was actually claimed to be
true in the first place.

In my tests, using the boltdb completion thingy with fsync turned *on*, this
reduced the cold start for big buck bunny from multiple seconds to just a few
ms.
