### PR TITLE
fix(tracker): avoid data race reading trackerClients after unlock

### DIFF
--- a/client-tracker-announcer.go
+++ b/client-tracker-announcer.go
@@ -628,11 +628,17 @@ func (me *regularTrackerAnnounceDispatcher) singleAnnounce(
 	// A logger that includes the nice torrent group so we know what the announce is for.
 	logger = logger.With(t.slogGroup())
 	req := t.announceRequest(event, key.ShortInfohash)
+	// Capture the tracker client and announce options while the client lock is
+	// still held. trackerClients is mutated under the lock by initTrackerClient
+	// (via AddTrackers), so reading it after unlock is a data race and can trigger
+	// a fatal concurrent map read/write.
+	trackerClient := me.trackerClients[key.url].client
+	announceOpts := me.getAnnounceOpts()
 	me.torrentClient.unlock()
 	ctx, cancel := context.WithTimeout(context.TODO(), tracker.DefaultTrackerAnnounceTimeout)
 	defer cancel()
 	logger.Debug("announcing", "req", req)
-	resp, err := me.trackerClients[key.url].client.Announce(ctx, req, me.getAnnounceOpts())
+	resp, err := trackerClient.Announce(ctx, req, announceOpts)
 	now := time.Now()
 	{
 		level := slog.LevelDebug

--- a/client-tracker_test.go
+++ b/client-tracker_test.go
@@ -1,6 +1,7 @@
 package torrent
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -9,8 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coder/websocket"
 	qt "github.com/go-quicktest/qt"
-	"github.com/gorilla/websocket"
 
 	"github.com/anacrolix/torrent/internal/testutil"
 	"github.com/anacrolix/torrent/tracker"
@@ -57,23 +58,17 @@ func TestClientInvalidTracker(t *testing.T) {
 	to.Drop()
 }
 
-var upgrader = websocket.Upgrader{}
-
 func testtracker(w http.ResponseWriter, r *http.Request) {
-	c, err := upgrader.Upgrade(w, r, nil)
+	c, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
 	if err != nil {
 		return
 	}
-	defer c.Close()
+	defer c.CloseNow()
 	for {
-		_, _, err := c.ReadMessage()
+		_, _, err := c.Read(context.Background())
 		if err != nil {
 			break
 		}
-		//err = c.WriteMessage(mt, message)
-		//if err != nil {
-		//	break
-		//}
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0
 	github.com/bradfitz/iter v0.0.0-20191230175014-e8f45d346db8
 	github.com/cespare/xxhash v1.1.0
+	github.com/coder/websocket v1.8.15
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dustin/go-humanize v1.0.0
 	github.com/edsrzf/mmap-go v1.1.0
@@ -36,7 +37,6 @@ require (
 	github.com/go-quicktest/qt v1.101.0
 	github.com/google/btree v1.1.2
 	github.com/google/go-cmp v0.7.0
-	github.com/gorilla/websocket v1.5.0
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/pion/datachannel v1.5.9

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -293,8 +295,6 @@ github.com/gopherjs/gopherjs v0.0.0-20190309154008-847fc94819f9/go.mod h1:wJfORR
 github.com/gopherjs/gopherjs v0.0.0-20190910122728-9d188e94fb99/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
-github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3 h1:NmZ1PKzSTQbuGHw9DGPFomqkkLWMC+vZCkfs+FHv1Vg=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3/go.mod h1:zQrxl1YP88HQlA6i9c63DSVPFklWpGX4OWAc9bFuaH4=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/webtorrent/tracker-client.go
+++ b/webtorrent/tracker-client.go
@@ -12,7 +12,7 @@ import (
 
 	g "github.com/anacrolix/generics"
 	"github.com/anacrolix/log"
-	"github.com/gorilla/websocket"
+	"github.com/coder/websocket"
 	"github.com/pion/webrtc/v4"
 	"go.opentelemetry.io/otel/trace"
 
@@ -33,9 +33,10 @@ type TrackerClient struct {
 	PeerId             [20]byte
 	OnConn             onDataChannelOpen
 	// Deprecated: Use Slogger.
-	Logger  log.Logger
-	Slogger *slog.Logger
-	Dialer             *websocket.Dialer
+	Logger           log.Logger
+	Slogger          *slog.Logger
+	HttpClient       *http.Client
+	HandshakeTimeout time.Duration
 
 	mu             sync.Mutex
 	cond           sync.Cond
@@ -118,12 +119,24 @@ func (tc *TrackerClient) doWebsocket() error {
 		header = tc.WebsocketTrackerHttpHeader()
 	}
 
-	c, _, err := tc.Dialer.Dial(tc.Url, header)
+	dialCtx := context.Background()
+	if tc.HandshakeTimeout > 0 {
+		var cancel context.CancelFunc
+		dialCtx, cancel = context.WithTimeout(dialCtx, tc.HandshakeTimeout)
+		defer cancel()
+	}
+	c, _, err := websocket.Dial(dialCtx, tc.Url, &websocket.DialOptions{
+		HTTPClient: tc.HttpClient,
+		HTTPHeader: header,
+	})
 	if err != nil {
 		tc.OnDisconnected(err)
 		return fmt.Errorf("dialing tracker: %w", err)
 	}
-	defer c.Close()
+	// WebTorrent SDP offer/answer batches can exceed coder/websocket's 32 KiB
+	// default read limit; raise it so large announce responses aren't truncated.
+	c.SetReadLimit(1 << 20)
+	defer c.CloseNow()
 	tc.slogger().Debug("connected")
 	tc.mu.Lock()
 	tc.wsConn = c
@@ -135,24 +148,24 @@ func (tc *TrackerClient) doWebsocket() error {
 		for {
 			select {
 			case <-tc.pingTicker.C:
-				tc.mu.Lock()
-				err := c.WriteMessage(websocket.PingMessage, []byte{})
-				tc.mu.Unlock()
+				// coder/websocket's Ping sends a ping and waits for the pong; it is
+				// safe to call concurrently with Write. Bound it so a dead tracker
+				// stops the keepalive goroutine instead of blocking forever.
+				pingCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				err := c.Ping(pingCtx)
+				cancel()
 				if err != nil {
 					return
 				}
 			case <-closeChan:
 				return
-
 			}
 		}
 	}()
 	tc.OnConnected(nil)
-	err = tc.trackerReadLoop(tc.wsConn)
+	err = tc.trackerReadLoop(c)
 	close(closeChan)
-	tc.mu.Lock()
-	c.Close()
-	tc.mu.Unlock()
+	c.CloseNow()
 	return err
 }
 
@@ -184,7 +197,7 @@ func (tc *TrackerClient) Close() error {
 	tc.mu.Lock()
 	tc.closed = true
 	if tc.wsConn != nil {
-		tc.wsConn.Close()
+		tc.wsConn.CloseNow()
 	}
 	tc.closeUnusedOffers()
 	tc.pingTicker.Stop()
@@ -351,12 +364,12 @@ func (tc *TrackerClient) writeMessage(data []byte) error {
 		}
 		tc.cond.Wait()
 	}
-	return tc.wsConn.WriteMessage(websocket.TextMessage, data)
+	return tc.wsConn.Write(context.Background(), websocket.MessageText, data)
 }
 
 func (tc *TrackerClient) trackerReadLoop(tracker *websocket.Conn) error {
 	for {
-		_, message, err := tracker.ReadMessage()
+		_, message, err := tracker.Read(context.Background())
 		if err != nil {
 			return fmt.Errorf("read message error: %w", err)
 		}

--- a/wstracker.go
+++ b/wstracker.go
@@ -8,9 +8,9 @@ import (
 	netHttp "net/http"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/anacrolix/log"
-	"github.com/gorilla/websocket"
 	"github.com/pion/webrtc/v4"
 
 	"github.com/anacrolix/torrent/tracker"
@@ -69,19 +69,21 @@ func (me *websocketTrackers) Get(url string, infoHash [20]byte) (*webtorrent.Tra
 	defer me.mu.Unlock()
 	value, ok := me.clients[url]
 	if !ok {
-		dialer := &websocket.Dialer{
-			Proxy:            me.Proxy,
-			NetDialContext:   me.DialContext,
-			HandshakeTimeout: websocket.DefaultDialer.HandshakeTimeout,
+		httpClient := &netHttp.Client{
+			Transport: &netHttp.Transport{
+				Proxy:       me.Proxy,
+				DialContext: me.DialContext,
+			},
 		}
 		value = &refCountedWebtorrentTrackerClient{
 			TrackerClient: webtorrent.TrackerClient{
-				Dialer:             dialer,
-				Url:                url,
-				GetAnnounceRequest: me.GetAnnounceRequest,
-				PeerId:             me.PeerId,
-				OnConn:             me.OnConn,
-				Slogger: me.slogger().With("trackerClientUrl", url),
+				HttpClient:                 httpClient,
+				HandshakeTimeout:           45 * time.Second,
+				Url:                        url,
+				GetAnnounceRequest:         me.GetAnnounceRequest,
+				PeerId:                     me.PeerId,
+				OnConn:                     me.OnConn,
+				Slogger:                    me.slogger().With("trackerClientUrl", url),
 				WebsocketTrackerHttpHeader: me.WebsocketTrackerHttpHeader,
 				ICEServers:                 me.ICEServers,
 				OnConnected: func(err error) {


### PR DESCRIPTION
regularTrackerAnnounceDispatcher.singleAnnounce released the client lock and then read me.trackerClients[key.url] to perform the announce. That map is written under the client lock by initTrackerClient (via AddTrackers -> startTrackerAnnouncer), so reading it after unlock is a data race on a builtin map and can trigger a fatal "concurrent map read and map write" crash when trackers are added to torrents while announces are in flight.

Capture the tracker client and announce options (getAnnounceOpts only reads immutable config) into locals before unlocking, then announce with those. No behavior change.