### PR TITLE
Stop PRO tree traversal when allTorrentsUnverifiedBytes reaches MaxUnverifiedBytes

### DIFF
--- a/request-strategy/order.go
+++ b/request-strategy/order.go
@@ -67,22 +67,22 @@ func GetRequestablePieces(
 
 		ih := _i.key.InfoHash
 		t := input.Torrent(ih)
+		pieceLength := t.PieceLength()
+		if storageLeft != nil {
+			if *storageLeft < pieceLength {
+				return false
+			}
+			*storageLeft -= pieceLength
+		}
 		if t.IgnorePiece(_i.key.Index) {
 			// TODO: Clarify exactly what is verified. Stuff that's being hashed should be
 			// considered unverified and hold up further requests.
 			return true
 		}
 
-		pieceLength := t.PieceLength()
 		allTorrentsUnverifiedBytes += pieceLength
 		if input.MaxUnverifiedBytes() != 0 && allTorrentsUnverifiedBytes > input.MaxUnverifiedBytes() {
 			return false
-		}
-		if storageLeft != nil {
-			if *storageLeft < pieceLength {
-				return false
-			}
-			*storageLeft -= pieceLength
 		}
 
 		f(ih, _i.key.Index, _i.state)

--- a/request-strategy/order.go
+++ b/request-strategy/order.go
@@ -67,22 +67,24 @@ func GetRequestablePieces(
 
 		ih := _i.key.InfoHash
 		t := input.Torrent(ih)
+		if t.IgnorePiece(_i.key.Index) {
+			// TODO: Clarify exactly what is verified. Stuff that's being hashed should be
+			// considered unverified and hold up further requests.
+			return true
+		}
+
 		pieceLength := t.PieceLength()
+		allTorrentsUnverifiedBytes += pieceLength
+		if input.MaxUnverifiedBytes() != 0 && allTorrentsUnverifiedBytes > input.MaxUnverifiedBytes() {
+			return false
+		}
 		if storageLeft != nil {
 			if *storageLeft < pieceLength {
 				return false
 			}
 			*storageLeft -= pieceLength
 		}
-		if t.IgnorePiece(_i.key.Index) {
-			// TODO: Clarify exactly what is verified. Stuff that's being hashed should be
-			// considered unverified and hold up further requests.
-			return true
-		}
-		if input.MaxUnverifiedBytes() != 0 && allTorrentsUnverifiedBytes+pieceLength > input.MaxUnverifiedBytes() {
-			return true
-		}
-		allTorrentsUnverifiedBytes += pieceLength
+
 		f(ih, _i.key.Index, _i.state)
 		return true
 	})


### PR DESCRIPTION
If I understand correctly we should stop processing tree items once MaxUnverifiedBytes limit is reached.
Existing implementation still goes through the whole tree resolving pointer to the torrent and calling t.IgnorePiece(_i.key.Index) for each piece.

while here moving storage check at the very end since it's quite unlikely it'll return False compared to MaxUnverifiedBytes or t.IgnorePiece().