### PR TITLE
Webseed update timer

### DIFF
--- a/requesting.go
+++ b/requesting.go
@@ -312,13 +312,22 @@ func (p *Peer) applyRequestState(next desiredRequestState) {
 		if cap(next.Requests.requestIndexes) != cap(orig) {
 			panic("changed")
 		}
+
+		if p.needRequestUpdate == "Peer.remoteRejectedRequest" {
+			continue
+		}
+
 		existing := t.requestingPeer(req)
 		if existing != nil && existing != p {
+			if p.needRequestUpdate == "Peer.cancel" {
+				continue
+			}
+
 			// Don't steal from the poor.
 			diff := int64(current.Requests.GetCardinality()) + 1 - (int64(existing.uncancelledRequests()) - 1)
 			// Steal a request that leaves us with one more request than the existing peer
 			// connection if the stealer more recently received a chunk.
-			if diff > 1 || (diff == 1 && p.lastUsefulChunkReceived.Before(existing.lastUsefulChunkReceived)) {
+			if diff > 1 || (diff == 1 && !p.lastUsefulChunkReceived.After(existing.lastUsefulChunkReceived)) {
 				continue
 			}
 			t.cancelRequest(req)

--- a/webseed-peer.go
+++ b/webseed-peer.go
@@ -27,7 +27,7 @@ type webseedPeer struct {
 	client           webseed.Client
 	activeRequests   map[Request]webseed.Request
 	requesterCond    sync.Cond
-	updateRequestor  *time.Timer
+	updateRequester  *time.Timer
 	lastUnhandledErr time.Time
 }
 
@@ -122,16 +122,16 @@ func (ws *webseedPeer) requester(i int) {
 
 		if !restart {
 			if !ws.peer.t.dataDownloadDisallowed.Bool() && ws.peer.isLowOnRequests() && len(ws.peer.getDesiredRequestState().Requests.requestIndexes) > 0 {
-				if ws.updateRequestor == nil {
-					ws.updateRequestor = time.AfterFunc(updateRequestsTimerDuration, func() { requestUpdate(ws) })
+				if ws.updateRequester == nil {
+					ws.updateRequester = time.AfterFunc(updateRequestsTimerDuration, func() { requestUpdate(ws) })
 				}
 			}
 
 			ws.requesterCond.Wait()
 
-			if ws.updateRequestor != nil {
-				ws.updateRequestor.Stop()
-				ws.updateRequestor = nil
+			if ws.updateRequester != nil {
+				ws.updateRequester.Stop()
+				ws.updateRequester = nil
 			}
 		}
 	}

--- a/webseed-peer.go
+++ b/webseed-peer.go
@@ -27,6 +27,7 @@ type webseedPeer struct {
 	client           webseed.Client
 	activeRequests   map[Request]webseed.Request
 	requesterCond    sync.Cond
+	updateRequestor  *time.Timer
 	lastUnhandledErr time.Time
 }
 
@@ -72,7 +73,6 @@ func (ws *webseedPeer) intoSpec(r Request) webseed.RequestSpec {
 }
 
 func (ws *webseedPeer) _request(r Request) bool {
-	ws.requesterCond.Signal()
 	return true
 }
 
@@ -91,15 +91,17 @@ func (ws *webseedPeer) doRequest(r Request) error {
 func (ws *webseedPeer) requester(i int) {
 	ws.requesterCond.L.Lock()
 	defer ws.requesterCond.L.Unlock()
-start:
+
 	for !ws.peer.closed.IsSet() {
 		// Restart is set if we don't need to wait for the requestCond before trying again.
 		restart := false
+
 		ws.peer.requestState.Requests.Iterate(func(x RequestIndex) bool {
 			r := ws.peer.t.requestIndexToRequest(x)
 			if _, ok := ws.activeRequests[r]; ok {
 				return true
 			}
+
 			err := ws.doRequest(r)
 			ws.requesterCond.L.Unlock()
 			if err != nil && !errors.Is(err, context.Canceled) {
@@ -117,10 +119,38 @@ start:
 			ws.requesterCond.L.Lock()
 			return false
 		})
-		if restart {
-			goto start
+
+		if !restart {
+			if !ws.peer.t.dataDownloadDisallowed.Bool() && ws.peer.isLowOnRequests() && len(ws.peer.getDesiredRequestState().Requests.requestIndexes) > 0 {
+				if ws.updateRequestor == nil {
+					ws.updateRequestor = time.AfterFunc(updateRequestsTimerDuration, func() { requestUpdate(ws) })
+				}
+			}
+
+			ws.requesterCond.Wait()
+
+			if ws.updateRequestor != nil {
+				ws.updateRequestor.Stop()
+				ws.updateRequestor = nil
+			}
 		}
-		ws.requesterCond.Wait()
+	}
+}
+
+func requestUpdate(ws *webseedPeer) {
+	if ws != nil {
+		if !ws.peer.closed.IsSet() {
+			if len(ws.peer.getDesiredRequestState().Requests.requestIndexes) > 0 {
+				if ws.peer.isLowOnRequests() {
+					if time.Since(ws.peer.lastRequestUpdate) > updateRequestsTimerDuration {
+						ws.peer.updateRequests(peerUpdateRequestsTimerReason)
+						return
+					}
+				}
+
+				ws.requesterCond.Signal()
+			}
+		}
 	}
 }
 
@@ -142,6 +172,7 @@ func (ws *webseedPeer) handleUpdateRequests() {
 		ws.peer.t.cl.lock()
 		defer ws.peer.t.cl.unlock()
 		ws.peer.maybeUpdateActualRequestState()
+		ws.requesterCond.Signal()
 	}()
 }
 


### PR DESCRIPTION
This fixes an issue with small files (1 to 2 pieces) when they are seeded from web peers into a sparse torrent network.

If there are a significant number of peers in the network which don't have the requested torrent on initial download a webpeer with the file is not guaranteed to be the selected request provider.  When this happens if the webpeer does not do an update to its request state it will wait forever and the torrent will never get downloaded.

This fix also includes an update to steal processing in `applyRequestState` - so that rejecting and cancelled peers do not steal from a potentially good peer.   Also the steal logic uses after instead of before in its time logic, to avoid a peer with equal time (which is zero at initial download) preemptively stealing as this creates a chain reaction on initial download.