### PR TITLE
Fix panic requesting hashes for files with 512n+1 pieces

### DIFF
--- a/peerconn.go
+++ b/peerconn.go
@@ -1455,9 +1455,10 @@ file:
 			// Minimizing to the number of pieces in a file conflicts with the BEP.
 			length := merkle.RoundUpToPowerOfTwo(uint(min(512, fileNumPieces-index)))
 			if length < 2 {
-				// This should have been filtered out by baseLayer and pieces root as piece hash
-				// checks.
-				panic(length)
+				// A file with fileNumPieces % 512 == 1 leaves a single trailing hash. The hash
+				// layer is padded to a power of two, so request the pad sibling too, per the BEP 52
+				// minimum length of 2. The responder pads hashes past the end of the file.
+				length = 2
 			}
 			if length%2 != 0 {
 				pc.protocolLogger.Levelf(log.Warning, "requesting odd hashes length %d", length)

--- a/peerconn_test.go
+++ b/peerconn_test.go
@@ -332,6 +332,59 @@ func TestPeerConnRejectsHashesForMissingRoot(t *testing.T) {
 	qt.Assert(t, qt.StringContains(err.Error(), "no file for pieces root"))
 }
 
+func TestRequestMissingHashesTrailingSingleHash(t *testing.T) {
+	// A v2 file with fileNumPieces % 512 == 1 leaves a single hash in the last
+	// request block. That used to round up to a request length of 1 and hit
+	// panic(length) in requestMissingHashes.
+	const numPieces = 513
+	const pieceLength = int64(1) << 14
+	var piecesRoot [32]byte
+	piecesRoot[0] = 1
+	cl := &Client{}
+	tor := &Torrent{
+		cl:        cl,
+		chunkSize: defaultChunkSize,
+		info: &metainfo.Info{
+			MetaVersion: 2,
+			Name:        "dummy",
+			PieceLength: pieceLength,
+			FileTree: metainfo.FileTree{
+				Dir: map[string]metainfo.FileTree{
+					"dummy": {File: metainfo.FileTreeFile{
+						Length:     pieceLength * numPieces,
+						PiecesRoot: string(piecesRoot[:]),
+					}},
+				},
+			},
+		},
+		pieces: make([]Piece, numPieces),
+	}
+	for i := range tor.pieces {
+		tor.pieces[i].t = tor
+	}
+	c := &PeerConn{
+		Peer: Peer{
+			cl: cl,
+			t:  tor,
+		},
+	}
+	c.legacyPeerImpl = c
+	c.peerImpl = c
+	c.v2 = true
+	c.peerSentHaveAll = true
+	c.initMessageWriter()
+	c.requestMissingHashes()
+	// The trailing block must be requested with the BEP 52 minimum length of 2.
+	trailing := false
+	for hr := range c.sentHashRequests {
+		if hr.index == 512 {
+			qt.Assert(t, qt.Equals(hr.length, pp.Integer(2)))
+			trailing = true
+		}
+	}
+	qt.Assert(t, qt.IsTrue(trailing))
+}
+
 func TestConnPexPeerFlags(t *testing.T) {
 	var (
 		tcpAddr = &net.TCPAddr{IP: net.IPv6loopback, Port: 4848}


### PR DESCRIPTION
Fixes #1061. A v2 file with fileNumPieces % 512 == 1 (e.g. 513 pieces) leaves a single hash in the last request block, which rounds up to a request length of 1 and hits the panic(length) in requestMissingHashes. Since the hash layer is padded to a power of two, request the pad sibling too with the BEP 52 minimum length of 2; getHashes on the responding side already pads hashes past the end of the file, and onReadHashes drops the extra hash in its bounded copy.