### PR TITLE
GetRequestablePieces: remove runtime correctness check

### DIFF
--- a/request-strategy/order.go
+++ b/request-strategy/order.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"expvar"
 
-	g "github.com/anacrolix/generics"
 	"github.com/anacrolix/multiless"
 
 	"github.com/anacrolix/torrent/metainfo"
@@ -55,16 +54,7 @@ func GetRequestablePieces(
 		storageLeft = &cap
 	}
 	var allTorrentsUnverifiedBytes int64
-	var lastItem g.Option[pieceRequestOrderItem]
 	pro.tree.Scan(func(_i pieceRequestOrderItem) bool {
-		// Check that scan emits pieces in priority order.
-		if lastItem.Ok {
-			if _i.Less(&lastItem.Value) {
-				panic("scan not in order")
-			}
-		}
-		lastItem.Set(_i)
-
 		ih := _i.key.InfoHash
 		t := input.Torrent(ih)
 		pieceLength := t.PieceLength()


### PR DESCRIPTION
In profiles I collected correctness check https://github.com/anacrolix/torrent/blob/c73c99b372114204b3e62ab7fe7103b2477c7dee/request-strategy/order.go#L60-L66 takes up to 10% cpu time. Would it make sense to remove it from runtime and add a unit-test for that instead (if not already)?

<img width="1727" alt="Screenshot 2024-02-07 at 11 25 12 PM" src="https://github.com/anacrolix/torrent/assets/6113489/874d95fe-c5bd-4457-9704-2c32c4683338">

additional discussion is in https://github.com/anacrolix/torrent/issues/897#issuecomment-1933596287
