### PR TITLE
fix BEP 52 metainfo handling

### DIFF
--- a/metainfo/file-tree.go
+++ b/metainfo/file-tree.go
@@ -1,6 +1,7 @@
 package metainfo
 
 import (
+	"fmt"
 	"iter"
 	"maps"
 	"slices"
@@ -156,4 +157,25 @@ func (ft *FileTree) PiecesRootAsByteArray() (ret g.Option[infohash_v2.T]) {
 	}
 	ret.Ok = true
 	return
+}
+
+// Validate checks structural invariants required by BEP 52. Non-empty leaf files must have a
+// pieces root of exactly 32 bytes; empty files must not have one.
+func (ft *FileTree) Validate() error {
+	var err error
+	ft.Walk(nil, func(path []string, node *FileTree) {
+		if err != nil {
+			return
+		}
+		if node.IsDir() {
+			return
+		}
+		n := len(node.File.PiecesRoot)
+		if node.File.Length > 0 && n != 32 {
+			err = fmt.Errorf("file %q: pieces root length %d, expected 32", path, n)
+		} else if node.File.Length == 0 && n != 0 {
+			err = fmt.Errorf("file %q: empty file has pieces root of length %d", path, n)
+		}
+	})
+	return err
 }

--- a/metainfo/info_test.go
+++ b/metainfo/info_test.go
@@ -1,6 +1,7 @@
 package metainfo
 
 import (
+	"strings"
 	"testing"
 
 	g "github.com/anacrolix/generics"
@@ -16,3 +17,95 @@ func TestMarshalInfo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, "d4:name0:12:piece lengthi0e6:pieces0:e", string(b))
 }
+
+func TestFileTreeValidate(t *testing.T) {
+	valid32 := strings.Repeat("x", 32)
+
+	for _, tc := range []struct {
+		name    string
+		tree    FileTree
+		wantErr bool
+	}{
+		{
+			name: "ValidNonEmptyFile",
+			tree: FileTree{
+				Dir: map[string]FileTree{
+					"a": {File: FileTreeFile{Length: 1024, PiecesRoot: valid32}},
+				},
+			},
+		},
+		{
+			name: "EmptyFileNoRoot",
+			tree: FileTree{
+				Dir: map[string]FileTree{
+					"a": {File: FileTreeFile{Length: 0, PiecesRoot: ""}},
+				},
+			},
+		},
+		{
+			name:    "ShortRoot",
+			wantErr: true,
+			tree: FileTree{
+				Dir: map[string]FileTree{
+					"a": {File: FileTreeFile{Length: 1, PiecesRoot: "short"}},
+				},
+			},
+		},
+		{
+			name:    "LongRoot",
+			wantErr: true,
+			tree: FileTree{
+				Dir: map[string]FileTree{
+					"a": {File: FileTreeFile{Length: 1, PiecesRoot: strings.Repeat("x", 64)}},
+				},
+			},
+		},
+		{
+			name:    "MissingRootNonEmptyFile",
+			wantErr: true,
+			tree: FileTree{
+				Dir: map[string]FileTree{
+					"a": {File: FileTreeFile{Length: 100, PiecesRoot: ""}},
+				},
+			},
+		},
+		{
+			name:    "EmptyFileWithRoot",
+			wantErr: true,
+			tree: FileTree{
+				Dir: map[string]FileTree{
+					"a": {File: FileTreeFile{Length: 0, PiecesRoot: valid32}},
+				},
+			},
+		},
+		{
+			name:    "NestedInvalidEntry",
+			wantErr: true,
+			tree: FileTree{
+				Dir: map[string]FileTree{
+					"dir": {
+						Dir: map[string]FileTree{
+							"good": {File: FileTreeFile{Length: 1, PiecesRoot: valid32}},
+							"bad":  {File: FileTreeFile{Length: 1, PiecesRoot: "short"}},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.tree.Validate()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected validation error")
+				}
+				t.Logf("got expected error: %v", err)
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+

--- a/misc.go
+++ b/misc.go
@@ -2,6 +2,7 @@ package torrent
 
 import (
 	"errors"
+	"fmt"
 	"net"
 
 	"github.com/RoaringBitmap/roaring/v2"
@@ -88,6 +89,11 @@ func torrentRequestOffset(torrentLength, pieceSize int64, r Request) (off int64)
 }
 
 func validateInfo(info *metainfo.Info) error {
+	if info.HasV2() {
+		if err := info.FileTree.Validate(); err != nil {
+			return fmt.Errorf("bad v2 file tree: %w", err)
+		}
+	}
 	if len(info.Pieces)%20 != 0 {
 		return errors.New("pieces has invalid length")
 	}

--- a/misc_test.go
+++ b/misc_test.go
@@ -5,8 +5,12 @@ import (
 	"strings"
 	"testing"
 
+	g "github.com/anacrolix/generics"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/anacrolix/torrent/metainfo"
+	infohash_v2 "github.com/anacrolix/torrent/types/infohash-v2"
 )
 
 func TestTorrentOffsetRequest(t *testing.T) {
@@ -26,4 +30,91 @@ func TestSpewConnStats(t *testing.T) {
 	t.Logf("\n%s", s)
 	lines := strings.Count(s, "\n")
 	assert.EqualValues(t, 2+reflect.ValueOf(ConnStats{}).NumField(), lines)
+}
+
+func TestValidateInfoShortV2Root(t *testing.T) {
+	info := metainfo.Info{
+		MetaVersion: 2,
+		PieceLength: 16384,
+		Name:        "x",
+		FileTree: metainfo.FileTree{
+			Dir: map[string]metainfo.FileTree{
+				"a": {File: metainfo.FileTreeFile{Length: 1, PiecesRoot: "short"}},
+			},
+		},
+	}
+	err := validateInfo(&info)
+	if err == nil {
+		t.Fatal("expected validateInfo to reject short pieces root")
+	}
+	if !strings.Contains(err.Error(), "pieces root length 5") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateInfoMissingV2Root(t *testing.T) {
+	info := metainfo.Info{
+		MetaVersion: 2,
+		PieceLength: 16384,
+		Name:        "x",
+		FileTree: metainfo.FileTree{
+			Dir: map[string]metainfo.FileTree{
+				"a": {File: metainfo.FileTreeFile{Length: 100, PiecesRoot: ""}},
+			},
+		},
+	}
+	err := validateInfo(&info)
+	if err == nil {
+		t.Fatal("expected validateInfo to reject missing pieces root on non-empty file")
+	}
+	if !strings.Contains(err.Error(), "pieces root length 0") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateInfoValidV2(t *testing.T) {
+	valid32 := strings.Repeat("x", 32)
+	info := metainfo.Info{
+		MetaVersion: 2,
+		PieceLength: 16384,
+		Name:        "x",
+		FileTree: metainfo.FileTree{
+			Dir: map[string]metainfo.FileTree{
+				"a": {File: metainfo.FileTreeFile{Length: 1024, PiecesRoot: valid32}},
+			},
+		},
+	}
+	err := validateInfo(&info)
+	if err != nil {
+		t.Fatalf("expected valid v2 info to pass, got: %v", err)
+	}
+}
+
+// End-to-end: AddTorrentSpec with a crafted v2 info dict containing a short pieces root
+// must return an error instead of panicking through PiecesRootAsByteArray.
+func TestAddTorrentSpecBadV2Root(t *testing.T) {
+	infoBytes := append(
+		[]byte("d9:file treed1:ad0:d6:lengthi1e11:pieces root5:shorteee6:lengthi1e12:meta versioni2e4:name1:x12:piece lengthi16384e6:pieces20:"),
+		make([]byte, metainfo.HashSize)...)
+	infoBytes = append(infoBytes, 'e')
+
+	cl, err := NewClient(TestingConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	_, _, err = cl.AddTorrentSpec(&TorrentSpec{
+		AddTorrentOpts: AddTorrentOpts{
+			InfoHash:   metainfo.HashBytes(infoBytes),
+			InfoHashV2: g.Some(infohash_v2.HashBytes(infoBytes)),
+			InfoBytes:  infoBytes,
+		},
+	})
+	if err == nil {
+		t.Fatal("expected AddTorrentSpec to reject malformed v2 pieces root")
+	}
+	if !strings.Contains(err.Error(), "bad v2 file tree") {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }

--- a/tracker/udp/client-race_test.go
+++ b/tracker/udp/client-race_test.go
@@ -1,0 +1,89 @@
+package udp
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Reproduces the data race reported in
+// https://github.com/erigontech/erigon/issues/20491: concurrent (*Client).Announce
+// calls receiving an ActionError response race on the unlocked
+// `cl.connIdIssued = time.Time{}` write inside (*Client).request — that write
+// races with the cl.mu-protected write at the end of doConnectRoundTrip on
+// another goroutine.
+//
+// The race is timing-sensitive — a single test invocation has roughly a 10%
+// chance of catching it. Run with `go test -race -count=20` to amplify.
+func TestRaceConcurrentAnnounceErrorResponse(t *testing.T) {
+	t.Parallel()
+	srv, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer srv.Close()
+
+	go func() {
+		buf := make([]byte, 0x800)
+		for {
+			n, addr, err := srv.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			if n < 16 {
+				continue
+			}
+			var rh RequestHeader
+			if err := binary.Read(bytes.NewReader(buf[:n]), binary.BigEndian, &rh); err != nil {
+				continue
+			}
+			var resp bytes.Buffer
+			switch rh.Action {
+			case ActionConnect:
+				_ = Write(&resp, ResponseHeader{Action: ActionConnect, TransactionId: rh.TransactionId})
+				_ = Write(&resp, ConnectionResponse{ConnectionId: 0xdeadbeef})
+			default:
+				_ = Write(&resp, ResponseHeader{Action: ActionError, TransactionId: rh.TransactionId})
+				resp.WriteString(ConnectionIdMissmatchNul)
+			}
+			if _, err := srv.WriteTo(resp.Bytes(), addr); err != nil {
+				return
+			}
+		}
+	}()
+
+	cc, err := NewConnClient(NewConnClientOpts{
+		Network: "udp",
+		Host:    srv.LocalAddr().String(),
+	})
+	require.NoError(t, err)
+	defer cc.Close()
+
+	// Force every request to attempt a fresh connect, maximising pressure on cl.connIdIssued.
+	cc.Client.shouldReconnectOverride = func() bool { return true }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const goroutines = 32
+	const perGoroutine = 200
+	var ar AnnounceRequest
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range perGoroutine {
+				if ctx.Err() != nil {
+					return
+				}
+				_, _, _ = cc.Announce(ctx, ar, Options{})
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/tracker/udp/client.go
+++ b/tracker/udp/client.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/anacrolix/dht/v2/krpc"
@@ -17,15 +19,28 @@ import (
 // Client interacts with UDP trackers via its Writer and Dispatcher. It has no knowledge of
 // connection specifics.
 type Client struct {
-	mu           ctxlock.Lock
-	connId       ConnectionId
+	// Guards connId / connIdIssued / connSeq. Held only for short, in-memory critical
+	// sections — never across network I/O.
+	stateMu sync.Mutex
+	// Serialises actual connect round-trips. Held across the connect's network I/O so a burst
+	// of expirations causes one roundtrip rather than N. Cancellable so a goroutine waiting
+	// for an in-flight connect can bail when its ctx is done.
+	connectMu ctxlock.Lock
+
+	connId ConnectionId
+	// Set to zero if connId is invalidated or expired (you can still use connId, but it's a hint
+	// to trigger a reconnect).
 	connIdIssued time.Time
+	// Local-only value tracking connection ID issuance. Incremented on connect replies.
+	connSeq connSeq
 
 	shouldReconnectOverride func() bool
 
 	Dispatcher *Dispatcher
 	Writer     io.Writer
 }
+
+type connSeq int
 
 func (cl *Client) Announce(
 	ctx context.Context, req AnnounceRequest, opts Options,
@@ -37,7 +52,7 @@ func (cl *Client) Announce(
 	peers AnnounceResponsePeers,
 	err error,
 ) {
-	respBody, addr, err := cl.request(ctx, ActionAnnounce, append(mustMarshal(req), opts.Encode()...))
+	respBody, addr, err := cl.actionRequest(ctx, ActionAnnounce, append(mustMarshal(req), opts.Encode()...))
 	if err != nil {
 		return
 	}
@@ -65,7 +80,7 @@ func (cl *Client) Scrape(
 ) (
 	out ScrapeResponse, err error,
 ) {
-	respBody, _, err := cl.request(ctx, ActionScrape, mustMarshal(ScrapeRequest(ihs)))
+	respBody, _, err := cl.actionRequest(ctx, ActionScrape, mustMarshal(ScrapeRequest(ihs)))
 	if err != nil {
 		return
 	}
@@ -85,77 +100,105 @@ func (cl *Client) Scrape(
 	return
 }
 
-func (cl *Client) shouldReconnectDefault() bool {
-	return cl.connIdIssued.IsZero() || time.Since(cl.connIdIssued) >= time.Minute
+// actionRequest runs an Announce or Scrape: get a connId, send the request, and on a
+// "Connection ID missmatch" reply, retry once. resetConn no-ops when another goroutine has
+// already reconnected, so the retry naturally reuses the newer connId rather than forcing
+// yet another connect.
+func (cl *Client) actionRequest(
+	ctx context.Context, action Action, body []byte,
+) (respBody []byte, addr net.Addr, err error) {
+	const maxAttempts = 2
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		var connId ConnectionId
+		var seq connSeq
+		connId, seq, err = cl.ensureConnId(ctx)
+		if err != nil {
+			return
+		}
+		respBody, addr, err = cl.request(ctx, action, body, connId)
+		if err == nil {
+			return
+		}
+		if !isConnIdMismatch(err) {
+			return
+		}
+		cl.resetConn(seq)
+	}
+	return
 }
 
-func (cl *Client) shouldReconnect() bool {
+func isConnIdMismatch(err error) bool {
+	var er ErrorResponse
+	return errors.As(err, &er) && er.Message == ConnectionIdMissmatchNul
+}
+
+// shouldReconnectLocked reports whether a fresh connect is needed. Caller must hold stateMu.
+func (cl *Client) shouldReconnectLocked() bool {
 	if cl.shouldReconnectOverride != nil {
 		return cl.shouldReconnectOverride()
 	}
-	return cl.shouldReconnectDefault()
+	return cl.connIdIssued.IsZero() || time.Since(cl.connIdIssued) >= time.Minute
 }
 
-func (cl *Client) connect(ctx context.Context) (err error) {
-	if !cl.shouldReconnect() {
-		return nil
+// ensureConnId returns a connection ID valid right now, performing a connect round-trip if
+// necessary. seq is the issuance generation; pass it to resetConn(seq) to invalidate without
+// clobbering a fresher connect issued by another goroutine.
+//
+// Caller must NOT hold stateMu or connectMu.
+func (cl *Client) ensureConnId(ctx context.Context) (id ConnectionId, seq connSeq, err error) {
+	cl.stateMu.Lock()
+	if !cl.shouldReconnectLocked() {
+		id, seq = cl.connId, cl.connSeq
+		cl.stateMu.Unlock()
+		return
 	}
+	cl.stateMu.Unlock()
+
+	if err = cl.connectMu.LockCtx(ctx); err != nil {
+		err = fmt.Errorf("locking connection: %w", err)
+		return
+	}
+	defer cl.connectMu.Unlock()
+
+	// Another goroutine may have completed a connect while we were waiting on connectMu.
+	cl.stateMu.Lock()
+	if !cl.shouldReconnectLocked() {
+		id, seq = cl.connId, cl.connSeq
+		cl.stateMu.Unlock()
+		return
+	}
+	cl.stateMu.Unlock()
+
 	return cl.doConnectRoundTrip(ctx)
 }
 
-// This just does the connect request and updates local state if it succeeds.
-func (cl *Client) doConnectRoundTrip(ctx context.Context) (err error) {
-	respBody, _, err := cl.request(ctx, ActionConnect, nil)
+// doConnectRoundTrip does the connect request and updates local state if it succeeds. Returns
+// the freshly-issued (id, seq). Caller MUST hold connectMu (this is what serialises concurrent
+// connects). stateMu is taken briefly only to publish the result.
+func (cl *Client) doConnectRoundTrip(ctx context.Context) (id ConnectionId, seq connSeq, err error) {
+	respBody, _, err := cl.request(ctx, ActionConnect, nil, ConnectRequestConnectionId)
 	if err != nil {
-		return err
+		return
 	}
 	var connResp ConnectionResponse
 	err = binary.Read(bytes.NewReader(respBody), binary.BigEndian, &connResp)
 	if err != nil {
 		return
 	}
+	cl.stateMu.Lock()
 	cl.connId = connResp.ConnectionId
 	cl.connIdIssued = time.Now()
-	//log.Printf("conn id set to %x", cl.connId)
-	return
-}
-
-func (cl *Client) connIdForRequest(ctx context.Context, action Action) (id ConnectionId, err error) {
-	if action == ActionConnect {
-		id = ConnectRequestConnectionId
-		return
-	}
-	err = cl.connect(ctx)
-	if err != nil {
-		return
-	}
-	id = cl.connId
+	cl.connSeq++
+	id, seq = cl.connId, cl.connSeq
+	cl.stateMu.Unlock()
 	return
 }
 
 func (cl *Client) writeRequest(
-	ctx context.Context, action Action, body []byte, tId TransactionId, buf *bytes.Buffer,
+	ctx context.Context, action Action, body []byte, tId TransactionId, connId ConnectionId, buf *bytes.Buffer,
 ) (
 	err error,
 ) {
-	var connId ConnectionId
-	if action == ActionConnect {
-		connId = ConnectRequestConnectionId
-	} else {
-		// We lock here while establishing a connection ID, and then ensuring that the request is
-		// written before allowing the connection ID to change again. This is to ensure the server
-		// doesn't assign us another ID before we've sent this request. Note that this doesn't allow
-		// for us to return if the context is cancelled while we wait to obtain a new ID.
-		err = cl.mu.LockCtx(ctx)
-		if err != nil {
-			return fmt.Errorf("locking connection id: %w", err)
-		}
-		defer cl.mu.Unlock()
-		connId, err = cl.connIdForRequest(ctx, action)
-		if err != nil {
-			return
-		}
-	}
 	buf.Reset()
 	err = Write(buf, RequestHeader{
 		ConnectionId:  connId,
@@ -167,8 +210,18 @@ func (cl *Client) writeRequest(
 	}
 	buf.Write(body)
 	_, err = cl.Writer.Write(buf.Bytes())
-	//log.Printf("sent request with conn id %x", connId)
 	return
+}
+
+// resetConn marks the connection ID as expired so the next ensureConnId reconnects. If
+// cl.connSeq has advanced past seq, another goroutine has already reconnected — nothing to
+// do, the next caller will see the fresher connId.
+func (cl *Client) resetConn(seq connSeq) {
+	cl.stateMu.Lock()
+	defer cl.stateMu.Unlock()
+	if cl.connSeq == seq {
+		cl.connIdIssued = time.Time{}
+	}
 }
 
 func (cl *Client) requestWriter(
@@ -176,10 +229,11 @@ func (cl *Client) requestWriter(
 	action Action,
 	body []byte,
 	tId TransactionId,
+	connId ConnectionId,
 ) (err error) {
 	var buf bytes.Buffer
 	for n := 0; ; n++ {
-		err = cl.writeRequest(ctx, action, body, tId, &buf)
+		err = cl.writeRequest(ctx, action, body, tId, connId, &buf)
 		if err != nil {
 			return
 		}
@@ -201,10 +255,14 @@ func (me ErrorResponse) Error() string {
 	return fmt.Sprintf("error response: %#q", me.Message)
 }
 
+// request sends a single tracker request with the provided connId and waits for the matching
+// response. It does not touch stateMu or connectMu. Connection-ID expiry is the caller's
+// concern (via ensureConnId / resetConn).
 func (cl *Client) request(
 	ctx context.Context,
 	action Action,
 	body []byte,
+	connId ConnectionId,
 ) (respBody []byte, addr net.Addr, err error) {
 	respChan := make(chan DispatchedResponse, 1)
 	t := cl.Dispatcher.NewTransaction(func(dr DispatchedResponse) {
@@ -215,7 +273,7 @@ func (cl *Client) request(
 	defer cancel()
 	writeErr := make(chan error, 1)
 	go func() {
-		writeErr <- cl.requestWriter(ctx, action, body, t.Id())
+		writeErr <- cl.requestWriter(ctx, action, body, t.Id(), connId)
 	}()
 	select {
 	case dr := <-respChan:
@@ -231,9 +289,6 @@ func (cl *Client) request(
 			if stringBody == ConnectionIdMissmatchNul {
 				err = log.WithLevel(log.Debug, err)
 			}
-			// Force a reconnection. Probably any error is worth doing this for, but the one we're
-			// specifically interested in is ConnectionIdMissmatchNul.
-			cl.connIdIssued = time.Time{}
 		default:
 			err = fmt.Errorf("unexpected response action %v", dr.Header.Action)
 		}


### PR DESCRIPTION
## Issue

This one came up while going through the BEP 52 metainfo handling paths. `FileTree.PiecesRootAsByteArray` copies the bencoded `pieces root` into a `[32]byte` and straight up panics if the length isn't exactly 32. The thing is, this gets called from `upvertedFilesInner`, which is the file tree iterator used by pretty much everything downstream - `FileSegmentsIndex()`, `initFiles()`, `cacheLength()`, `Piece.Length()`, all of them go through it.

Now, `validateInfo` is supposed to be the gate that catches bad metainfo before `setInfo` starts using it. But it doesn't actually check anything about the v2 file tree entries. So what happens is `validateInfo` passes fine, then `setInfo` calls `info.FileSegmentsIndex()`, the iterator walks into the file tree, hits `PiecesRootAsByteArray`, and the whole thing panics on the malformed root.

The annoying part is this is reachable through every public ingestion path - `AddTorrent`, `AddTorrentFromFile`, `AddTorrentSpec`, `SetInfoBytes`, and even through peer metadata exchange via `setInfoBytesLocked`. The panic fires before any piece transfer happens, right during the initial torrent setup itself.

For anyone running crawlers, gateways, or any long-running service that picks up untrusted torrents, one bad torrent file is enough to bring down the whole process. That's not great.

## Fix

Added a `FileTree.Validate()` method in `metainfo/file-tree.go`. It walks the v2 file tree and checks the BEP 52 structural requirements - non-empty files need exactly 32 bytes for the pieces root, and empty files shouldn't have one at all.

This gets called right at the top of `validateInfo()` in `misc.go`, before anything else touches the file tree. If the tree is malformed, `setInfo` returns a proper error and the torrent gets rejected cleanly - no storage gets opened, no files get initialised, no pieces get created.

The `panic(n)` in `PiecesRootAsByteArray` stays as it is. After the validation runs, it should never fire from untrusted input anymore. It's just a defensive invariant at that point, which is consistent with how `panicif` is used elsewhere in the codebase.

Kept the fix intentionally small. No signature changes to `PiecesRootAsByteArray`, no new allocations on the hot path, no changes to file iteration semantics. Valid BEP 52 torrents keep working exactly as before.

## Tests

Added coverage in the existing relevant test files:

- `TestFileTreeValidate` - table-driven test in `metainfo/info_test.go` for the new `Validate()` method. Covers valid files, empty files, short roots, long roots, missing roots on non-empty files, empty files with spurious roots, and nested directories with mixed good and bad entries.
- `TestValidateInfoShortV2Root` - checks that `validateInfo` rejects a v2 info dict where the pieces root is too short.
- `TestValidateInfoMissingV2Root` - checks that `validateInfo` catches a non-empty file with no pieces root at all.
- `TestValidateInfoValidV2` - makes sure valid v2 info still goes through fine, so we haven't broken the happy path.
- `TestAddTorrentSpecBadV2Root` - end-to-end through the public `AddTorrentSpec` API with crafted bencoded info bytes. Confirms the error comes back cleanly instead of panicking.
