### PR TITLE
fix: upnp clear loop trap

### DIFF
--- a/portfwd.go
+++ b/portfwd.go
@@ -72,10 +72,10 @@ func (cl *Client) clearPortMappings() {
 	var wg sync.WaitGroup
 	wg.Add(mLen)
 	for _, m := range cl.upnpMappings {
-		go func() {
+		go func(m *upnpMapping) {
 			defer wg.Done()
 			cl.deletePortMapping(m.d, m.proto, m.externalPort)
-		}()
+		}(m)
 	}
 	cl.upnpMappings = nil
 }


### PR DESCRIPTION
Accroding to https://github.com/anacrolix/torrent/pull/942#issuecomment-2131309178 , it no problem with go 1.22 or above, but we can still consider fixing it to improve compatibility with old go versions.