### PR TITLE
Refinement of API Design with Introduction of AddTorrent2 Function

### DIFF
--- a/client.go
+++ b/client.go
@@ -1832,3 +1832,80 @@ func (cl *Client) addTorrentFromSpec(spec *TorrentSpec) (*Torrent, bool, error) 
 
 	return t, isNew, nil
 }
+
+// addTorrentReq hide all internal details from consumers of AddTorrent2 and allows you
+// to change it to any other style/way without breaking changes.
+type addTorrentReq interface {
+	isAddTorrentReq()
+}
+
+type rMagnetURI struct {
+	URI string
+}
+
+func (rMagnetURI) isAddTorrentReq() {}
+
+func FromMagnetURI(uri string) rMagnetURI {
+	return rMagnetURI{
+		URI: uri,
+	}
+}
+
+type rTorrentSpec struct {
+	Spec *TorrentSpec
+}
+
+func (rTorrentSpec) isAddTorrentReq() {}
+
+func FromTorrentSpec(spec *TorrentSpec) rTorrentSpec {
+	return rTorrentSpec{
+		Spec: spec,
+	}
+}
+
+type rTorrentOpts struct {
+	Opts AddTorrentOpts
+}
+
+func (rTorrentOpts) isAddTorrentReq() {}
+
+func FromTorrentOpts(opts AddTorrentOpts) rTorrentOpts {
+	return rTorrentOpts{
+		Opts: opts,
+	}
+}
+
+type rHash struct {
+	Hash metainfo.Hash
+}
+
+func (rHash) isAddTorrentReq() {}
+
+func FromHash(hash metainfo.Hash) rHash {
+	return rHash{Hash: hash}
+}
+
+type rMetaInfo struct {
+	Meta *metainfo.MetaInfo
+}
+
+func (rMetaInfo) isAddTorrentReq() {}
+
+func FromMetaInfo(metaInfo *metainfo.MetaInfo) rMetaInfo {
+	return rMetaInfo{
+		Meta: metaInfo,
+	}
+}
+
+type rFile struct {
+	Filename string
+}
+
+func (rFile) isAddTorrentReq() {}
+
+func FromFilename(filename string) rFile {
+	return rFile{
+		Filename: filename,
+	}
+}
+

--- a/client.go
+++ b/client.go
@@ -1310,14 +1310,6 @@ func (cl *Client) newTorrentOpt(opts AddTorrentOpts) (t *Torrent) {
 	return
 }
 
-// A file-like handle to some torrent data resource.
-type Handle interface {
-	io.Reader
-	io.Seeker
-	io.Closer
-	io.ReaderAt
-}
-
 // addTorrentReq hide all internal details from consumers of AddTorrent2 and allows you
 // to change it to any other style/way without breaking changes.
 type addTorrentReq interface {
@@ -1456,6 +1448,14 @@ func (cl *Client) AddTorrent2(_ context.Context, req addTorrentReq) (*Torrent, b
 
 		return t, isNew, nil
 	}
+}
+
+// A file-like handle to some torrent data resource.
+type Handle interface {
+	io.Reader
+	io.Seeker
+	io.Closer
+	io.ReaderAt
 }
 
 // AddTorrentInfoHash adds a torrent by InfoHash.

--- a/client.go
+++ b/client.go
@@ -1909,3 +1909,66 @@ func FromFilename(filename string) rFile {
 	}
 }
 
+// AddTorrent2 adds a torrent to client from different sources.
+// Returns a torrent object after successful adding. Returns true when torrent was not added
+// to the client before and false in other case.
+func (cl *Client) AddTorrent2(_ context.Context, req addTorrentReq) (*Torrent, bool, error) {
+	switch req := req.(type) {
+	default:
+		return nil, false, fmt.Errorf("unknown request type: %#v", req)
+	case rHash:
+		t, isNew := cl.addTorrentOpt(AddTorrentOpts{
+			InfoHash:  req.Hash,
+			Storage:   nil,
+			ChunkSize: 0,
+			InfoBytes: nil,
+		})
+		return t, isNew, nil
+	case rTorrentOpts:
+		t, isNew := cl.addTorrentOpt(req.Opts)
+		return t, isNew, nil
+	case rTorrentSpec:
+		return cl.addTorrentFromSpec(req.Spec)
+	case rMetaInfo:
+		tSpec, err := TorrentSpecFromMetaInfoErr(req.Meta)
+		if err != nil {
+			return nil, false, fmt.Errorf("torrent spec from metainfo: %w", err)
+		}
+
+		t, isNew, err := cl.addTorrentFromSpec(tSpec)
+		if err != nil {
+			return nil, false, fmt.Errorf("add torrent spec: %w", err)
+		}
+
+		return t, isNew, nil
+	case rMagnetURI:
+		spec, err := TorrentSpecFromMagnetUri(req.URI)
+		if err != nil {
+			return nil, false, fmt.Errorf("torrent spec from magnet uri: %w", err)
+		}
+
+		t, isNew, err := cl.addTorrentFromSpec(spec)
+		if err != nil {
+			return nil, false, fmt.Errorf("add torrent spec: %w", err)
+		}
+
+		return t, isNew, nil
+	case rFile:
+		meta, err := metainfo.LoadFromFile(req.Filename)
+		if err != nil {
+			return nil, false, fmt.Errorf("load metainfo: %w", err)
+		}
+
+		tSpec, err := TorrentSpecFromMetaInfoErr(meta)
+		if err != nil {
+			return nil, false, fmt.Errorf("torrent spec from metainfo: %w", err)
+		}
+
+		t, isNew, err := cl.addTorrentFromSpec(tSpec)
+		if err != nil {
+			return nil, false, fmt.Errorf("add torrent spec: %w", err)
+		}
+
+		return t, isNew, nil
+	}
+}

--- a/client.go
+++ b/client.go
@@ -1366,24 +1366,11 @@ func (cl *Client) AddTorrentOpt(opts AddTorrentOpts) (*Torrent, bool) {
 	return t, isNew
 }
 
-// Add or merge a torrent spec. Returns new if the torrent wasn't already in the client. See also
+// AddTorrentSpec add or merge a torrent spec. Returns new if the torrent wasn't already in the client. See also
 // Torrent.MergeSpec.
-func (cl *Client) AddTorrentSpec(spec *TorrentSpec) (t *Torrent, new bool, err error) {
-	t, new = cl.AddTorrentOpt(AddTorrentOpts{
-		InfoHash:  spec.InfoHash,
-		Storage:   spec.Storage,
-		ChunkSize: spec.ChunkSize,
-	})
-	modSpec := *spec
-	if new {
-		// ChunkSize was already applied by adding a new Torrent, and MergeSpec disallows changing
-		// it.
-		modSpec.ChunkSize = 0
-	}
-	err = t.MergeSpec(&modSpec)
-	if err != nil && new {
-		t.Drop()
-	}
+// Deprecated: use AddTorrent2 instead.
+func (cl *Client) AddTorrentSpec(spec *TorrentSpec) (t *Torrent, isNew bool, err error) {
+	t, isNew, err = cl.AddTorrent2(FromTorrentSpec(spec))
 	return
 }
 

--- a/client.go
+++ b/client.go
@@ -1374,6 +1374,27 @@ func (cl *Client) AddTorrentSpec(spec *TorrentSpec) (t *Torrent, isNew bool, err
 	return
 }
 
+// AddMagnet adds a torrent by magnet URI.
+// Deprecated: use AddTorrent2 instead.
+func (cl *Client) AddMagnet(uri string) (t *Torrent, err error) {
+	t, _, err = cl.AddTorrent2(FromMagnetURI(uri))
+	return
+}
+
+// AddTorrent adds a torrent by MetaInfo.
+// Deprecated: use AddTorrent2 instead.
+func (cl *Client) AddTorrent(mi *metainfo.MetaInfo) (t *Torrent, err error) {
+	t, _, err = cl.AddTorrent2(FromMetaInfo(mi))
+	return
+}
+
+// AddTorrentFromFile adds a torrent from filepath.
+// Deprecated: use AddTorrent2 instead.
+func (cl *Client) AddTorrentFromFile(filename string) (t *Torrent, err error) {
+	t, _, err = cl.AddTorrent2(FromFilename(filename))
+	return
+}
+
 // The trackers will be merged with the existing ones. If the Info isn't yet known, it will be set.
 // spec.DisallowDataDownload/Upload will be read and applied
 // The display name is replaced if the new spec provides one. Note that any `Storage` is ignored.
@@ -1462,32 +1483,6 @@ func (cl *Client) torrentsAsSlice() (ret []*Torrent) {
 		ret = append(ret, t)
 	}
 	return
-}
-
-func (cl *Client) AddMagnet(uri string) (T *Torrent, err error) {
-	spec, err := TorrentSpecFromMagnetUri(uri)
-	if err != nil {
-		return
-	}
-	T, _, err = cl.AddTorrentSpec(spec)
-	return
-}
-
-func (cl *Client) AddTorrent(mi *metainfo.MetaInfo) (T *Torrent, err error) {
-	ts, err := TorrentSpecFromMetaInfoErr(mi)
-	if err != nil {
-		return
-	}
-	T, _, err = cl.AddTorrentSpec(ts)
-	return
-}
-
-func (cl *Client) AddTorrentFromFile(filename string) (T *Torrent, err error) {
-	mi, err := metainfo.LoadFromFile(filename)
-	if err != nil {
-		return
-	}
-	return cl.AddTorrent(mi)
 }
 
 func (cl *Client) DhtServers() []DhtServer {

--- a/client.go
+++ b/client.go
@@ -1261,6 +1261,13 @@ func (cl *Client) badPeerIPPort(ip net.IP, port int) bool {
 	return false
 }
 
+type AddTorrentOpts struct {
+	InfoHash  infohash.T
+	Storage   storage.ClientImpl
+	ChunkSize pp.Integer
+	InfoBytes []byte
+}
+
 // Return a Torrent ready for insertion into a Client.
 func (cl *Client) newTorrent(ih metainfo.Hash, specStorage storage.ClientImpl) (t *Torrent) {
 	return cl.newTorrentOpt(AddTorrentOpts{
@@ -1373,13 +1380,6 @@ func (cl *Client) AddTorrentOpt(opts AddTorrentOpts) (t *Torrent, new bool) {
 	// Tickle Client.waitAccept, new torrent may want conns.
 	cl.event.Broadcast()
 	return
-}
-
-type AddTorrentOpts struct {
-	InfoHash  infohash.T
-	Storage   storage.ClientImpl
-	ChunkSize pp.Integer
-	InfoBytes []byte
 }
 
 // Add or merge a torrent spec. Returns new if the torrent wasn't already in the client. See also

--- a/client.go
+++ b/client.go
@@ -1419,27 +1419,6 @@ func (cl *Client) addTorrentFromSpec(spec *TorrentSpec) (*Torrent, bool, error) 
 	return t, isNew, nil
 }
 
-// AddMagnet adds a torrent by magnet URI.
-// Deprecated: use AddTorrent2 instead.
-func (cl *Client) AddMagnet(uri string) (t *Torrent, err error) {
-	t, _, err = cl.AddTorrent2(context.TODO(), FromMagnetURI(uri))
-	return
-}
-
-// AddTorrent adds a torrent by MetaInfo.
-// Deprecated: use AddTorrent2 instead.
-func (cl *Client) AddTorrent(mi *metainfo.MetaInfo) (t *Torrent, err error) {
-	t, _, err = cl.AddTorrent2(context.TODO(), FromMetaInfo(mi))
-	return
-}
-
-// AddTorrentFromFile adds a torrent from filepath.
-// Deprecated: use AddTorrent2 instead.
-func (cl *Client) AddTorrentFromFile(filename string) (t *Torrent, err error) {
-	t, _, err = cl.AddTorrent2(context.TODO(), FromFilename(filename))
-	return
-}
-
 // addTorrentReq hide all internal details from consumers of AddTorrent2 and allows you
 // to change it to any other style/way without breaking changes.
 type addTorrentReq interface {
@@ -1667,6 +1646,27 @@ func (cl *Client) torrentsAsSlice() (ret []*Torrent) {
 	for _, t := range cl.torrents {
 		ret = append(ret, t)
 	}
+	return
+}
+
+// AddMagnet adds a torrent by magnet URI.
+// Deprecated: use AddTorrent2 instead.
+func (cl *Client) AddMagnet(uri string) (t *Torrent, err error) {
+	t, _, err = cl.AddTorrent2(context.TODO(), FromMagnetURI(uri))
+	return
+}
+
+// AddTorrent adds a torrent by MetaInfo.
+// Deprecated: use AddTorrent2 instead.
+func (cl *Client) AddTorrent(mi *metainfo.MetaInfo) (t *Torrent, err error) {
+	t, _, err = cl.AddTorrent2(context.TODO(), FromMetaInfo(mi))
+	return
+}
+
+// AddTorrentFromFile adds a torrent from filepath.
+// Deprecated: use AddTorrent2 instead.
+func (cl *Client) AddTorrentFromFile(filename string) (t *Torrent, err error) {
+	t, _, err = cl.AddTorrent2(context.TODO(), FromFilename(filename))
 	return
 }
 

--- a/client.go
+++ b/client.go
@@ -1328,7 +1328,7 @@ type Handle interface {
 // AddTorrentInfoHash adds a torrent by InfoHash.
 // Deprecated: use AddTorrent2 instead.
 func (cl *Client) AddTorrentInfoHash(infoHash metainfo.Hash) (*Torrent, bool) {
-	t, isNew, err := cl.AddTorrent2(FromHash(infoHash))
+	t, isNew, err := cl.AddTorrent2(context.TODO(), FromHash(infoHash))
 	if err != nil {
 		return nil, false
 	}
@@ -1341,7 +1341,7 @@ func (cl *Client) AddTorrentInfoHash(infoHash metainfo.Hash) (*Torrent, bool) {
 // existing torrent returned with `new` set to `false`.
 // Deprecated: use AddTorrent2 instead.
 func (cl *Client) AddTorrentInfoHashWithStorage(infoHash metainfo.Hash, specStorage storage.ClientImpl) (*Torrent, bool) {
-	t, isNew, err := cl.AddTorrent2(FromTorrentOpts(AddTorrentOpts{
+	t, isNew, err := cl.AddTorrent2(context.TODO(), FromTorrentOpts(AddTorrentOpts{
 		InfoHash:  infoHash,
 		Storage:   specStorage,
 		ChunkSize: 0,
@@ -1358,7 +1358,7 @@ func (cl *Client) AddTorrentInfoHashWithStorage(infoHash metainfo.Hash, specStor
 // then this Storage is ignored and the existing torrent returned with `new` set to `false`.
 // Deprecated: use AddTorrent2 instead.
 func (cl *Client) AddTorrentOpt(opts AddTorrentOpts) (*Torrent, bool) {
-	t, isNew, err := cl.AddTorrent2(FromTorrentOpts(opts))
+	t, isNew, err := cl.AddTorrent2(context.TODO(), FromTorrentOpts(opts))
 	if err != nil {
 		return nil, false
 	}
@@ -1370,28 +1370,28 @@ func (cl *Client) AddTorrentOpt(opts AddTorrentOpts) (*Torrent, bool) {
 // Torrent.MergeSpec.
 // Deprecated: use AddTorrent2 instead.
 func (cl *Client) AddTorrentSpec(spec *TorrentSpec) (t *Torrent, isNew bool, err error) {
-	t, isNew, err = cl.AddTorrent2(FromTorrentSpec(spec))
+	t, isNew, err = cl.AddTorrent2(context.TODO(), FromTorrentSpec(spec))
 	return
 }
 
 // AddMagnet adds a torrent by magnet URI.
 // Deprecated: use AddTorrent2 instead.
 func (cl *Client) AddMagnet(uri string) (t *Torrent, err error) {
-	t, _, err = cl.AddTorrent2(FromMagnetURI(uri))
+	t, _, err = cl.AddTorrent2(context.TODO(), FromMagnetURI(uri))
 	return
 }
 
 // AddTorrent adds a torrent by MetaInfo.
 // Deprecated: use AddTorrent2 instead.
 func (cl *Client) AddTorrent(mi *metainfo.MetaInfo) (t *Torrent, err error) {
-	t, _, err = cl.AddTorrent2(FromMetaInfo(mi))
+	t, _, err = cl.AddTorrent2(context.TODO(), FromMetaInfo(mi))
 	return
 }
 
 // AddTorrentFromFile adds a torrent from filepath.
 // Deprecated: use AddTorrent2 instead.
 func (cl *Client) AddTorrentFromFile(filename string) (t *Torrent, err error) {
-	t, _, err = cl.AddTorrent2(FromFilename(filename))
+	t, _, err = cl.AddTorrent2(context.TODO(), FromFilename(filename))
 	return
 }
 

--- a/client.go
+++ b/client.go
@@ -1325,8 +1325,15 @@ type Handle interface {
 	io.ReaderAt
 }
 
-func (cl *Client) AddTorrentInfoHash(infoHash metainfo.Hash) (t *Torrent, new bool) {
-	return cl.AddTorrentInfoHashWithStorage(infoHash, nil)
+// AddTorrentInfoHash adds a torrent by InfoHash.
+// Deprecated: use AddTorrent2 instead.
+func (cl *Client) AddTorrentInfoHash(infoHash metainfo.Hash) (*Torrent, bool) {
+	t, isNew, err := cl.AddTorrent2(FromHash(infoHash))
+	if err != nil {
+		return nil, false
+	}
+
+	return t, isNew
 }
 
 // Adds a torrent by InfoHash with a custom Storage implementation.

--- a/client.go
+++ b/client.go
@@ -1261,13 +1261,6 @@ func (cl *Client) badPeerIPPort(ip net.IP, port int) bool {
 	return false
 }
 
-type AddTorrentOpts struct {
-	InfoHash  infohash.T
-	Storage   storage.ClientImpl
-	ChunkSize pp.Integer
-	InfoBytes []byte
-}
-
 // Return a Torrent ready for insertion into a Client.
 func (cl *Client) newTorrent(ih metainfo.Hash, specStorage storage.ClientImpl) (t *Torrent) {
 	return cl.newTorrentOpt(AddTorrentOpts{
@@ -1364,6 +1357,13 @@ func (cl *Client) AddTorrentOpt(opts AddTorrentOpts) (*Torrent, bool) {
 	}
 
 	return t, isNew
+}
+
+type AddTorrentOpts struct {
+	InfoHash  infohash.T
+	Storage   storage.ClientImpl
+	ChunkSize pp.Integer
+	InfoBytes []byte
 }
 
 // AddTorrentSpec add or merge a torrent spec. Returns new if the torrent wasn't already in the client. See also


### PR DESCRIPTION
Related with #369 

I have carefully reviewed the discussions in thread #243 regarding the design of a new API, but it appears that a definitive decision has not been reached. In response, I have proposed a straightforward solution that maintains simplicity and allows for future refactoring without introducing breaking changes.


**Key Changes:**

- Introducing a new function named `AddTorrent2` to address the absence of an available name for the existing `AddTorrent` function. (do you have any idea about a new name?)
- All pre-existing functions now utilize the newly introduced `AddTorrent2` function.
- Deprecating all previous functions to guide users toward adopting the updated design.
- Incorporating the use of `context.Context` within the `AddTorrent2` function to facilitate potential internal library use in the future.
- Implementing the `addTorrentReq` interface and its associated implementations to provide flexibility for future design modifications without causing disruptions for end-users.

**Important Note:**

It has been observed that `AddTorrentInfoHashWithStorage` bears a striking resemblance to `AddTorrentOpt`, with the only discernible difference being the absence of `t.setInfoBytesLocked(opts.InfoBytes)` in the new version. While I believe this modification is secure, it is crucial to bring attention to this point for thorough consideration.