### PR TITLE
Expose WebRTC peerconn stats

### DIFF
--- a/torrent.go
+++ b/torrent.go
@@ -3003,16 +3003,15 @@ func (t *Torrent) iterUndirtiedRequestIndexesInPiece(
 	)
 }
 
-type webRtcStatsReports []webrtc.StatsReport
+type webRtcStatsReports map[string]webrtc.StatsReport
 
 func (t *Torrent) GetWebRtcPeerConnStats() map[string]webRtcStatsReports {
 	stats := make(map[string]webRtcStatsReports)
 	trackersMap := t.cl.websocketTrackers.clients
 	for i, trackerClient := range trackersMap {
-		ts := trackerClient.TransportStats()
+		ts := trackerClient.RtcPeerConnStats()
 		stats[i] = ts
 	}
-
 	return stats
 }
 

--- a/torrent.go
+++ b/torrent.go
@@ -33,6 +33,7 @@ import (
 	"github.com/anacrolix/multiless"
 	"github.com/anacrolix/sync"
 	"github.com/pion/datachannel"
+	"github.com/pion/webrtc/v3"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/anacrolix/torrent/bencode"
@@ -3000,6 +3001,19 @@ func (t *Torrent) iterUndirtiedRequestIndexesInPiece(
 		pieceRequestIndexOffset, pieceRequestIndexOffset+t.pieceNumChunks(piece),
 		f,
 	)
+}
+
+type webRtcStatsReports []webrtc.StatsReport
+
+func (t *Torrent) GetWebRtcPeerConnStats() map[string]webRtcStatsReports {
+	stats := make(map[string]webRtcStatsReports)
+	trackersMap := t.cl.websocketTrackers.clients
+	for i, trackerClient := range trackersMap {
+		ts := trackerClient.TransportStats()
+		stats[i] = ts
+	}
+
+	return stats
 }
 
 type requestState struct {

--- a/webtorrent/peer-conn-stats.go
+++ b/webtorrent/peer-conn-stats.go
@@ -1,0 +1,15 @@
+//go:build !js
+// +build !js
+
+package webtorrent
+
+import (
+	"github.com/pion/webrtc/v3"
+)
+
+func GetPeerConnStats(pc *wrappedPeerConnection) (stats webrtc.StatsReport) {
+	if pc != nil {
+		stats = pc.GetStats()
+	}
+	return
+}

--- a/webtorrent/peer-conn-stats_js.go
+++ b/webtorrent/peer-conn-stats_js.go
@@ -1,0 +1,13 @@
+//go:build js && wasm
+// +build js,wasm
+
+package webtorrent
+
+import (
+	"github.com/pion/webrtc/v3"
+)
+
+// webrtc.PeerConnection.GetStats() is not currently supported for WASM. Return empty stats.
+func GetPeerConnStats(pc *wrappedPeerConnection) (stats webrtc.StatsReport) {
+	return
+}

--- a/webtorrent/tracker-client.go
+++ b/webtorrent/tracker-client.go
@@ -45,7 +45,7 @@ type TrackerClient struct {
 	WebsocketTrackerHttpHeader func() http.Header
 	ICEServers                 []webrtc.ICEServer
 
-	transportStats []webrtc.StatsReport
+	rtcPeerConns map[string]*wrappedPeerConnection
 }
 
 func (me *TrackerClient) Stats() TrackerClientStats {
@@ -236,9 +236,11 @@ func (tc *TrackerClient) Announce(event tracker.AnnounceEvent, infoHash [20]byte
 		return fmt.Errorf("creating offer: %w", err)
 	}
 
+	// save the leecher peer connections
+	tc.storePeerConnection(offerIDBinary, pc)
+
 	pc.OnClose(func() {
-		stats := pc.GetStats()
-		tc.transportStats = append(tc.transportStats, stats)
+		delete(tc.rtcPeerConns, offerIDBinary)
 	})
 
 	tc.Logger.Levelf(log.Debug, "announcing offer")
@@ -298,8 +300,17 @@ func (tc *TrackerClient) announce(event tracker.AnnounceEvent, infoHash [20]byte
 	return nil
 }
 
-func (tc *TrackerClient) TransportStats() []webrtc.StatsReport {
-	return tc.transportStats
+// Calculate the stats for all the peer connections the moment they are requested.
+// As the stats will change over the life of a peer connection, this ensures that
+// the updated values are returned.
+func (tc *TrackerClient) RtcPeerConnStats() map[string]webrtc.StatsReport {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	sr := make(map[string]webrtc.StatsReport)
+	for id, pc := range tc.rtcPeerConns {
+		sr[id] = pc.GetStats()
+	}
+	return sr
 }
 
 func (tc *TrackerClient) writeMessage(data []byte) error {
@@ -368,6 +379,10 @@ func (tc *TrackerClient) handleOffer(
 	if err != nil {
 		return fmt.Errorf("creating answering peer connection: %w", err)
 	}
+
+	// save the seeder peer connections
+	tc.storePeerConnection(offerContext.Id, peerConnection)
+
 	response := AnnounceResponse{
 		Action:   "announce",
 		InfoHash: binaryToJsonString(offerContext.InfoHash[:]),
@@ -409,4 +424,13 @@ func (tc *TrackerClient) handleAnswer(offerId string, answer webrtc.SessionDescr
 	}
 	delete(tc.outboundOffers, offerId)
 	go tc.Announce(tracker.None, offer.infoHash)
+}
+
+func (tc *TrackerClient) storePeerConnection(offerId string, pc *wrappedPeerConnection) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	if tc.rtcPeerConns == nil {
+		tc.rtcPeerConns = make(map[string]*wrappedPeerConnection)
+	}
+	tc.rtcPeerConns[offerId] = pc
 }

--- a/webtorrent/tracker-client.go
+++ b/webtorrent/tracker-client.go
@@ -308,7 +308,7 @@ func (tc *TrackerClient) RtcPeerConnStats() map[string]webrtc.StatsReport {
 	defer tc.mu.Unlock()
 	sr := make(map[string]webrtc.StatsReport)
 	for id, pc := range tc.rtcPeerConns {
-		sr[id] = pc.GetStats()
+		sr[id] = GetPeerConnStats(pc)
 	}
 	return sr
 }

--- a/webtorrent/tracker-client.go
+++ b/webtorrent/tracker-client.go
@@ -237,7 +237,7 @@ func (tc *TrackerClient) Announce(event tracker.AnnounceEvent, infoHash [20]byte
 	}
 
 	// save the leecher peer connections
-	tc.storePeerConnection(offerIDBinary, pc)
+	tc.storePeerConnection(fmt.Sprintf("%x", randOfferId[:]), pc)
 
 	pc.OnClose(func() {
 		delete(tc.rtcPeerConns, offerIDBinary)
@@ -381,7 +381,7 @@ func (tc *TrackerClient) handleOffer(
 	}
 
 	// save the seeder peer connections
-	tc.storePeerConnection(offerContext.Id, peerConnection)
+	tc.storePeerConnection(fmt.Sprintf("%x", offerContext.Id[:]), peerConnection)
 
 	response := AnnounceResponse{
 		Action:   "announce",


### PR DESCRIPTION
I revisited the work on #803 and improved on it. By saving a pointer to the open peer connections, we get stats more reliably. Stats now also work when seeding.

A note on the `Pion/webrtc` version. While some stats are available in the current latest version (`v3`), the project greatly improved on them in `v4`, currently in beta. I'd recommend upgrading to `v4` as soon as it's convenient when it gets out of beta.