### PR TITLE
Optimize merkle root and streaming hash computation

### DIFF
--- a/merkle/hash.go
+++ b/merkle/hash.go
@@ -3,58 +3,59 @@ package merkle
 import (
 	"crypto/sha256"
 	"hash"
-	"unsafe"
 )
 
 func NewHash() *Hash {
-	h := &Hash{
-		nextBlock: sha256.New(),
-	}
-	return h
+	return &Hash{}
 }
 
 type Hash struct {
 	blocks    [][32]byte
-	nextBlock hash.Hash
+	nextBlock [BlockSize]byte
 	// How many bytes have been written to nextBlock so far.
 	nextBlockWritten int
 }
 
-func (h *Hash) remaining() int {
-	return BlockSize - h.nextBlockWritten
-}
-
 func (h *Hash) Write(p []byte) (n int, err error) {
-	for len(p) > 0 {
-		var n1 int
-		n1, err = h.nextBlock.Write(p[:min(len(p), h.remaining())])
-		n += n1
+	if h.nextBlockWritten != 0 {
+		n1 := copy(h.nextBlock[h.nextBlockWritten:], p)
 		h.nextBlockWritten += n1
+		n += n1
 		p = p[n1:]
-		if h.remaining() == 0 {
-			h.blocks = append(h.blocks, h.nextBlockSum())
-			h.nextBlock.Reset()
+		if h.nextBlockWritten == BlockSize {
+			h.blocks = append(h.blocks, sha256.Sum256(h.nextBlock[:]))
 			h.nextBlockWritten = 0
 		}
-		if err != nil {
-			break
-		}
+	}
+
+	for len(p) >= BlockSize {
+		h.blocks = append(h.blocks, sha256.Sum256(p[:BlockSize]))
+		p = p[BlockSize:]
+		n += BlockSize
+	}
+
+	if len(p) != 0 {
+		n1 := copy(h.nextBlock[:], p)
+		h.nextBlockWritten = n1
+		n += n1
 	}
 	return
 }
 
 func (h *Hash) nextBlockSum() (sum [32]byte) {
-	if unsafe.SliceData(h.nextBlock.Sum(sum[:0])) != unsafe.SliceData(sum[:]) {
-		panic("go sux")
+	if h.nextBlockWritten == 0 {
+		return
 	}
-	return
+	return sha256.Sum256(h.nextBlock[:h.nextBlockWritten])
 }
 
 func (h *Hash) curBlocks() [][32]byte {
-	blocks := h.blocks
-	if h.nextBlockWritten != 0 {
-		blocks = append(blocks, h.nextBlockSum())
+	if h.nextBlockWritten == 0 {
+		return h.blocks
 	}
+	blocks := make([][32]byte, len(h.blocks)+1)
+	copy(blocks, h.blocks)
+	blocks[len(h.blocks)] = h.nextBlockSum()
 	return blocks
 }
 
@@ -68,14 +69,17 @@ func (h *Hash) Sum(b []byte) []byte {
 func (h *Hash) SumMinLength(b []byte, length int) []byte {
 	blocks := h.curBlocks()
 	minBlocks := (length + BlockSize - 1) / BlockSize
-	blocks = append(blocks, make([][32]byte, minBlocks-len(blocks))...)
+	if minBlocks > len(blocks) {
+		padded := make([][32]byte, minBlocks)
+		copy(padded, blocks)
+		blocks = padded
+	}
 	sum := RootWithPadHash(blocks, [32]byte{})
 	return append(b, sum[:]...)
 }
 
 func (h *Hash) Reset() {
 	h.blocks = h.blocks[:0]
-	h.nextBlock.Reset()
 	h.nextBlockWritten = 0
 }
 
@@ -84,7 +88,7 @@ func (h *Hash) Size() int {
 }
 
 func (h *Hash) BlockSize() int {
-	return h.nextBlock.BlockSize()
+	return sha256.BlockSize
 }
 
 var _ hash.Hash = (*Hash)(nil)

--- a/merkle/hash_test.go
+++ b/merkle/hash_test.go
@@ -1,0 +1,108 @@
+package merkle
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"testing"
+)
+
+func TestHashSumMatchesManualBlockRoot(t *testing.T) {
+	data := makeTestData(BlockSize*2 + BlockSize/2)
+	h := NewHash()
+	writeInChunks(t, h, data, 1, 17, BlockSize-3, 23)
+	got := h.Sum(nil)
+	want := RootWithPadHash(blockHashesFromData(data), [sha256.Size]byte{})
+	if !bytes.Equal(got, want[:]) {
+		t.Fatalf("got %x, want %x", got, want)
+	}
+}
+
+func TestHashSumMinLengthPadsMissingBlocks(t *testing.T) {
+	data := makeTestData(BlockSize + 123)
+	h := NewHash()
+	writeInChunks(t, h, data, 257, BlockSize-1, 11)
+	minLength := BlockSize * 4
+	got := h.SumMinLength(nil, minLength)
+
+	blocks := blockHashesFromData(data)
+	blocks = append(blocks, make([][sha256.Size]byte, blocksForLength(minLength)-len(blocks))...)
+	want := RootWithPadHash(blocks, [sha256.Size]byte{})
+	if !bytes.Equal(got, want[:]) {
+		t.Fatalf("got %x, want %x", got, want)
+	}
+}
+
+func TestHashResetClearsState(t *testing.T) {
+	h := NewHash()
+	writeInChunks(t, h, makeTestData(BlockSize+99), 33, BlockSize-5)
+	h.Reset()
+	if h.nextBlockWritten != 0 {
+		t.Fatalf("nextBlockWritten = %d, want 0", h.nextBlockWritten)
+	}
+	if len(h.blocks) != 0 {
+		t.Fatalf("len(blocks) = %d, want 0", len(h.blocks))
+	}
+	got := h.Sum(nil)
+	want := sha256.Sum256(nil)
+	if !bytes.Equal(got, want[:]) {
+		t.Fatalf("got %x, want %x", got, want)
+	}
+}
+
+func BenchmarkHashWriteAndSum(b *testing.B) {
+	data := makeTestData(BlockSize * 16)
+	b.ReportAllocs()
+	for b.Loop() {
+		h := NewHash()
+		if _, err := h.Write(data); err != nil {
+			b.Fatalf("write failed: %v", err)
+		}
+		_ = h.Sum(nil)
+	}
+}
+
+func makeTestData(n int) []byte {
+	data := make([]byte, n)
+	for i := range data {
+		data[i] = byte(i * 31)
+	}
+	return data
+}
+
+func writeInChunks(t testing.TB, h *Hash, data []byte, chunkSizes ...int) {
+	t.Helper()
+	offset := 0
+	chunk := 0
+	for offset < len(data) {
+		size := chunkSizes[chunk%len(chunkSizes)]
+		if size <= 0 {
+			t.Fatalf("invalid chunk size %d", size)
+		}
+		end := min(offset+size, len(data))
+		n, err := h.Write(data[offset:end])
+		if err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+		if n != end-offset {
+			t.Fatalf("write returned %d, want %d", n, end-offset)
+		}
+		offset = end
+		chunk++
+	}
+}
+
+func blockHashesFromData(data []byte) [][sha256.Size]byte {
+	if len(data) == 0 {
+		return nil
+	}
+	blocks := make([][sha256.Size]byte, 0, blocksForLength(len(data)))
+	for offset := 0; offset < len(data); offset += BlockSize {
+		end := min(offset+BlockSize, len(data))
+		blocks = append(blocks, sha256.Sum256(data[offset:end]))
+	}
+	return blocks
+}
+
+func blocksForLength(length int) int {
+	return (length + BlockSize - 1) / BlockSize
+}

--- a/merkle/merkle.go
+++ b/merkle/merkle.go
@@ -4,8 +4,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"math/bits"
-
-	g "github.com/anacrolix/generics"
 )
 
 // The leaf block size for BitTorrent v2 Merkle trees.
@@ -22,33 +20,58 @@ func Root(hashes [][sha256.Size]byte) [sha256.Size]byte {
 	if numHashes != RoundUpToPowerOfTwo(uint(len(hashes))) {
 		panic(fmt.Sprintf("expected power of two number of hashes, got %d", numHashes))
 	}
-	var next [][sha256.Size]byte
-	for i := 0; i < len(hashes); i += 2 {
-		left := hashes[i]
-		right := hashes[i+1]
-		h := sha256.Sum256(append(left[:], right[:]...))
-		next = append(next, h)
-	}
-	return Root(next)
+	working := make([][sha256.Size]byte, len(hashes))
+	copy(working, hashes)
+	return rootInPlace(working)
 }
 
 func RootWithPadHash(hashes [][sha256.Size]byte, padHash [sha256.Size]byte) [sha256.Size]byte {
-	for uint(len(hashes)) < RoundUpToPowerOfTwo(uint(len(hashes))) {
-		hashes = append(hashes, padHash)
+	switch len(hashes) {
+	case 0:
+		return sha256.Sum256(nil)
+	case 1:
+		return hashes[0]
 	}
-	return Root(hashes)
+	targetLen := len(hashes)
+	if !isPowerOfTwo(targetLen) {
+		targetLen = int(RoundUpToPowerOfTwo(uint(targetLen)))
+	}
+	working := make([][sha256.Size]byte, targetLen)
+	copy(working, hashes)
+	for i := len(hashes); i < targetLen; i++ {
+		working[i] = padHash
+	}
+	return rootInPlace(working)
 }
 
 func CompactLayerToSliceHashes(compactLayer string) (hashes [][sha256.Size]byte, err error) {
-	g.MakeSliceWithLength(&hashes, len(compactLayer)/sha256.Size)
+	hashes = make([][sha256.Size]byte, len(compactLayer)/sha256.Size)
 	for i := range hashes {
-		n := copy(hashes[i][:], compactLayer[i*sha256.Size:])
-		if n != sha256.Size {
-			err = fmt.Errorf("compact layer has incomplete hash at index %d", i)
-			return
-		}
+		copy(hashes[i][:], compactLayer[i*sha256.Size:(i+1)*sha256.Size])
 	}
 	return
+}
+
+// rootInPlace reduces a complete hash layer to its root by overwriting the slice level by level.
+func rootInPlace(level [][sha256.Size]byte) [sha256.Size]byte {
+	var pair [2 * sha256.Size]byte
+	for len(level) > 1 {
+		nextLen := len(level) / 2
+		for i := range nextLen {
+			left := level[i*2]
+			right := level[i*2+1]
+			copy(pair[:sha256.Size], left[:])
+			copy(pair[sha256.Size:], right[:])
+			level[i] = sha256.Sum256(pair[:])
+		}
+		level = level[:nextLen]
+	}
+	return level[0]
+}
+
+// isPowerOfTwo reports whether n is a positive power of two.
+func isPowerOfTwo(n int) bool {
+	return n > 0 && n&(n-1) == 0
 }
 
 func RoundUpToPowerOfTwo(n uint) (ret uint) {

--- a/merkle/merkle_test.go
+++ b/merkle/merkle_test.go
@@ -1,0 +1,126 @@
+package merkle
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"slices"
+	"testing"
+)
+
+func TestRootMatchesReference(t *testing.T) {
+	for _, leaves := range []int{0, 1, 2, 4, 8, 64, 1024} {
+		t.Run(fmt.Sprintf("leaves=%d", leaves), func(t *testing.T) {
+			hashes := makeTestHashes(leaves)
+			got := Root(hashes)
+			want := referenceRoot(hashes)
+			if got != want {
+				t.Fatalf("got %x, want %x", got, want)
+			}
+		})
+	}
+}
+
+func TestRootWithPadHashMatchesReference(t *testing.T) {
+	padHash := sha256.Sum256([]byte("pad"))
+	for _, leaves := range []int{0, 1, 3, 5, 63, 511} {
+		t.Run(fmt.Sprintf("leaves=%d", leaves), func(t *testing.T) {
+			hashes := makeTestHashes(leaves)
+			got := RootWithPadHash(hashes, padHash)
+			want := referenceRootWithPadHash(hashes, padHash)
+			if got != want {
+				t.Fatalf("got %x, want %x", got, want)
+			}
+		})
+	}
+}
+
+func TestRootDoesNotMutateInput(t *testing.T) {
+	hashes := makeTestHashes(8)
+	original := append([][sha256.Size]byte(nil), hashes...)
+	_ = Root(hashes)
+	if len(hashes) != len(original) {
+		t.Fatalf("input length changed from %d to %d", len(original), len(hashes))
+	}
+	for i := range hashes {
+		if hashes[i] != original[i] {
+			t.Fatalf("input hash at index %d changed", i)
+		}
+	}
+}
+
+func TestRootPanicsForNonPowerOfTwo(t *testing.T) {
+	hashes := makeTestHashes(3)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for non-power-of-two hash count")
+		}
+	}()
+	_ = Root(hashes)
+}
+
+func TestCompactLayerToSliceHashes(t *testing.T) {
+	hashes := makeTestHashes(4)
+	var compact []byte
+	for _, hash := range hashes {
+		compact = append(compact, hash[:]...)
+	}
+	got, err := CompactLayerToSliceHashes(string(compact))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !slices.Equal(got, hashes) {
+		t.Fatalf("got %x, want %x", got, hashes)
+	}
+}
+
+func BenchmarkRoot(b *testing.B) {
+	hashes := makeTestHashes(1024)
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = Root(hashes)
+	}
+}
+
+func BenchmarkRootWithPadHash(b *testing.B) {
+	hashes := makeTestHashes(511)
+	padHash := sha256.Sum256([]byte("pad"))
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = RootWithPadHash(hashes, padHash)
+	}
+}
+
+func makeTestHashes(n int) [][sha256.Size]byte {
+	hashes := make([][sha256.Size]byte, n)
+	for i := range hashes {
+		hashes[i] = sha256.Sum256([]byte(fmt.Sprintf("leaf-%d", i)))
+	}
+	return hashes
+}
+
+func referenceRoot(hashes [][sha256.Size]byte) [sha256.Size]byte {
+	switch len(hashes) {
+	case 0:
+		return sha256.Sum256(nil)
+	case 1:
+		return hashes[0]
+	}
+	numHashes := uint(len(hashes))
+	if numHashes != RoundUpToPowerOfTwo(uint(len(hashes))) {
+		panic(fmt.Sprintf("expected power of two number of hashes, got %d", numHashes))
+	}
+	var next [][sha256.Size]byte
+	for i := 0; i < len(hashes); i += 2 {
+		left := hashes[i]
+		right := hashes[i+1]
+		next = append(next, sha256.Sum256(append(left[:], right[:]...)))
+	}
+	return referenceRoot(next)
+}
+
+func referenceRootWithPadHash(hashes [][sha256.Size]byte, padHash [sha256.Size]byte) [sha256.Size]byte {
+	for uint(len(hashes)) < RoundUpToPowerOfTwo(uint(len(hashes))) {
+		hashes = append(hashes, padHash)
+	}
+	return referenceRoot(hashes)
+}


### PR DESCRIPTION
This change improves the `merkle` package by simplifying how Merkle roots are built and by making the streaming hash path handle block hashing more directly. The root calculation now reduces hashes in place instead of building extra intermediate slices, and the hash writer now works with fixed block buffering instead of the older incremental hashing flow. I also added focused tests and benchmarks around the root and hash paths so the main logic is easier to verify and measure.

```
goos: linux
goarch: amd64
pkg: github.com/anacrolix/torrent/merkle
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
                │ old_bench.txt │            new_bench.txt            │
                │    sec/op     │   sec/op     vs base                │
HashWriteAndSum     787.3µ ± 3%   791.1µ ± 3%        ~ (p=0.280 n=10)
Root                565.8µ ± 2%   506.9µ ± 4%  -10.42% (p=0.000 n=10)
RootWithPadHash     285.3µ ± 4%   243.4µ ± 5%  -14.68% (p=0.000 n=10)
geomean             502.8µ        460.4µ        -8.42%

                │ old_bench.txt │            new_bench.txt             │
                │     B/op      │     B/op      vs base                │
HashWriteAndSum    3.297Ki ± 0%   1.500Ki ± 0%  -54.50% (p=0.000 n=10)
Root              127.25Ki ± 0%   32.00Ki ± 0%  -74.85% (p=0.000 n=10)
RootWithPadHash    89.94Ki ± 0%   16.00Ki ± 0%  -82.21% (p=0.000 n=10)
geomean            33.54Ki        9.158Ki       -72.70%

                │ old_bench.txt │           new_bench.txt            │
                │   allocs/op   │ allocs/op   vs base                │
HashWriteAndSum     45.000 ± 0%   7.000 ± 0%  -84.44% (p=0.000 n=10)
Root              1068.000 ± 0%   1.000 ± 0%  -99.91% (p=0.000 n=10)
RootWithPadHash    548.000 ± 0%   1.000 ± 0%  -99.82% (p=0.000 n=10)
geomean              297.5        1.913       -99.36%
```