### PR TITLE
remove golang.org/x/exp since it doesn't follow go 1 compatibility promise

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.11.1
 	go.opentelemetry.io/otel/sdk v1.11.1
 	go.opentelemetry.io/otel/trace v1.11.1
-	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
 	golang.org/x/sync v0.7.0
 	golang.org/x/sys v0.18.0
 	golang.org/x/time v0.0.0-20220609170525-579cf78fd858
@@ -136,6 +135,7 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
+	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect

--- a/internal/exp/maps/maps.go
+++ b/internal/exp/maps/maps.go
@@ -1,0 +1,21 @@
+package maps
+
+// Keys returns the keys of the map m.
+// The keys will be in an indeterminate order.
+func Keys[M ~map[K]V, K comparable, V any](m M) []K {
+	r := make([]K, 0, len(m))
+	for k := range m {
+		r = append(r, k)
+	}
+	return r
+}
+
+// Values returns the values of the map m.
+// The values will be in an indeterminate order.
+func Values[M ~map[K]V, K comparable, V any](m M) []V {
+	r := make([]V, 0, len(m))
+	for _, v := range m {
+		r = append(r, v)
+	}
+	return r
+}

--- a/metainfo/file-tree.go
+++ b/metainfo/file-tree.go
@@ -4,9 +4,9 @@ import (
 	"sort"
 
 	g "github.com/anacrolix/generics"
-	"golang.org/x/exp/maps"
 
 	"github.com/anacrolix/torrent/bencode"
+	"github.com/anacrolix/torrent/internal/exp/maps"
 )
 
 const FileTreePropertiesKey = ""

--- a/peerconn.go
+++ b/peerconn.go
@@ -21,11 +21,11 @@ import (
 	"github.com/anacrolix/log"
 	"github.com/anacrolix/missinggo/v2/bitmap"
 	"github.com/anacrolix/multiless"
-	"golang.org/x/exp/maps"
 	"golang.org/x/time/rate"
 
 	"github.com/anacrolix/torrent/bencode"
 	"github.com/anacrolix/torrent/internal/alloclim"
+	"github.com/anacrolix/torrent/internal/exp/maps"
 	"github.com/anacrolix/torrent/merkle"
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/anacrolix/torrent/mse"

--- a/tests/peers-bootstrapping/main.go
+++ b/tests/peers-bootstrapping/main.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -13,7 +14,6 @@ import (
 	"github.com/anacrolix/log"
 	"github.com/anacrolix/sync"
 	"github.com/dustin/go-humanize"
-	"golang.org/x/exp/slog"
 
 	"github.com/anacrolix/torrent"
 	"github.com/anacrolix/torrent/bencode"

--- a/torrent.go
+++ b/torrent.go
@@ -32,11 +32,11 @@ import (
 	"github.com/anacrolix/multiless"
 	"github.com/anacrolix/sync"
 	"github.com/pion/datachannel"
-	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/anacrolix/torrent/bencode"
 	"github.com/anacrolix/torrent/internal/check"
+	"github.com/anacrolix/torrent/internal/exp/maps"
 	"github.com/anacrolix/torrent/internal/nestedmaps"
 	"github.com/anacrolix/torrent/merkle"
 	"github.com/anacrolix/torrent/metainfo"


### PR DESCRIPTION
[document](https://pkg.go.dev/golang.org/x/exp#section-readme) says `golang.org/x/exp` doesn't follow go 1 compatibility promise, so copy the package we used to internal for future compatibility promise.

In the future if downsteam user import exp with a newer non-compatibility version it will get unexpected surprise.

it's still a indirect dependency from `github.com/anacrolix/generics`, so I suggest to remove it from `github.com/anacrolix/generics` too