### PR TITLE
Support setting the Type-Of-Service field to for sockets

### DIFF
--- a/sockopts_unix.go
+++ b/sockopts_unix.go
@@ -27,3 +27,7 @@ func setReusePortSockOpts(fd uintptr) (err error) {
 func setSockNoLinger(fd uintptr) (err error) {
 	return syscall.SetsockoptLinger(int(fd), syscall.SOL_SOCKET, syscall.SO_LINGER, &lingerOffVal)
 }
+
+func setSockIPTOS(fd uintptr, val int) (err error) {
+	return syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_TOS, val)
+}

--- a/sockopts_wasm.go
+++ b/sockopts_wasm.go
@@ -10,3 +10,7 @@ func setReusePortSockOpts(fd uintptr) error {
 func setSockNoLinger(fd uintptr) error {
 	return nil
 }
+
+func setSockIPTOS(fd uintptr, val int) (err error) {
+	return nil
+}

--- a/sockopts_windows.go
+++ b/sockopts_windows.go
@@ -13,3 +13,7 @@ func setReusePortSockOpts(fd uintptr) (err error) {
 func setSockNoLinger(fd uintptr) (err error) {
 	return syscall.SetsockoptLinger(syscall.Handle(fd), syscall.SOL_SOCKET, syscall.SO_LINGER, &lingerOffVal)
 }
+
+func setSockIPTOS(fd uintptr, val int) (err error) {
+	return nil
+}


### PR DESCRIPTION
Optionally specify the Type-of-Service (TOS) setting for sockets. This is a layer 3 QOS option that may be used to prioritize IP packets on the network.