### PR TITLE
Optimize peer ranking paths in prioritized peers and worse connections

### DIFF
--- a/prioritized-peers.go
+++ b/prioritized-peers.go
@@ -2,34 +2,77 @@ package torrent
 
 import (
 	"hash/maphash"
+	"net/netip"
+	"strconv"
+	"strings"
 
-	"github.com/anacrolix/multiless"
 	"github.com/google/btree"
 )
 
 // Peers are stored with their priority at insertion. Their priority may
 // change if our apparent IP changes, we don't currently handle that.
 type prioritizedPeersItem struct {
-	prio peerPriority
-	p    PeerInfo
-}
-
-var hashSeed = maphash.MakeSeed()
-
-func (me prioritizedPeersItem) addrHash() int64 {
-	var h maphash.Hash
-	h.SetSeed(hashSeed)
-	h.WriteString(me.p.Addr.String())
-	return int64(h.Sum64())
+	prio     peerPriority
+	addrHash int64
+	p        PeerInfo
 }
 
 func (me prioritizedPeersItem) Less(than btree.Item) bool {
 	other := than.(prioritizedPeersItem)
-	return multiless.New().Bool(
-		me.p.Trusted, other.p.Trusted).Uint32(
-		me.prio, other.prio).Int64(
-		me.addrHash(), other.addrHash(),
-	).Less()
+	if me.p.Trusted != other.p.Trusted {
+		return !me.p.Trusted && other.p.Trusted
+	}
+	if me.prio != other.prio {
+		return me.prio < other.prio
+	}
+	return me.addrHash < other.addrHash
+}
+
+var hashSeed = maphash.MakeSeed()
+
+// newPrioritizedPeersItem materializes the tree key once so repeated B-tree comparisons can reuse
+// the priority fields and stable address hash without recomputing them.
+func newPrioritizedPeersItem(prio peerPriority, p PeerInfo) prioritizedPeersItem {
+	var h maphash.Hash
+	h.SetSeed(hashSeed)
+	writePeerRemoteAddrHash(&h, p.Addr)
+	return prioritizedPeersItem{
+		prio:     prio,
+		addrHash: int64(h.Sum64()),
+		p:        p,
+	}
+}
+
+// writePeerRemoteAddrHash writes the same byte representation as addr.String() into the hash, using
+// concrete address types to avoid building an intermediate string when possible.
+func writePeerRemoteAddrHash(h *maphash.Hash, addr PeerRemoteAddr) {
+	switch v := addr.(type) {
+	case StringAddr:
+		h.WriteString(string(v))
+	case ipPortAddr:
+		writeIPPortAddrStringHash(h, v)
+	case netip.AddrPort:
+		var buf [64]byte
+		h.Write(v.AppendTo(buf[:0]))
+	default:
+		h.WriteString(addr.String())
+	}
+}
+
+// writeIPPortAddrStringHash encodes ipPortAddr in net.JoinHostPort-compatible form so the cached
+// hash preserves the original tree ordering for IPv4 and IPv6 addresses.
+func writeIPPortAddrStringHash(h *maphash.Hash, addr ipPortAddr) {
+	host := addr.IP.String()
+	if strings.IndexByte(host, ':') >= 0 {
+		h.WriteString("[")
+		h.WriteString(host)
+		h.WriteString("]")
+	} else {
+		h.WriteString(host)
+	}
+	h.WriteString(":")
+	var portBuf [20]byte
+	h.Write(strconv.AppendInt(portBuf[:0], int64(addr.Port), 10))
 }
 
 type prioritizedPeers struct {
@@ -53,12 +96,12 @@ func (me *prioritizedPeers) Len() int {
 
 // Returns true if a peer is replaced.
 func (me *prioritizedPeers) Add(p PeerInfo) bool {
-	return me.om.ReplaceOrInsert(prioritizedPeersItem{me.getPrio(p), p}) != nil
+	return me.om.ReplaceOrInsert(newPrioritizedPeersItem(me.getPrio(p), p)) != nil
 }
 
 // Returns true if a peer is replaced.
 func (me *prioritizedPeers) AddReturningReplacedPeer(p PeerInfo) (ret PeerInfo, ok bool) {
-	item := me.om.ReplaceOrInsert(prioritizedPeersItem{me.getPrio(p), p})
+	item := me.om.ReplaceOrInsert(newPrioritizedPeersItem(me.getPrio(p), p))
 	if item == nil {
 		return
 	}

--- a/prioritized-peers_test.go
+++ b/prioritized-peers_test.go
@@ -1,7 +1,9 @@
 package torrent
 
 import (
+	"hash/maphash"
 	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/google/btree"
@@ -52,4 +54,25 @@ func TestPrioritizedPeers(t *testing.T) {
 	pop(&ps[0])
 	min(nil)
 	pop(nil)
+}
+
+// TestPrioritizedPeersAddrHash verifies that the hashing path preserves the exact
+// address-string hash used to order peers in the tree.
+func TestPrioritizedPeersAddrHash(t *testing.T) {
+	testCases := []PeerRemoteAddr{
+		StringAddr("192.0.2.1:1234"),
+		ipPortAddr{IP: net.ParseIP("192.0.2.1"), Port: 1234},
+		ipPortAddr{IP: net.ParseIP("2001:db8::1"), Port: 5678},
+		netip.MustParseAddrPort("198.51.100.7:4321"),
+		netip.MustParseAddrPort("[2001:db8::2]:8765"),
+	}
+	for _, addr := range testCases {
+		t.Run(addr.String(), func(t *testing.T) {
+			item := newPrioritizedPeersItem(7, PeerInfo{Addr: addr})
+			var expected maphash.Hash
+			expected.SetSeed(hashSeed)
+			expected.WriteString(addr.String())
+			assert.Equal(t, int64(expected.Sum64()), item.addrHash)
+		})
+	}
 }

--- a/worse-conns.go
+++ b/worse-conns.go
@@ -6,88 +6,93 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/anacrolix/multiless"
 	"github.com/anacrolix/sync"
 )
 
 type worseConnInput struct {
-	BadDirection        bool
-	Useful              bool
-	LastHelpful         time.Time
-	CompletedHandshake  time.Time
-	GetPeerPriority     func() (peerPriority, error)
-	getPeerPriorityOnce sync.Once
-	peerPriority        peerPriority
-	peerPriorityErr     error
-	Pointer             uintptr
+	BadDirection       bool
+	Useful             bool
+	LastHelpful        time.Time
+	CompletedHandshake time.Time
+	GetPeerPriority    func() (peerPriority, error)
+	Pointer            uintptr
 }
 
-func (me *worseConnInput) doGetPeerPriority() {
-	me.peerPriority, me.peerPriorityErr = me.GetPeerPriority()
-}
-
-func (me *worseConnInput) doGetPeerPriorityOnce() {
-	me.getPeerPriorityOnce.Do(me.doGetPeerPriority)
+func memoizePeerPriority(f func() (peerPriority, error)) func() (peerPriority, error) {
+	var once sync.Once
+	var prio peerPriority
+	var err error
+	return func() (peerPriority, error) {
+		once.Do(func() {
+			prio, err = f()
+		})
+		return prio, err
+	}
 }
 
 type worseConnLensOpts struct {
 	incomingIsBad, outgoingIsBad bool
 }
 
-func worseConnInputFromPeer(p *PeerConn, opts worseConnLensOpts) *worseConnInput {
-	ret := &worseConnInput{
-		Useful:             p.useful(),
-		LastHelpful:        p.lastHelpful(),
-		CompletedHandshake: p.completedHandshake,
-		Pointer:            uintptr(unsafe.Pointer(p)),
-		GetPeerPriority:    p.peerPriority,
-	}
+// worseConnInputFromPeer snapshots the peer fields used by connection ranking so heap operations
+// compare stable values instead of repeatedly reading live peer state.
+func worseConnInputFromPeer(dst *worseConnInput, p *PeerConn, opts worseConnLensOpts) {
+	dst.BadDirection = false
+	dst.Useful = p.useful()
+	dst.LastHelpful = p.lastHelpful()
+	dst.CompletedHandshake = p.completedHandshake
+	dst.GetPeerPriority = memoizePeerPriority(p.peerPriority)
+	dst.Pointer = uintptr(unsafe.Pointer(p))
 	if opts.incomingIsBad && !p.outgoing {
-		ret.BadDirection = true
+		dst.BadDirection = true
 	} else if opts.outgoingIsBad && p.outgoing {
-		ret.BadDirection = true
+		dst.BadDirection = true
 	}
-	return ret
 }
 
+// Less applies the connection ordering from lowest to highest desirability, deferring peer-priority
+// lookup until earlier fields tie and falling back to the pointer for a total ordering.
 func (l *worseConnInput) Less(r *worseConnInput) bool {
-	less, ok := multiless.New().Bool(
-		r.BadDirection, l.BadDirection).Bool(
-		l.Useful, r.Useful).CmpInt64(
-		l.LastHelpful.Sub(r.LastHelpful).Nanoseconds()).CmpInt64(
-		l.CompletedHandshake.Sub(r.CompletedHandshake).Nanoseconds()).LazySameLess(
-		func() (same, less bool) {
-			l.doGetPeerPriorityOnce()
-			if l.peerPriorityErr != nil {
-				same = true
-				return
-			}
-			r.doGetPeerPriorityOnce()
-			if r.peerPriorityErr != nil {
-				same = true
-				return
-			}
-			same = l.peerPriority == r.peerPriority
-			less = l.peerPriority < r.peerPriority
-			return
-		}).Uintptr(
-		l.Pointer, r.Pointer,
-	).LessOk()
-	if !ok {
+	if l.BadDirection != r.BadDirection {
+		return l.BadDirection && !r.BadDirection
+	}
+	if l.Useful != r.Useful {
+		return !l.Useful && r.Useful
+	}
+	if !l.LastHelpful.Equal(r.LastHelpful) {
+		return l.LastHelpful.Before(r.LastHelpful)
+	}
+	if !l.CompletedHandshake.Equal(r.CompletedHandshake) {
+		return l.CompletedHandshake.Before(r.CompletedHandshake)
+	}
+	lPeerPriority, lPeerPriorityErr := l.GetPeerPriority()
+	if lPeerPriorityErr == nil {
+		rPeerPriority, rPeerPriorityErr := r.GetPeerPriority()
+		if rPeerPriorityErr == nil && lPeerPriority != rPeerPriority {
+			return lPeerPriority < rPeerPriority
+		}
+	}
+	if l.Pointer == r.Pointer {
 		panic(fmt.Sprintf("cannot differentiate %#v and %#v", l, r))
 	}
-	return less
+	return l.Pointer < r.Pointer
 }
 
 type worseConnSlice struct {
-	conns []*PeerConn
-	keys  []*worseConnInput
+	conns      []*PeerConn
+	keys       []*worseConnInput
+	keyStorage []worseConnInput
 }
 
+// initKeys builds contiguous ranking keys for the heap so comparisons can reuse precomputed peer
+// metadata without one allocation per entry.
 func (me *worseConnSlice) initKeys(opts worseConnLensOpts) {
+	// Keep the key structs contiguous so heap comparisons don't allocate one object per peer.
+	me.keyStorage = make([]worseConnInput, len(me.conns))
 	me.keys = make([]*worseConnInput, len(me.conns))
 	for i, c := range me.conns {
-		me.keys[i] = worseConnInputFromPeer(c, opts)
+		worseConnInputFromPeer(&me.keyStorage[i], c, opts)
+		me.keys[i] = &me.keyStorage[i]
 	}
 }
 
@@ -104,7 +109,10 @@ func (me *worseConnSlice) Less(i, j int) bool {
 func (me *worseConnSlice) Pop() interface{} {
 	i := len(me.conns) - 1
 	ret := me.conns[i]
+	me.keys[i] = nil
 	me.conns = me.conns[:i]
+	me.keys = me.keys[:i]
+	me.keyStorage = me.keyStorage[:i]
 	return ret
 }
 

--- a/worse-conns_test.go
+++ b/worse-conns_test.go
@@ -1,6 +1,7 @@
 package torrent
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -41,3 +42,39 @@ func TestWorseConnLastHelpful(t *testing.T) {
 		Pointer:         1,
 	})))
 }
+
+// TestWorseConnPriorityError verifies that a left-side peer-priority error still falls back to
+// pointer ordering without forcing the right-side priority lookup.
+func TestWorseConnPriorityError(t *testing.T) {
+	rightCalls := 0
+	left := worseConnInput{
+		GetPeerPriority: func() (peerPriority, error) {
+			return 0, assertAnError
+		},
+		Pointer: 1,
+	}
+	right := worseConnInput{
+		GetPeerPriority: func() (peerPriority, error) {
+			rightCalls++
+			return 42, nil
+		},
+		Pointer: 2,
+	}
+	qt.Check(t, qt.IsTrue(left.Less(&right)))
+	qt.Check(t, qt.Equals(rightCalls, 0))
+}
+
+// TestWorseConnSameInputPanic verifies that the comparison still panics when every ordering field,
+// including the pointer tie-breaker, is identical.
+func TestWorseConnSameInputPanic(t *testing.T) {
+	input := worseConnInput{
+		GetPeerPriority: func() (peerPriority, error) {
+			return 42, nil
+		},
+	}
+	qt.Check(t, qt.PanicMatches(func() {
+		input.Less(&input)
+	}, "cannot differentiate.*"))
+}
+
+var assertAnError = errors.New("priority lookup failed")

--- a/worse-conns_test.go
+++ b/worse-conns_test.go
@@ -49,7 +49,7 @@ func TestWorseConnPriorityError(t *testing.T) {
 	rightCalls := 0
 	left := worseConnInput{
 		GetPeerPriority: func() (peerPriority, error) {
-			return 0, assertAnError
+			return 0, errPriorityLookup
 		},
 		Pointer: 1,
 	}
@@ -77,4 +77,4 @@ func TestWorseConnSameInputPanic(t *testing.T) {
 	}, "cannot differentiate.*"))
 }
 
-var assertAnError = errors.New("priority lookup failed")
+var errPriorityLookup = errors.New("priority lookup failed")


### PR DESCRIPTION
This update affects two ranking-heavy paths: prioritized peer insertion and worse-connection selection. 
- Peer ranking now caches the address hash at insertion time, employs direct comparison logic rather than the generic comparison builder, and handles common address types more efficiently by writing their canonical address form directly into the hash rather than creating an intermediate string first.
- Connection ranking now use direct field comparisons, stores ranking inputs in contiguous storage to decrease allocation overhead, and memoizes peer-priority lookups using a closure-based helper to prevent redundant work and address copylock concerns. 
- The relevant tests were expanded to include the address-hash path, as well as the priority-error and panic edge cases in worse-connection ordering.