### PR TITLE
Tidy up client ICEServers

### DIFF
--- a/client.go
+++ b/client.go
@@ -311,13 +311,6 @@ func NewClient(cfg *ClientConfig) (cl *Client, err error) {
 		}
 	}
 
-	var ICEServers []webrtc.ICEServer
-	if cl.config.ICEServerList != nil {
-		ICEServers = cl.config.ICEServerList
-	} else if cl.config.ICEServers != nil {
-		ICEServers = []webrtc.ICEServer{{URLs: cl.config.ICEServers}}
-	}
-
 	cl.websocketTrackers = websocketTrackers{
 		PeerId: cl.peerID,
 		Logger: cl.logger,
@@ -336,7 +329,7 @@ func NewClient(cfg *ClientConfig) (cl *Client, err error) {
 		},
 		Proxy:                      cl.config.HTTPProxy,
 		WebsocketTrackerHttpHeader: cl.config.WebsocketTrackerHttpHeader,
-		ICEServers:                 ICEServers,
+		ICEServers:                 cl.ICEServers(),
 		DialContext:                cl.config.TrackerDialContext,
 		OnConn: func(dc datachannel.ReadWriteCloser, dcc webtorrent.DataChannelContext) {
 			cl.lock()


### PR DESCRIPTION
Remove code repetition when initialising `Client.websocketTrackers`.