### PR TITLE
tracker/http: handle malformed non-compact peer list entries

### DIFF
--- a/tracker/http/http_test.go
+++ b/tracker/http/http_test.go
@@ -73,3 +73,59 @@ func TestSetAnnounceInfohashParamWithSpaces(t *testing.T) {
 		qt.StringContains(someUrl.String(),
 			"info_hash=%2Bv%0A%A1x%93%200%C8G%DC%DF%8E%AE%BFV%0A%1B%D1l"))
 }
+
+// These cases cover various forms of malformed non-compact peer lists that a
+// tracker might return. Before the fix, several of these caused panics due to
+// bare type assertions on untrusted data.
+func TestUnmarshalPeersMalformed(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantCount int
+	}{
+		{
+			// Integer in the peers list instead of a peer dictionary.
+			name:      "NonDictInList",
+			input:     "d8:intervali1800e5:peersli42eee",
+			wantCount: 0,
+		},
+		{
+			// Two valid peer dicts with an invalid integer between them.
+			// Both valid peers should still be collected.
+			name:      "MixedValidAndInvalid",
+			input:     "d5:peersld2:ip7:1.2.3.44:porti6881eei99ed2:ip8:5.6.7.894:porti6882eeee",
+			wantCount: 2,
+		},
+		{
+			// Peer dict has "peer id" but is missing the required "ip" and "port".
+			name:      "MissingFields",
+			input:     "d5:peersld7:peer id4:testeee",
+			wantCount: 0,
+		},
+		{
+			// "ip" is an integer and "port" is a string — wrong types for both.
+			name:      "WrongFieldTypes",
+			input:     "d5:peersld2:ipi12345e4:port7:not-inteee",
+			wantCount: 0,
+		},
+		{
+			// Empty peers list should work fine.
+			name:      "EmptyList",
+			input:     "d5:peerslee",
+			wantCount: 0,
+		},
+		{
+			// "ip" value is a string, but not a valid IP address.
+			name:      "InvalidIP",
+			input:     "d5:peersld2:ip9:not-an-ip4:porti6881eeee",
+			wantCount: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var hr HttpResponse
+			require.NoError(t, bencode.Unmarshal([]byte(tc.input), &hr))
+			assert.Len(t, hr.Peers.List, tc.wantCount)
+		})
+	}
+}

--- a/tracker/http/peer.go
+++ b/tracker/http/peer.go
@@ -1,6 +1,7 @@
 package httpTracker
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -30,13 +31,37 @@ func (p Peer) String() string {
 	}
 }
 
-// Set from the non-compact form in BEP 3.
-func (p *Peer) FromDictInterface(d map[string]interface{}) {
-	p.IP = net.ParseIP(d["ip"].(string))
-	if _, ok := d["peer id"]; ok {
-		p.ID = []byte(d["peer id"].(string))
+// Package-level errors for malformed peer dictionaries. We use these instead of
+// fmt.Errorf to avoid allocating a new error string on every malformed entry,
+// since a hostile tracker could send many of them in a single response.
+var (
+	errPeerDictMissingIP   = errors.New("peer dict: missing or invalid \"ip\"")
+	errPeerDictMissingPort = errors.New("peer dict: missing or invalid \"port\"")
+)
+
+// Set from the non-compact form in BEP 3. Returns an error if required fields
+// are missing or have unexpected types.
+func (p *Peer) FromDictInterface(d map[string]interface{}) error {
+	ipStr, ok := d["ip"].(string)
+	if !ok {
+		return errPeerDictMissingIP
 	}
-	p.Port = int(d["port"].(int64))
+	p.IP = net.ParseIP(ipStr)
+	if p.IP == nil {
+		// Don't let garbage like "not-an-ip" through — a nil IP would cause
+		// problems when we actually try to connect to this peer later.
+		return errPeerDictMissingIP
+	}
+	// "peer id" is optional in BEP 3. Only set it if present and valid.
+	if peerIdStr, ok := d["peer id"].(string); ok {
+		p.ID = []byte(peerIdStr)
+	}
+	portVal, ok := d["port"].(int64)
+	if !ok {
+		return errPeerDictMissingPort
+	}
+	p.Port = int(portVal)
+	return nil
 }
 
 func (p Peer) FromNodeAddr(na krpc.NodeAddr) Peer {

--- a/tracker/http/protocol.go
+++ b/tracker/http/protocol.go
@@ -70,8 +70,18 @@ func (me *Peers) UnmarshalBencode(b []byte) (err error) {
 		vars.Add("http responses with list peers", 1)
 		me.Compact = false
 		for _, i := range v {
+			// BEP 3 peers are dictionaries. Skip malformed entries to avoid
+			// panicking on type assertions from untrusted tracker data.
+			peerDict, ok := i.(map[string]interface{})
+			if !ok {
+				continue
+			}
 			var p Peer
-			p.FromDictInterface(i.(map[string]interface{}))
+			// Use := here, not =. We don't want a parse error from the last
+			// entry to leak into the named return and fail the whole unmarshal.
+			if err := p.FromDictInterface(peerDict); err != nil {
+				continue
+			}
 			me.List = append(me.List, p)
 		}
 		return


### PR DESCRIPTION
### Issue
The non-compact peers list parser in `Peers.UnmarshalBencode` does a bare type assertion on each list element - `i.(map[string]interface{})` - without checking if the element is actually a dictionary. Inside `FromDictInterface`, the `ip` and `port` fields are also pulled out with unchecked assertions that panic on missing or wrong-typed values. So if a tracker sends back something like `peers: [42]` instead of the expected list of dictionaries, the client panics and crashes. Same thing happens if a dictionary is missing `ip` or `port`, or if those fields have the wrong types. Since tracker URLs come from untrusted torrent files and magnet links, and announces run automatically in the background, a single bad tracker response is enough to take down the whole process.

### Fix
Both layers now use safe comma-ok type assertions instead of bare ones. In `UnmarshalBencode`, each list element is checked before treating it as a peer dict. If it's not a dictionary, we just skip it - this way a response with some valid and some garbage peers still returns the good ones instead of failing entirely.

`FromDictInterface` now returns an error instead of panicking. It validates that `ip` is a string and actually parseable by `net.ParseIP` (so we don't end up with nil IPs in the system), and that `port` is an integer. `peer id` stays optional as per BEP 3. The errors are package-level sentinels using `errors.New` - no `fmt.Errorf` allocations per call, which matters when a hostile tracker sends many bad entries.

One subtle thing we caught while writing this: the original loop used `err = p.FromDictInterface(...)` which writes to the named return. If the last entry in the list was invalid, that error would leak out through the bare `return` even though we collected valid peers above it. Fixed by using `err :=` to keep it local, with a comment so nobody changes it back by mistake.

### Tests
Unit tests use a table-driven `TestUnmarshalPeersMalformed` with six subcases:

- **NonDictInList**: integer in peers list, the original crash trigger
- **MixedValidAndInvalid**: valid peers mixed with garbage, checks that good ones are still kept
- **MissingFields**: dict with only `peer id`, no `ip` or `port`
- **WrongFieldTypes**: `ip` as integer, `port` as string
- **EmptyList**: empty list, normal tracker behaviour
- **InvalidIP**: `ip` is a string but not a valid address, checks the `net.ParseIP` guard