### PR TITLE
don't return error when trying to read past EOF

### DIFF
--- a/fs/file_handle.go
+++ b/fs/file_handle.go
@@ -53,6 +53,9 @@ func (me fileHandle) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse
 			// can demand up to 16MiB at a time, so this gets tricky. For now, I'll restore the old
 			// behaviour from before 2a7352a, which nobody reported problems with.
 			n, readErr = io.ReadFull(r, resp.Data)
+			if readErr == io.ErrUnexpectedEOF {
+				readErr = nil
+		       }
 		} else {
 			n, readErr = r.Read(resp.Data)
 			if readErr == io.EOF {


### PR DESCRIPTION
I encountered a bug where when an application attempts to read "across" the EOF (i.e. try to read $x$ bytes starting at offset $y$ where $x+y > len(file)$ ). The application dies with "unexpected EOF".

This patch fixes the bug for me.

I suspect that the fuse library does not expect `Read` to return non-nil errors except when no data was able to be read, but wasn't able to get into that library enough to confirm.