### PR TITLE
Support ICE servers auth

### DIFF
--- a/client.go
+++ b/client.go
@@ -35,6 +35,7 @@ import (
 	"github.com/dustin/go-humanize"
 	gbtree "github.com/google/btree"
 	"github.com/pion/datachannel"
+	"github.com/pion/webrtc/v3"
 
 	"github.com/anacrolix/torrent/bencode"
 	"github.com/anacrolix/torrent/internal/check"
@@ -1841,6 +1842,10 @@ func (cl *Client) locker() *lockWithDeferreds {
 
 func (cl *Client) String() string {
 	return fmt.Sprintf("<%[1]T %[1]p>", cl)
+}
+
+func (cl *Client) ICEServers() []webrtc.ICEServer {
+	return cl.config.ICEServers
 }
 
 // Returns connection-level aggregate connStats at the Client level. See the comment on

--- a/client.go
+++ b/client.go
@@ -311,6 +311,13 @@ func NewClient(cfg *ClientConfig) (cl *Client, err error) {
 		}
 	}
 
+	var ICEServers []webrtc.ICEServer
+	if cl.config.ICEServerList != nil {
+		ICEServers = cl.config.ICEServerList
+	} else if cl.config.ICEServers != nil {
+		ICEServers = []webrtc.ICEServer{{URLs: cl.config.ICEServers}}
+	}
+
 	cl.websocketTrackers = websocketTrackers{
 		PeerId: cl.peerID,
 		Logger: cl.logger,
@@ -329,7 +336,7 @@ func NewClient(cfg *ClientConfig) (cl *Client, err error) {
 		},
 		Proxy:                      cl.config.HTTPProxy,
 		WebsocketTrackerHttpHeader: cl.config.WebsocketTrackerHttpHeader,
-		ICEServers:                 cl.config.ICEServers,
+		ICEServers:                 ICEServers,
 		DialContext:                cl.config.TrackerDialContext,
 		OnConn: func(dc datachannel.ReadWriteCloser, dcc webtorrent.DataChannelContext) {
 			cl.lock()
@@ -1845,7 +1852,13 @@ func (cl *Client) String() string {
 }
 
 func (cl *Client) ICEServers() []webrtc.ICEServer {
-	return cl.config.ICEServers
+	var ICEServers []webrtc.ICEServer
+	if cl.config.ICEServerList != nil {
+		ICEServers = cl.config.ICEServerList
+	} else if cl.config.ICEServers != nil {
+		ICEServers = []webrtc.ICEServer{{URLs: cl.config.ICEServers}}
+	}
+	return ICEServers
 }
 
 // Returns connection-level aggregate connStats at the Client level. See the comment on

--- a/config.go
+++ b/config.go
@@ -185,9 +185,13 @@ type ClientConfig struct {
 
 	Callbacks Callbacks
 
-	// ICEServers defines a slice describing servers available to be used by
+	// ICEServerList defines a slice describing servers available to be used by
 	// ICE, such as STUN and TURN servers.
-	ICEServers []webrtc.ICEServer
+	ICEServerList []webrtc.ICEServer
+
+	// Legacy support. ICEServers does not support server authentication and therefore
+	// it cannot be used with most TURN servers. Use ICEServerList instead.
+	ICEServers []string
 
 	DialRateLimiter *rate.Limiter
 

--- a/config.go
+++ b/config.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/pion/webrtc/v3"
+
 	"github.com/anacrolix/dht/v2"
 	"github.com/anacrolix/dht/v2/krpc"
 	"github.com/anacrolix/log"
@@ -185,7 +187,7 @@ type ClientConfig struct {
 
 	// ICEServers defines a slice describing servers available to be used by
 	// ICE, such as STUN and TURN servers.
-	ICEServers []string
+	ICEServers []webrtc.ICEServer
 
 	DialRateLimiter *rate.Limiter
 

--- a/config.go
+++ b/config.go
@@ -7,12 +7,11 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/pion/webrtc/v3"
-
 	"github.com/anacrolix/dht/v2"
 	"github.com/anacrolix/dht/v2/krpc"
 	"github.com/anacrolix/log"
 	"github.com/anacrolix/missinggo/v2"
+	"github.com/pion/webrtc/v3"
 	"golang.org/x/time/rate"
 
 	"github.com/anacrolix/torrent/iplist"

--- a/config.go
+++ b/config.go
@@ -188,8 +188,9 @@ type ClientConfig struct {
 	// ICE, such as STUN and TURN servers.
 	ICEServerList []webrtc.ICEServer
 
-	// Legacy support. ICEServers does not support server authentication and therefore
+	// Deprecated. ICEServers does not support server authentication and therefore
 	// it cannot be used with most TURN servers. Use ICEServerList instead.
+	// ICEServers is kept for legacy support.
 	ICEServers []string
 
 	DialRateLimiter *rate.Limiter

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,6 @@ github.com/anacrolix/multiless v0.3.0 h1:5Bu0DZncjE4e06b9r1Ap2tUY4Au0NToBP5RpuEn
 github.com/anacrolix/multiless v0.3.0/go.mod h1:TrCLEZfIDbMVfLoQt5tOoiBS/uq4y8+ojuEVVvTNPX4=
 github.com/anacrolix/possum/go v0.1.1-0.20240309232535-7d660fa365f8 h1:XDKUI9RHyhyfGXVXb/4N+l5kGo5jQITrrbF7EZPLuak=
 github.com/anacrolix/possum/go v0.1.1-0.20240309232535-7d660fa365f8/go.mod h1:pw5HEMBSiL+otYzHe4q5jGaVuy5unl+Mt4Bx6SDemW8=
-github.com/anacrolix/squirrel v0.6.0 h1:ovfWW42wcGzrVYYI9s56pEYzfeTwtXxCCvSd+KwvUEA=
-github.com/anacrolix/squirrel v0.6.0/go.mod h1:60vdNPUbK1jYWePp39Wqn9whHm12Yb9JEuwOXzLMDuY=
 github.com/anacrolix/squirrel v0.6.4 h1:K6ABRMCms0xwpEIdY3kAaDBUqiUeUYCKLKI0yHTr9IQ=
 github.com/anacrolix/squirrel v0.6.4/go.mod h1:0kFVjOLMOKVOet6ja2ac1vTOrqVbLj2zy2Fjp7+dkE8=
 github.com/anacrolix/stm v0.2.0/go.mod h1:zoVQRvSiGjGoTmbM0vSLIiaKjWtNPeTvXUSdJQA4hsg=

--- a/webtorrent/tracker-client.go
+++ b/webtorrent/tracker-client.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/anacrolix/torrent/types/infohash"
-
 	g "github.com/anacrolix/generics"
 	"github.com/anacrolix/log"
 	"github.com/gorilla/websocket"

--- a/webtorrent/tracker-client.go
+++ b/webtorrent/tracker-client.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/anacrolix/torrent/types/infohash"
+
 	g "github.com/anacrolix/generics"
 	"github.com/anacrolix/log"
 	"github.com/gorilla/websocket"
@@ -43,7 +45,7 @@ type TrackerClient struct {
 	pingTicker     *time.Ticker
 
 	WebsocketTrackerHttpHeader func() http.Header
-	ICEServers                 []string
+	ICEServers                 []webrtc.ICEServer
 }
 
 func (me *TrackerClient) Stats() TrackerClientStats {

--- a/webtorrent/transport.go
+++ b/webtorrent/transport.go
@@ -48,12 +48,12 @@ func (me *wrappedPeerConnection) Close() error {
 	return err
 }
 
-func newPeerConnection(logger log.Logger, iceServers []string) (*wrappedPeerConnection, error) {
+func newPeerConnection(logger log.Logger, iceServers []webrtc.ICEServer) (*wrappedPeerConnection, error) {
 	newPeerConnectionMu.Lock()
 	defer newPeerConnectionMu.Unlock()
 	ctx, span := otel.Tracer(tracerName).Start(context.Background(), "PeerConnection")
 
-	pcConfig := webrtc.Configuration{ICEServers: []webrtc.ICEServer{{URLs: iceServers}}}
+	pcConfig := webrtc.Configuration{ICEServers: iceServers}
 
 	pc, err := api.NewPeerConnection(pcConfig)
 	if err != nil {

--- a/wstracker.go
+++ b/wstracker.go
@@ -8,8 +8,6 @@ import (
 	"net/url"
 	"sync"
 
-	"github.com/anacrolix/torrent/webtorrent"
-
 	"github.com/anacrolix/log"
 	"github.com/gorilla/websocket"
 	"github.com/pion/datachannel"

--- a/wstracker.go
+++ b/wstracker.go
@@ -8,9 +8,12 @@ import (
 	"net/url"
 	"sync"
 
+	"github.com/anacrolix/torrent/webtorrent"
+
 	"github.com/anacrolix/log"
 	"github.com/gorilla/websocket"
 	"github.com/pion/datachannel"
+	"github.com/pion/webrtc/v3"
 
 	"github.com/anacrolix/torrent/tracker"
 	httpTracker "github.com/anacrolix/torrent/tracker/http"
@@ -45,7 +48,7 @@ type websocketTrackers struct {
 	Proxy                      httpTracker.ProxyFunc
 	DialContext                func(ctx context.Context, network, addr string) (net.Conn, error)
 	WebsocketTrackerHttpHeader func() netHttp.Header
-	ICEServers                 []string
+	ICEServers                 []webrtc.ICEServer
 }
 
 func (me *websocketTrackers) Get(url string, infoHash [20]byte) (*webtorrent.TrackerClient, func()) {


### PR DESCRIPTION
Support passing ICE servers of type `[]webrtc.ICEServer` to the client config. This effectively enables the use of TURN servers when NAT traversal is needed. TURN servers normally require authentication, and the current implementation doesn't allow for that in the client config.

Fixes #903.