### PR TITLE
Complete BEP 6 Fast Extension: send Allowed Fast Set + record received

### DIFF
--- a/client.go
+++ b/client.go
@@ -1338,6 +1338,12 @@ func (pc *PeerConn) sendInitialMessages() {
 		}
 		pc.postBitfield()
 	}()
+	// BEP 6: announce the Allowed Fast Set so the peer can request these pieces
+	// while still choked. Only meaningful when both sides support Fast Extension
+	// and we know how many pieces the torrent has.
+	if pc.fastEnabled() && t.haveInfo() {
+		pc.sendAllowedFastSet()
+	}
 	if pc.PeerExtensionBytes.SupportsDHT() && cl.config.Extensions.SupportsDHT() && cl.haveDhtServer() {
 		pc.write(pp.Message{
 			Type: pp.Port,

--- a/internal/fast/fast.go
+++ b/internal/fast/fast.go
@@ -1,0 +1,71 @@
+// Package fast implements the Allowed Fast Set generation algorithm from
+// BEP 6 (Fast Extension).
+//
+// http://www.bittorrent.org/beps/bep_0006.html
+//
+// The algorithm is a deterministic function of the peer's IPv4 (masked to /24)
+// and the torrent's info hash, producing a small set of piece indices the
+// local peer is willing to serve while the remote peer is choked. The remote
+// peer can independently compute the same set to verify the sender is honest.
+package fast
+
+import (
+	"crypto/sha1"
+	"encoding/binary"
+	"net"
+	"slices"
+)
+
+// DefaultK is the number of allowed-fast pieces normally announced per peer.
+// BEP 6 leaves the exact value implementation-defined; common clients use a
+// small constant (mainline / libtorrent use 10).
+const DefaultK = 10
+
+// GenerateFastSet returns up to k piece indices that the local peer will
+// allow the remote peer to request even while choked.
+//
+// k is the requested set size, numPieces is the total number of pieces in
+// the torrent, infoHash is the torrent's 20-byte info hash, and ip is the
+// remote peer's address (IPv4 only — IPv6 returns nil per BEP 6).
+//
+// The algorithm follows BEP 6's reference pseudocode exactly so the remote
+// peer can independently re-derive and verify the set.
+func GenerateFastSet(k int, numPieces uint32, infoHash [20]byte, ip net.IP) []uint32 {
+	if k <= 0 || numPieces == 0 {
+		return nil
+	}
+	// BEP 6 only defines the algorithm for IPv4. IPv6 callers get nil.
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return nil
+	}
+	// Mask off the host bits, keeping the /24 network. This makes the set
+	// stable across reconnects from the same subnet, which is what the spec
+	// requires.
+	ip4 = ip4.Mask(net.CIDRMask(24, 32))
+
+	// x = masked_ip || infohash (4 + 20 = 24 bytes)
+	x := make([]byte, 24)
+	copy(x, ip4)
+	copy(x[4:], infoHash[:])
+
+	out := make([]uint32, 0, k)
+	contains := func(v uint32) bool { return slices.Contains(out, v) }
+
+	h := sha1.New()
+	// Outer cap mirrors the reference pseudocode: it bounds work for the
+	// pathological case where numPieces is tiny and many hash outputs collide.
+	for j := 0; j < k && len(out) < k; j++ {
+		h.Reset()
+		_, _ = h.Write(x)
+		x = h.Sum(x[:0])
+		for i := 0; i+4 <= 20 && len(out) < k; i += 4 {
+			y := binary.BigEndian.Uint32(x[i : i+4])
+			idx := y % numPieces
+			if !contains(idx) {
+				out = append(out, idx)
+			}
+		}
+	}
+	return out
+}

--- a/internal/fast/fast_test.go
+++ b/internal/fast/fast_test.go
@@ -1,0 +1,112 @@
+package fast
+
+import (
+	"net"
+	"reflect"
+	"testing"
+)
+
+// TestGenerateFastSet_BEP6Example verifies our output against the canonical
+// example from BEP 6:
+//
+//	ip        = 80.4.4.200  (masked to 80.4.4.0)
+//	infohash  = 0xAAAAAAAA... (20 bytes of 0xAA)
+//	numPieces = 1313
+//
+// The first seven allowed-fast pieces given by BEP 6 are:
+//
+//	1059, 431, 808, 1217, 287, 376, 1188
+//
+// http://www.bittorrent.org/beps/bep_0006.html
+func TestGenerateFastSet_BEP6Example(t *testing.T) {
+	var ih [20]byte
+	for i := range ih {
+		ih[i] = 0xAA
+	}
+	want := []uint32{1059, 431, 808, 1217, 287, 376, 1188}
+	got := GenerateFastSet(7, 1313, ih, net.IPv4(80, 4, 4, 200))
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("BEP 6 example mismatch:\nwant %v\n got %v", want, got)
+	}
+}
+
+// TestGenerateFastSet_Determinism asserts the function is a pure function of
+// its inputs. Two calls with identical args must produce byte-identical output.
+// Peers rely on this to independently verify the sender's allowed-fast set.
+func TestGenerateFastSet_Determinism(t *testing.T) {
+	var ih [20]byte
+	for i := range ih {
+		ih[i] = byte(i)
+	}
+	ip := net.IPv4(192, 0, 2, 17)
+	a := GenerateFastSet(10, 500, ih, ip)
+	b := GenerateFastSet(10, 500, ih, ip)
+	if !reflect.DeepEqual(a, b) {
+		t.Fatalf("non-deterministic output:\n#1 %v\n#2 %v", a, b)
+	}
+}
+
+// TestGenerateFastSet_Subnet24 asserts that IPs in the same /24 yield the
+// same fast set (BEP 6 explicitly masks to /24 so a single host can't game
+// the set by switching ports).
+func TestGenerateFastSet_Subnet24(t *testing.T) {
+	var ih [20]byte
+	for i := range ih {
+		ih[i] = byte(i ^ 0x55)
+	}
+	a := GenerateFastSet(8, 200, ih, net.IPv4(10, 1, 2, 3))
+	b := GenerateFastSet(8, 200, ih, net.IPv4(10, 1, 2, 250))
+	c := GenerateFastSet(8, 200, ih, net.IPv4(10, 1, 3, 3)) // different /24
+	if !reflect.DeepEqual(a, b) {
+		t.Fatalf("same /24 produced different sets:\n.3 -> %v\n.250 -> %v", a, b)
+	}
+	if reflect.DeepEqual(a, c) {
+		t.Fatalf("different /24 produced the same set; mask not applied")
+	}
+}
+
+// TestGenerateFastSet_IPv6Nil — BEP 6 only defines the algorithm for IPv4.
+// The function must signal "no fast set" for IPv6-only peers by returning nil.
+func TestGenerateFastSet_IPv6Nil(t *testing.T) {
+	var ih [20]byte
+	ipv6 := net.ParseIP("2001:db8::1")
+	got := GenerateFastSet(10, 1000, ih, ipv6)
+	if got != nil {
+		t.Fatalf("expected nil for IPv6 peer; got %v", got)
+	}
+}
+
+// TestGenerateFastSet_UniqueIndices — every produced index must be unique.
+// The outer/inner loops include a "contains" check; this test confirms it
+// holds even with a small piece count where collisions are likely.
+func TestGenerateFastSet_UniqueIndices(t *testing.T) {
+	var ih [20]byte
+	for i := range ih {
+		ih[i] = 0xFE
+	}
+	// Tiny torrent: 7 pieces, ask for 7 → every index must appear at most once.
+	got := GenerateFastSet(7, 7, ih, net.IPv4(203, 0, 113, 1))
+	seen := map[uint32]bool{}
+	for _, v := range got {
+		if seen[v] {
+			t.Fatalf("duplicate index %d in %v", v, got)
+		}
+		seen[v] = true
+		if v >= 7 {
+			t.Fatalf("index %d out of range for numPieces=7", v)
+		}
+	}
+}
+
+// TestGenerateFastSet_EdgeCases — defensive: zero k or zero pieces should
+// return nil rather than panic. The caller doesn't have to guard.
+func TestGenerateFastSet_EdgeCases(t *testing.T) {
+	var ih [20]byte
+	ip := net.IPv4(1, 2, 3, 4)
+	if got := GenerateFastSet(0, 100, ih, ip); got != nil {
+		t.Fatalf("k=0 should return nil, got %v", got)
+	}
+	if got := GenerateFastSet(5, 0, ih, ip); got != nil {
+		t.Fatalf("numPieces=0 should return nil, got %v", got)
+	}
+}

--- a/peerconn.go
+++ b/peerconn.go
@@ -28,6 +28,7 @@ import (
 	typedRoaring "github.com/anacrolix/torrent/typed-roaring"
 
 	"github.com/anacrolix/torrent/bencode"
+	"github.com/anacrolix/torrent/internal/fast"
 	requestStrategy "github.com/anacrolix/torrent/internal/request-strategy"
 
 	"github.com/anacrolix/torrent/merkle"
@@ -444,6 +445,35 @@ func (cn *PeerConn) postBitfield() {
 		Bitfield: cn.t.bitfield(),
 	})
 	cn.sentHaves = cn.t._completedPieces.Clone()
+}
+
+// sendAllowedFastSet computes the BEP 6 Allowed Fast Set for the remote peer
+// and sends one AllowedFast message per piece in the set. Callers must ensure
+// fastEnabled() and torrent metadata are available; the function is a no-op
+// when those preconditions don't hold or when the peer's address is not IPv4
+// (BEP 6 defines the algorithm only for IPv4).
+func (cn *PeerConn) sendAllowedFastSet() {
+	numPieces := uint32(cn.t.numPieces())
+	if numPieces == 0 {
+		return
+	}
+	ip := cn.remoteIp()
+	if ip == nil {
+		return
+	}
+	// BEP 6 derives the fast set from the BitTorrent v1 info hash. Torrents
+	// without a v1 hash (rare, v2-only) cannot produce a verifiable set.
+	if !cn.t.infoHash.Ok {
+		return
+	}
+	set := fast.GenerateFastSet(fast.DefaultK, numPieces, cn.t.infoHash.Value, ip)
+	for _, idx := range set {
+		cn.write(pp.Message{
+			Type:  pp.AllowedFast,
+			Index: pp.Integer(idx),
+		})
+		torrent.Add("allowed fasts sent", 1)
+	}
 }
 
 func (cn *PeerConn) handleOnNeedUpdateRequests() {
@@ -1017,6 +1047,10 @@ func (c *PeerConn) mainReadLoop() (err error) {
 		case pp.AllowedFast:
 			torrent.Add("allowed fasts received", 1)
 			log.Fmsg("peer allowed fast: %d", msg.Index).AddValues(c).LogLevel(log.Debug, c.t.logger)
+			// Record the allowed-fast piece so requesting.go and shouldRequestWithoutBias
+			// can serve requests for it while we are choked. Without this Add, the
+			// peerAllowedFast bitmap stays empty and AllowedFast is effectively a no-op.
+			c.peerAllowedFast.Add(pieceIndex(msg.Index))
 			c.onNeedUpdateRequests("PeerConn.mainReadLoop allowed fast")
 		case pp.Extended:
 			err = c.onReadExtendedMsg(msg.ExtendedID, msg.ExtendedPayload)


### PR DESCRIPTION
Closes #235.

Completes BEP 6 Fast Extension by adding the two missing pieces:

### 1. Bug fix: received `AllowedFast` was a no-op

Before this change, `case pp.AllowedFast` in `peerconn.mainReadLoop` logged the message but **never wrote to `peerAllowedFast`**. Every downstream check (`requesting.go`, `shouldRequestWithoutBias`, `peer.go:peerAllowedFast.Iterate`, `torrent.go:1548`) read an empty bitmap, so honoring a peer's allowed-fast set was effectively disabled.

### 2. New: send our Allowed Fast Set

When `fastEnabled()` and torrent metadata are available, we now compute the BEP 6 allowed-fast set for the remote peer and send one `AllowedFast` message per piece after the Have-all/Have-none/Bitfield decision in `sendInitialMessages`. Peers can request these pieces while choked, removing the cold-start penalty.

### Algorithm

`internal/fast/fast.go` — SHA1-based pseudorandom indices seeded with the /24-masked peer IP and v1 info hash. Pure function so peers can independently re-derive and verify. Returns nil for IPv6 (BEP 6 defines the algorithm for IPv4 only). Reference: [cenkalti/rain/internal/fast](https://github.com/cenkalti/rain/blob/master/internal/fast/fast.go) (as suggested in #235).

### Tests

`internal/fast/fast_test.go`:

- **BEP 6 canonical example**: ip=80.4.4.200, infohash=0xAA*20, numPieces=1313, k=7 ⇒ `[1059, 431, 808, 1217, 287, 376, 1188]` ✅
- Determinism (peers must reproduce the same set)
- /24 subnet stability (same subnet ⇒ same set, different subnet ⇒ different)
- IPv6 returns nil
- Uniqueness in collision-prone configurations (k = numPieces)
- Edge cases: k=0, numPieces=0

All existing tests pass. `storage/possum` fails locally on Windows due to a missing native `libpossum` library — unrelated to this change.

### Files

- `internal/fast/fast.go` — new package
- `internal/fast/fast_test.go` — new tests
- `peerconn.go` — fix receive path, add `sendAllowedFastSet`
- `client.go` — invoke `sendAllowedFastSet` after Have-all/Have-none/Bitfield

cc @cenkalti (parts of the algorithm are based on rain's implementation).