### PR TITLE
fix: udp tracker panic

### DIFF
--- a/tracker/udp/conn-client.go
+++ b/tracker/udp/conn-client.go
@@ -42,7 +42,8 @@ func (cc *ConnClient) reader() {
 			// read error.
 			cc.readErr = err
 			if !cc.closed {
-				panic(err)
+				// don't panic, just close the connection, fix https://github.com/anacrolix/torrent/issues/845
+				cc.Close()
 			}
 			break
 		}


### PR DESCRIPTION
fix https://github.com/anacrolix/torrent/issues/845

Some traker servers do not follow the udp traker specification, and the response packet returned is larger than the defined udp buffer size. We need to handle the error instead of panic.