### PR TITLE
torrent.KnownSwarm: keep client lock when iterating over connections

### DIFF
--- a/torrent.go
+++ b/torrent.go
@@ -245,6 +245,8 @@ func (t *Torrent) KnownSwarm() (ks []PeerInfo) {
 	}
 
 	// Add active peers to the list
+	t.cl.rLock()
+	defer t.cl.rUnlock()
 	for conn := range t.conns {
 		ks = append(ks, PeerInfo{
 			Id:     conn.PeerID,


### PR DESCRIPTION
We started seeing some rate of panics after we added periodic `(*Torrent).KnownSwarm()` call for debugging purposes.
It looks like in a few other places operations with t.conns are processed while  t.cl.rLock() is held, replicating the same behavior.
```
fatal error: concurrent map iteration and map write

goroutine 86949826 [running]:
github.com/anacrolix/torrent.(*Torrent).KnownSwarm(0xc00355a000)
        go/src/github.com/anacrolix/torrent/torrent.go:248 +0x17d
...
```