### PR TITLE
fix: reject unsolicited BEP 52 hashes messages

### DIFF
--- a/peerconn.go
+++ b/peerconn.go
@@ -1448,16 +1448,32 @@ file:
 }
 
 func (pc *PeerConn) onReadHashes(msg *pp.Message) (err error) {
+	hr := hashRequestFromMessage(*msg)
+	// A BEP 52 Hashes message is only meaningful as a response to a request we sent. Treat anything
+	// else as peer-controlled protocol noise so it can't allocate per-file hash state or touch unknown
+	// pieces roots.
+	if !g.MapContains(pc.sentHashRequests, hr) {
+		return fmt.Errorf("received unsolicited hashes message: %v", hr)
+	}
+	delete(pc.sentHashRequests, hr)
+	if msg.ProofLayers != 0 {
+		return errors.New("proof layers not supported")
+	}
+	if uint64(msg.Length) != uint64(len(msg.Hashes)) {
+		return fmt.Errorf("received %d hashes for length %d", len(msg.Hashes), msg.Length)
+	}
 	file := pc.t.getFileByPiecesRoot(msg.PiecesRoot)
+	if file == nil {
+		return fmt.Errorf("no file for pieces root %x", msg.PiecesRoot)
+	}
 	filePieceHashes := pc.receivedHashPieces[msg.PiecesRoot]
 	if filePieceHashes == nil {
 		filePieceHashes = make([][32]byte, file.numPieces())
 		g.MakeMapIfNil(&pc.receivedHashPieces)
 		pc.receivedHashPieces[msg.PiecesRoot] = filePieceHashes
 	}
-	if msg.ProofLayers != 0 {
-		// This isn't handled yet.
-		panic(msg.ProofLayers)
+	if uint64(msg.Index) > uint64(len(filePieceHashes)) {
+		return fmt.Errorf("hash index %d is past file piece count %d", msg.Index, len(filePieceHashes))
 	}
 	copy(filePieceHashes[msg.Index:], msg.Hashes)
 	root := merkle.RootWithPadHash(

--- a/peerconn_test.go
+++ b/peerconn_test.go
@@ -1,11 +1,13 @@
 package torrent
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/netip"
 	"sync"
@@ -16,9 +18,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 
+	"github.com/anacrolix/torrent/merkle"
 	"github.com/anacrolix/torrent/metainfo"
 	pp "github.com/anacrolix/torrent/peer_protocol"
 	"github.com/anacrolix/torrent/storage"
+	infohash_v2 "github.com/anacrolix/torrent/types/infohash-v2"
 )
 
 // Ensure that no race exists between sending a bitfield, and a subsequent
@@ -205,6 +209,127 @@ func BenchmarkConnectionMainReadLoop(b *testing.B) {
 	qt.Assert(b, qt.IsNil(err))
 	qt.Assert(b, qt.Equals(cn._stats.ChunksReadUseful.Int64(), int64(b.N)*int64(numRequests)))
 	qt.Assert(b, qt.IsTrue(t.smartBanCache.HasBlocks()))
+}
+
+func TestPeerConnRejectsUnsolicitedHashes(t *testing.T) {
+	var knownRoot infohash_v2.T
+	knownRoot[0] = 1
+	cl := &Client{}
+	cl._mu.client = cl
+	cl.slogger = slog.Default()
+	tor := &Torrent{
+		cl:        cl,
+		chunkSize: defaultChunkSize,
+		files: &[]*File{{
+			piecesRoot: g.Some(knownRoot),
+		}},
+	}
+	var msgBuf bytes.Buffer
+	// Feed the message through the read loop so this covers the network-reachable path, not just the
+	// private handler.
+	msg := pp.Message{
+		Type:   pp.Hashes,
+		Length: 1,
+		Hashes: [][32]byte{{}},
+	}
+	require.NoError(t, msg.WriteTo(&msgBuf))
+	cn := &PeerConn{
+		Peer: Peer{
+			cl:        cl,
+			t:         tor,
+			callbacks: &Callbacks{},
+		},
+		r: bytes.NewReader(msgBuf.Bytes()),
+	}
+
+	cl.lock()
+	err := cn.mainReadLoop()
+	cl.unlock()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsolicited hashes message")
+}
+
+func TestPeerConnAcceptsSolicitedHashes(t *testing.T) {
+	pieceHashes := [][32]byte{{}, {}}
+	piecesRoot := infohash_v2.T(merkle.Root(pieceHashes))
+	var v1Hash metainfo.Hash
+	cl := &Client{}
+	tor := &Torrent{
+		cl:        cl,
+		chunkSize: defaultChunkSize,
+		info: &metainfo.Info{
+			PieceLength: 1,
+		},
+		pieces: []Piece{
+			{hash: &v1Hash},
+			{hash: &v1Hash, index: 1},
+		},
+		files: &[]*File{{
+			t:          nil,
+			length:     2,
+			fi:         metainfo.FileInfo{Length: 2, PiecesRoot: g.Some(piecesRoot)},
+			piecesRoot: g.Some(piecesRoot),
+		}},
+	}
+	(*tor.files)[0].t = tor
+	for i := range tor.pieces {
+		tor.pieces[i].t = tor
+	}
+	msg := pp.Message{
+		Type:       pp.Hashes,
+		PiecesRoot: piecesRoot,
+		Length:     2,
+		Hashes:     pieceHashes,
+	}
+	cn := &PeerConn{
+		Peer: Peer{
+			cl: cl,
+			t:  tor,
+		},
+		sentHashRequests: map[hashRequest]struct{}{
+			hashRequestFromMessage(msg): {},
+		},
+	}
+
+	require.NoError(t, cn.onReadHashes(&msg))
+	require.NotContains(t, cn.sentHashRequests, hashRequestFromMessage(msg))
+	// Matching the requested root should promote the received file layer hashes into piece v2 hashes.
+	require.Equal(t, g.Some(pieceHashes[0]), tor.pieces[0].hashV2)
+	require.Equal(t, g.Some(pieceHashes[1]), tor.pieces[1].hashV2)
+}
+
+func TestPeerConnRejectsHashesForMissingRoot(t *testing.T) {
+	var knownRoot infohash_v2.T
+	knownRoot[0] = 1
+	var missingRoot infohash_v2.T
+	missingRoot[0] = 2
+	cl := &Client{}
+	tor := &Torrent{
+		cl:        cl,
+		chunkSize: defaultChunkSize,
+		files: &[]*File{{
+			piecesRoot: g.Some(knownRoot),
+		}},
+	}
+	msg := pp.Message{
+		Type:       pp.Hashes,
+		PiecesRoot: missingRoot,
+		Length:     1,
+		Hashes:     [][32]byte{{}},
+	}
+	cn := &PeerConn{
+		Peer: Peer{
+			cl: cl,
+			t:  tor,
+		},
+		sentHashRequests: map[hashRequest]struct{}{
+			hashRequestFromMessage(msg): {},
+		},
+	}
+
+	err := cn.onReadHashes(&msg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no file for pieces root")
 }
 
 func TestConnPexPeerFlags(t *testing.T) {


### PR DESCRIPTION
## Issue
This PR fixes a peer-triggered crash in the BEP 52 hash exchange path.

`PeerConn.onReadHashes` handles incoming `Hashes` messages from peers. Those messages are supposed to be responses to `HashRequest` messages sent by this client. Before this change, the handler accepted a Hashes message without first checking whether it matched an outstanding request from that peer.

That made the handler trust peer-controlled fields too early. A malicious or broken peer could send a `Hashes` message with a `pieces root` that does not belong to any file in the torrent. The code would call `getFileByPiecesRoot`, receive `nil`, and then dereference that file while creating the per-file hash buffer. That could panic the process.

This is reachable through the normal peer read path. The message is read from the network by `mainReadLoop`, dispatched through the `pp.Hashes` case, and then passed into `onReadHashes`. So even though `onReadHashes` is private, the bug is exposed to connected peers through the public networking behavior of the client.

For production users, this matters because a single malformed peer message should not be able to crash a long-running torrent client, gateway, crawler, or service using this library.


## Fix
This change makes `Hashes` handling validate the peer message before touching file hash state.

A `Hashes` message is now only accepted if it matches a hash request that was previously sent to that peer. If no matching request exists, the message is rejected as an unsolicited protocol message. When a matching response is accepted, the request entry is removed so the same response cannot be replayed to repeatedly trigger hash processing.

The handler now also rejects unsupported proof layers with an error instead of panicking, checks that the declared length matches the number of hashes in the message, verifies that the pieces root maps to a known file, and validates the hash index before copying into the stored hash slice.

Valid BEP 52 responses still work as before. Once the received hashes produce the expected file pieces root, the hashes are promoted into the torrent piece v2 hash state.

The fix is intentionally small and cheap for the peer read path. It uses the existing request-tracking map, adds only simple validation, does not add goroutines, does not introduce blocking work, and avoids allocating per-file hash state for unsolicited peer input.

## Tests
This PR adds focused coverage for the BEP 52 Hashes path.

`TestPeerConnRejectsUnsolicitedHashes` feeds a crafted `Hashes` message through `mainReadLoop`. This covers the real network-reachable path and verifies that an unsolicited message is rejected instead of reaching the old nil dereference.

`TestPeerConnRejectsHashesForMissingRoot` covers the explicit missing-root case. It simulates a response that matches an outstanding request but uses a pieces root that is not present in the torrent, and verifies the handler returns a protocol error instead of touching a nil file.

`TestPeerConnAcceptsSolicitedHashes` verifies the valid path still works. It builds a small BEP 52 file hash response, marks the corresponding request as outstanding, accepts the response, consumes the request, and checks that the received hashes are stored as v2 piece hashes.