### PR TITLE
Fix Reader

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -83,7 +83,9 @@ type reader struct {
 }
 
 func (r *reader) SetContext(ctx context.Context) {
+	r.mu.Lock()
 	r.ctx = ctx
+	r.mu.Unlock()
 }
 
 var _ io.ReadSeekCloser = (*reader)(nil)
@@ -169,14 +171,19 @@ func (r *reader) Read(b []byte) (n int, err error) {
 }
 
 func (r *reader) read(b []byte) (n int, err error) {
-	return r.readContext(r.ctx, b)
+	r.mu.Lock()
+	ctx := r.ctx
+	r.mu.Unlock()
+	return r.readContext(ctx, b)
 }
 
 // Deprecated: Use SetContext and Read. TODO: I've realised this breaks the ability to pass through
 // optional interfaces like io.WriterTo and io.ReaderFrom. Go sux. Context should be provided
 // somewhere else.
 func (r *reader) ReadContext(ctx context.Context, b []byte) (n int, err error) {
+	r.mu.Lock()
 	r.ctx = ctx
+	r.mu.Unlock()
 	return r.Read(b)
 }
 


### PR DESCRIPTION
Fix race condition in reader context synchronization
The reader struct had a data race where the ctx field was accessed without proper synchronization, causing potential panics and inconsistent behavior in concurrent scenarios.

Changes
reader.go:85-87: Added mutex lock/unlock in SetContext before writing r.ctx
reader.go:171-173: Added mutex lock/unlock in read before reading r.ctx
reader.go:178-181: Added mutex lock/unlock in ReadContext before writing r.ctx

Testing
All existing tests pass with -race flag, including:
TestReceiveChunkStorageFailureSeederFastExtensionDisabled
TestReceiveChunkStorageFailure