### PR TITLE
Ignore pieces with availability of 0

### DIFF
--- a/request-strategy/order.go
+++ b/request-strategy/order.go
@@ -67,6 +67,9 @@ func GetRequestablePieces(
 			// considered unverified and hold up further requests.
 			return true
 		}
+		if _i.state.Availability == 0 {
+			return false
+		}
 		if input.MaxUnverifiedBytes() != 0 && allTorrentsUnverifiedBytes+pieceLength > input.MaxUnverifiedBytes() {
 			return false
 		}


### PR DESCRIPTION
resolves: #916 
Pieces with zero availability shouldn't
consume MaxUnverifiedBytes and shouldn't
be prioritised.