### PR TITLE
fix(tracker): resolve peer discovery failure on re-add

### DIFF
--- a/client-tracker-announcer.go
+++ b/client-tracker-announcer.go
@@ -440,12 +440,8 @@ func (me *regularTrackerAnnounceDispatcher) step() mytimer.TimeValue {
 }
 
 func (me *regularTrackerAnnounceDispatcher) addKey(key torrentTrackerAnnouncerKey) {
-	if me.announceData.ContainsKey(key) {
-		return
-	}
-	t := me.torrentFromShortInfohash(key.ShortInfohash)
+t := me.torrentFromShortInfohash(key.ShortInfohash)
 	if t == nil {
-		// Crude, but the torrent was already dropped. We probably called AddTrackers late.
 		return
 	}
 	g.MakeMapIfNil(&me.torrentForAnnounceRequests)
@@ -456,6 +452,11 @@ func (me *regularTrackerAnnounceDispatcher) addKey(key torrentTrackerAnnouncerKe
 		g.MapMustAssignNew(me.announceStates, key, g.PtrTo(announceState{}))
 	}
 	t.regularTrackerAnnounceState[key] = g.MapMustGet(me.announceStates, key)
+	if me.announceData.ContainsKey(key) {
+		me.pendTorrentInputUpdate(t)
+		me.updateTimer()
+		return
+	}
 	me.announceData.Create(key, nextAnnounceInput{
 		torrent:                me.makeTorrentInput(t),
 		nextAnnounceStateInput: me.makeAnnounceStateInput(key),
@@ -559,6 +560,13 @@ func (me *regularTrackerAnnounceDispatcher) finishedAnnounce(key torrentTrackerA
 
 func (me *regularTrackerAnnounceDispatcher) syncAnnounceState(key torrentTrackerAnnouncerKey) {
 	input := me.makeAnnounceStateInput(key)
+
+	if input.When.IsZero() {
+		me.announceData.Delete(key)
+		delete(me.announceStates, key)
+		return
+	}
+
 	me.announceData.UpdateOrCreate(key, func(old nextAnnounceInput) nextAnnounceInput {
 		old.nextAnnounceStateInput = input
 		return old
@@ -838,7 +846,7 @@ func (me *regularTrackerAnnounceDispatcher) nextAnnounceEvent(key torrentTracker
 	if !state.sentCompleted && t.sawInitiallyIncompleteData && t.haveAllPieces() {
 		return tracker.Completed, time.Now()
 	}
-	if lastOk.Completed.IsZero() {
+	if lastOk.Completed.IsZero() || lastOk.AnnouncedEvent == tracker.Stopped {
 		// Returning now should be fine as sorting should occur on "overdue" derived value.
 		return tracker.Started, time.Now()
 	}


### PR DESCRIPTION
Currently, if a user calls t.Drop() on a torrent and then immediately re-adds the same torrent (same infohash) to the client, the new torrent instance will fail to find any peers.

Upon investigation, this is caused by the regularTrackerAnnounceDispatcher 's lifecycle management:

1. When dropped, the dispatcher intentionally retains the torrent's state to send the final Stopped event.
2. When the new torrent is added, addKey hits if me.announceData.ContainsKey(key) { return } . The weak reference ( torrentForAnnounceRequests ) is never updated to the new Torrent pointer, routing all incoming peers to the dead instance.
3. Furthermore, there is a memory leak. As noted in the comments ( when.IsZero if there's nothing to do and the data can be forgotten ), the data was supposed to be purged after the Stopped event, but announceData.Delete() was never actually called. 

**What changed**
This PR introduces three targeted fixes to make the dispatcher's state machine robust:

1. Fix Memory Leak in syncAnnounceState :
   Added logic to delete the key from announceData and announceStates if input.When.IsZero() is true, properly purging GC'd/dropped torrents after their final announce.
2. Fix Stale Weak Reference in addKey :
   Removed the early return. addKey now unconditionally updates torrentForAnnounceRequests with the newest weak reference. If the record already exists (e.g., a race condition where Stopped is still pending), it calls me.pendTorrentInputUpdate(t) to hijack the state for the active torrent.
3. Reset Announce Event in nextAnnounceEvent :
   Added a condition ( lastOk.AnnouncedEvent == tracker.Stopped ) so that a newly added torrent correctly sends a Started event to the tracker instead of a regular None update, ensuring it properly rejoins the swarm.