### PR TITLE
tracker/udp: guard connIdIssued reset with mu

### DIFF
--- a/tracker/udp/client.go
+++ b/tracker/udp/client.go
@@ -233,7 +233,9 @@ func (cl *Client) request(
 			}
 			// Force a reconnection. Probably any error is worth doing this for, but the one we're
 			// specifically interested in is ConnectionIdMissmatchNul.
+			cl.mu.Lock()
 			cl.connIdIssued = time.Time{}
+			cl.mu.Unlock()
 		default:
 			err = fmt.Errorf("unexpected response action %v", dr.Header.Action)
 		}


### PR DESCRIPTION
The `ActionError` branch in `Client.request` resets `connIdIssued` to force a reconnection, but `request` handles the response with `cl.mu` released. That makes the reset a data race: `writeRequest` holds `mu` while reading/updating `connId`/`connIdIssued` (and holds it across the write, per the comment there), and concurrent announces on the same `Client` also write `connIdIssued`. Every other `connIdIssued` access is already under `mu`.

Surfaced by `-race` in a erigon — two `singleAnnounce` goroutines both reaching `request` → the `client.go` reset line.