### PR TITLE
downloader: speedup "--downloader.verify" mode

### DIFF
--- a/client.go
+++ b/client.go
@@ -1287,8 +1287,9 @@ func (cl *Client) newTorrentOpt(opts AddTorrentOpts) (t *Torrent) {
 		metadataChanged: sync.Cond{
 			L: cl.locker(),
 		},
-		webSeeds:     make(map[string]*Peer),
-		gotMetainfoC: make(chan struct{}),
+		webSeeds:       make(map[string]*Peer),
+		gotMetainfoC:   make(chan struct{}),
+		maxPieceHashes: cl.config.PieceHashersPerTorrent,
 	}
 	t.smartBanCache.Hash = sha1.Sum
 	t.smartBanCache.Init()

--- a/client.go
+++ b/client.go
@@ -1287,9 +1287,9 @@ func (cl *Client) newTorrentOpt(opts AddTorrentOpts) (t *Torrent) {
 		metadataChanged: sync.Cond{
 			L: cl.locker(),
 		},
-		webSeeds:       make(map[string]*Peer),
-		gotMetainfoC:   make(chan struct{}),
-		maxPieceHashes: cl.config.PieceHashersPerTorrent,
+		webSeeds:        make(map[string]*Peer),
+		gotMetainfoC:    make(chan struct{}),
+		maxPieceHashers: cl.config.PieceHashersPerTorrent,
 	}
 	t.smartBanCache.Hash = sha1.Sum
 	t.smartBanCache.Init()

--- a/config.go
+++ b/config.go
@@ -140,6 +140,8 @@ type ClientConfig struct {
 	TorrentPeersHighWater int
 	// Minumum number of peers before effort is made to obtain more peers.
 	TorrentPeersLowWater int
+	// Max number of "hasher" goroutines - which do read piece from disk (if need) and hash it
+	PieceHashersPerTorrent int
 
 	// Limit how long handshake can take. This is to reduce the lingering
 	// impact of a few bad apples. 4s loses 1% of successful handshakes that
@@ -205,6 +207,7 @@ func NewDefaultClientConfig() *ClientConfig {
 		TotalHalfOpenConns:             100,
 		TorrentPeersHighWater:          500,
 		TorrentPeersLowWater:           50,
+		PieceHashersPerTorrent:         2,
 		HandshakesTimeout:              4 * time.Second,
 		KeepAliveTimeout:               time.Minute,
 		MaxAllocPeerRequestDataPerConn: 1 << 20,

--- a/torrent.go
+++ b/torrent.go
@@ -149,6 +149,7 @@ type Torrent struct {
 	// Pieces that need to be hashed.
 	piecesQueuedForHash       bitmap.Bitmap
 	activePieceHashes         int
+	maxPieceHashes            int
 	initialPieceCheckDisabled bool
 
 	connsWithAllPieces map[*Peer]struct{}
@@ -2239,7 +2240,7 @@ func (t *Torrent) onIncompletePiece(piece pieceIndex) {
 }
 
 func (t *Torrent) tryCreateMorePieceHashers() {
-	for !t.closed.IsSet() && t.activePieceHashes < 1024 && t.tryCreatePieceHasher() {
+	for !t.closed.IsSet() && t.activePieceHashes < 2 && t.tryCreatePieceHasher() {
 	}
 }
 

--- a/torrent.go
+++ b/torrent.go
@@ -2239,7 +2239,7 @@ func (t *Torrent) onIncompletePiece(piece pieceIndex) {
 }
 
 func (t *Torrent) tryCreateMorePieceHashers() {
-	for !t.closed.IsSet() && t.activePieceHashes < 2 && t.tryCreatePieceHasher() {
+	for !t.closed.IsSet() && t.activePieceHashes < 1024 && t.tryCreatePieceHasher() {
 	}
 }
 

--- a/torrent.go
+++ b/torrent.go
@@ -149,7 +149,7 @@ type Torrent struct {
 	// Pieces that need to be hashed.
 	piecesQueuedForHash       bitmap.Bitmap
 	activePieceHashes         int
-	maxPieceHashes            int
+	maxPieceHashers           int
 	initialPieceCheckDisabled bool
 
 	connsWithAllPieces map[*Peer]struct{}
@@ -2240,7 +2240,7 @@ func (t *Torrent) onIncompletePiece(piece pieceIndex) {
 }
 
 func (t *Torrent) tryCreateMorePieceHashers() {
-	for !t.closed.IsSet() && t.activePieceHashes < 2 && t.tryCreatePieceHasher() {
+	for !t.closed.IsSet() && t.activePieceHashes < t.maxPieceHashers && t.tryCreatePieceHasher() {
 	}
 }
 


### PR DESCRIPTION
deduplicate logic
create more producer goroutines (torrent lib does limiting internally amount of consumers/disk-readers/hashers by 2, and it's enough because we can verify multiple files in parallel)
move flag from "downloader torrent_hashes --verify" to "downloader --verify" 