### PR TITLE
Fix worseConnSlice.keyStorage trim, and pool the ranking key arenas

### DIFF
--- a/bencode/api.go
+++ b/bencode/api.go
@@ -33,7 +33,7 @@ func (e *UnmarshalInvalidArgError) Error() string {
 		return "bencode: Unmarshal(nil)"
 	}
 
-	if e.Type.Kind() != reflect.Ptr {
+	if e.Type.Kind() != reflect.Pointer {
 		return "bencode: Unmarshal(non-pointer " + e.Type.String() + ")"
 	}
 	return "bencode: Unmarshal(nil " + e.Type.String() + ")"

--- a/bencode/decode.go
+++ b/bencode/decode.go
@@ -55,7 +55,7 @@ func (d *Decoder) Decode(v interface{}) (err error) {
 	}()
 
 	pv := reflect.ValueOf(v)
-	if pv.Kind() != reflect.Ptr || pv.IsNil() {
+	if pv.Kind() != reflect.Pointer || pv.IsNil() {
 		return &UnmarshalInvalidArgError{reflect.TypeOf(v)}
 	}
 
@@ -346,14 +346,14 @@ func parseStructFields(struct_ reflect.Type, each func(key string, df dictField)
 		f := struct_.Field(i)
 		if f.Anonymous {
 			t := f.Type
-			if t.Kind() == reflect.Ptr {
+			if t.Kind() == reflect.Pointer {
 				t = t.Elem()
 			}
 			parseStructFields(t, func(key string, df dictField) {
 				innerGet := df.Get
 				df.Get = func(value reflect.Value) func(reflect.Value) {
 					anonPtr := value.Field(i)
-					if anonPtr.Kind() == reflect.Ptr && anonPtr.IsNil() {
+					if anonPtr.Kind() == reflect.Pointer && anonPtr.IsNil() {
 						anonPtr.Set(reflect.New(f.Type.Elem()))
 						anonPtr = anonPtr.Elem()
 					}
@@ -603,7 +603,7 @@ func (d *Decoder) parseUnmarshaler(v reflect.Value) bool {
 // ("e") and no value was stored.
 func (d *Decoder) parseValue(v reflect.Value) (bool, error) {
 	// we support one level of indirection at the moment
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		// if the pointer is nil, allocate a new element of the type it
 		// points to
 		if v.IsNil() {

--- a/bencode/encode.go
+++ b/bencode/encode.go
@@ -83,7 +83,7 @@ func (e *Encoder) reflectByteSlice(s []byte) {
 // done successfully.
 func (e *Encoder) reflectMarshaler(v reflect.Value) bool {
 	if !v.Type().Implements(marshalerType) {
-		if v.Kind() != reflect.Ptr && v.CanAddr() && v.Addr().Type().Implements(marshalerType) {
+		if v.Kind() != reflect.Pointer && v.CanAddr() && v.Addr().Type().Implements(marshalerType) {
 			v = v.Addr()
 		} else {
 			return false
@@ -166,7 +166,7 @@ func (e *Encoder) reflectValue(v reflect.Value) {
 		e.reflectSequence(v)
 	case reflect.Interface:
 		e.reflectValue(v.Elem())
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if v.IsNil() {
 			v = reflect.Zero(v.Type().Elem())
 		} else {
@@ -249,7 +249,7 @@ func makeEncodeFields(t reflect.Type) (fs []encodeField) {
 		}
 		if f.Anonymous {
 			t := f.Type
-			if t.Kind() == reflect.Ptr {
+			if t.Kind() == reflect.Pointer {
 				t = t.Elem()
 			}
 			anonEFs := makeEncodeFields(t)
@@ -258,7 +258,7 @@ func makeEncodeFields(t reflect.Type) (fs []encodeField) {
 				bottomField := anonEF
 				bottomField.i = func(v reflect.Value) reflect.Value {
 					v = v.Field(i)
-					if v.Kind() == reflect.Ptr {
+					if v.Kind() == reflect.Pointer {
 						if v.IsNil() {
 							// This will skip serializing this value.
 							return reflect.Value{}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anacrolix/torrent
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.16.0

--- a/torrent.go
+++ b/torrent.go
@@ -517,17 +517,6 @@ func pieceFirstFileIndex(pieceOffset int64, files []*File) int {
 	return 0
 }
 
-// Returns the index after the last file containing the piece. files must be
-// ordered by offset.
-func pieceEndFileIndex(pieceEndOffset int64, files []*File) int {
-	for i, f := range files {
-		if f.offset >= pieceEndOffset {
-			return i
-		}
-	}
-	return len(files)
-}
-
 func (t *Torrent) cacheLength() {
 	var l int64
 	for _, f := range t.info.UpvertedFiles() {

--- a/torrent.go
+++ b/torrent.go
@@ -1419,7 +1419,11 @@ func getPeerConnSlice(cap int) []*PeerConn {
 // this is a frequent occurrence.
 func (t *Torrent) withUnclosedConns(f func([]*PeerConn)) {
 	sl := t.appendUnclosedConns(getPeerConnSlice(len(t.conns)))
+	defer putPeerConnSlice(sl)
 	f(sl)
+}
+
+func putPeerConnSlice(sl []*PeerConn) {
 	// Don't let the pooled backing array keep conns alive until the pool drains. The full capacity
 	// is cleared, not just the length, because a longer earlier use can have left conns beyond the
 	// current length.
@@ -1428,11 +1432,11 @@ func (t *Torrent) withUnclosedConns(f func([]*PeerConn)) {
 }
 
 func (t *Torrent) worstBadConnFromSlice(opts worseConnLensOpts, sl []*PeerConn) *PeerConn {
-	wcs := worseConnSlice{conns: sl}
-	wcs.initKeys(opts)
-	heap.Init(&wcs)
+	wcs := getWorseConnSlice(sl, opts)
+	defer wcs.release()
+	heap.Init(wcs)
 	for wcs.Len() != 0 {
-		c := heap.Pop(&wcs).(*PeerConn)
+		c := heap.Pop(wcs).(*PeerConn)
 		if opts.incomingIsBad && !c.outgoing {
 			return c
 		}
@@ -2596,15 +2600,15 @@ func (t *Torrent) SetMaxEstablishedConns(max int) (oldMax int) {
 	defer t.cl.unlock()
 	oldMax = t.maxEstablishedConns
 	t.maxEstablishedConns = max
-	wcs := worseConnSlice{
-		conns: t.appendConns(nil, func(*PeerConn) bool {
-			return true
-		}),
-	}
-	wcs.initKeys(worseConnLensOpts{})
-	heap.Init(&wcs)
+	conns := t.appendConns(getPeerConnSlice(len(t.conns)), func(*PeerConn) bool {
+		return true
+	})
+	defer putPeerConnSlice(conns)
+	wcs := getWorseConnSlice(conns, worseConnLensOpts{})
+	defer wcs.release()
+	heap.Init(wcs)
 	for len(t.conns) > t.maxEstablishedConns && wcs.Len() > 0 {
-		t.dropConnection(heap.Pop(&wcs).(*PeerConn))
+		t.dropConnection(heap.Pop(wcs).(*PeerConn))
 	}
 	t.openNewConns()
 	return oldMax

--- a/torrent.go
+++ b/torrent.go
@@ -1431,6 +1431,10 @@ func getPeerConnSlice(cap int) []*PeerConn {
 func (t *Torrent) withUnclosedConns(f func([]*PeerConn)) {
 	sl := t.appendUnclosedConns(getPeerConnSlice(len(t.conns)))
 	f(sl)
+	// Don't let the pooled backing array keep conns alive until the pool drains. The full capacity
+	// is cleared, not just the length, because a longer earlier use can have left conns beyond the
+	// current length.
+	clear(sl[:cap(sl)])
 	peerConnSlices.Put(&sl)
 }
 

--- a/torrent.go
+++ b/torrent.go
@@ -2901,13 +2901,17 @@ func (t *Torrent) finishHash(index pieceIndex) {
 	t.cl.activePieceHashers--
 }
 
-// Return the connections that touched a piece, and clear the entries while doing it.
+// Forget the connections that touched a piece, on both the piece and the peers.
 func (t *Torrent) clearPieceTouchers(pi pieceIndex) {
-	dirtiers := t.pieces[pi].dirtiers
-	for c := range dirtiers {
+	ps := &t.pieces[pi]
+	for c := range ps.dirtiers {
 		delete(c.peerTouchedPieces, pi)
-		delete(dirtiers, c)
 	}
+	// Release the map instead of just emptying it. Go maps never shrink, so an emptied map retains
+	// its header and group table (192 bytes for the 1-8 dirtier case that covers almost every
+	// piece) for the life of the Torrent. Torrents here have millions of pieces and most of them
+	// get dirtied at some point, so that dominated the heap. onDirtiedPiece remakes it on demand.
+	ps.dirtiers = nil
 }
 
 // Queue a check if one hasn't occurred before for the piece, and the completion state is unknown.

--- a/worse-conns.go
+++ b/worse-conns.go
@@ -112,7 +112,8 @@ func (me *worseConnSlice) Pop() interface{} {
 	me.keys[i] = nil
 	me.conns = me.conns[:i]
 	me.keys = me.keys[:i]
-	me.keyStorage = me.keyStorage[:i]
+	// keyStorage is only the arena the key pointers refer into. Swap permutes keys, not keyStorage,
+	// so keyStorage[i] doesn't correspond to keys[i] and trimming it would drop an arbitrary entry.
 	return ret
 }
 

--- a/worse-conns.go
+++ b/worse-conns.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 	"unsafe"
-
-	"github.com/anacrolix/sync"
 )
 
 type worseConnInput struct {
@@ -16,18 +14,20 @@ type worseConnInput struct {
 	CompletedHandshake time.Time
 	GetPeerPriority    func() (peerPriority, error)
 	Pointer            uintptr
+
+	peerPriority     peerPriority
+	peerPriorityErr  error
+	peerPriorityDone bool
 }
 
-func memoizePeerPriority(f func() (peerPriority, error)) func() (peerPriority, error) {
-	var once sync.Once
-	var prio peerPriority
-	var err error
-	return func() (peerPriority, error) {
-		once.Do(func() {
-			prio, err = f()
-		})
-		return prio, err
+// getPeerPriority memoizes the peer priority lookup. Ranking runs single-threaded under the client
+// lock, so this doesn't need to synchronize.
+func (me *worseConnInput) getPeerPriority() (peerPriority, error) {
+	if !me.peerPriorityDone {
+		me.peerPriority, me.peerPriorityErr = me.GetPeerPriority()
+		me.peerPriorityDone = true
 	}
+	return me.peerPriority, me.peerPriorityErr
 }
 
 type worseConnLensOpts struct {
@@ -41,7 +41,10 @@ func worseConnInputFromPeer(dst *worseConnInput, p *PeerConn, opts worseConnLens
 	dst.Useful = p.useful()
 	dst.LastHelpful = p.lastHelpful()
 	dst.CompletedHandshake = p.completedHandshake
-	dst.GetPeerPriority = memoizePeerPriority(p.peerPriority)
+	dst.GetPeerPriority = p.peerPriority
+	dst.peerPriority = 0
+	dst.peerPriorityErr = nil
+	dst.peerPriorityDone = false
 	dst.Pointer = uintptr(unsafe.Pointer(p))
 	if opts.incomingIsBad && !p.outgoing {
 		dst.BadDirection = true
@@ -65,9 +68,9 @@ func (l *worseConnInput) Less(r *worseConnInput) bool {
 	if !l.CompletedHandshake.Equal(r.CompletedHandshake) {
 		return l.CompletedHandshake.Before(r.CompletedHandshake)
 	}
-	lPeerPriority, lPeerPriorityErr := l.GetPeerPriority()
+	lPeerPriority, lPeerPriorityErr := l.getPeerPriority()
 	if lPeerPriorityErr == nil {
-		rPeerPriority, rPeerPriorityErr := r.GetPeerPriority()
+		rPeerPriority, rPeerPriorityErr := r.getPeerPriority()
 		if rPeerPriorityErr == nil && lPeerPriority != rPeerPriority {
 			return lPeerPriority < rPeerPriority
 		}

--- a/worse-conns.go
+++ b/worse-conns.go
@@ -3,8 +3,11 @@ package torrent
 import (
 	"container/heap"
 	"fmt"
+	"slices"
 	"time"
 	"unsafe"
+
+	"github.com/anacrolix/sync"
 )
 
 type worseConnInput struct {
@@ -87,12 +90,45 @@ type worseConnSlice struct {
 	keyStorage []worseConnInput
 }
 
+// A pool of worseConnSlice, to reuse the ranking key arenas. Ranking runs on every attempt to open
+// or accept a connection while a Torrent is at its established conn limit, and the arena is the bulk
+// of the memory it touches.
+var worseConnSlices sync.Pool
+
+// getWorseConnSlice returns a heap of the given conns, ranked with opts. Release it when done.
+func getWorseConnSlice(conns []*PeerConn, opts worseConnLensOpts) *worseConnSlice {
+	me, _ := worseConnSlices.Get().(*worseConnSlice)
+	if me == nil {
+		me = new(worseConnSlice)
+	}
+	me.conns = conns
+	me.initKeys(opts)
+	return me
+}
+
+// release returns the key arenas to the pool. The conns aren't owned by the worseConnSlice, so
+// they're only dropped, not returned anywhere.
+func (me *worseConnSlice) release() {
+	me.dropPeerRefs()
+	worseConnSlices.Put(me)
+}
+
+// dropPeerRefs discards everything that refers to a peer, so pooling a worseConnSlice doesn't keep
+// dead conns alive until the pool drains.
+func (me *worseConnSlice) dropPeerRefs() {
+	// The keys refer to peers through GetPeerPriority, so clear the full capacity rather than just
+	// the length: Pop trims the length, and an earlier longer use can have left keys beyond it.
+	clear(me.keyStorage[:cap(me.keyStorage)])
+	clear(me.keys[:cap(me.keys)])
+	me.conns = nil
+}
+
 // initKeys builds contiguous ranking keys for the heap so comparisons can reuse precomputed peer
 // metadata without one allocation per entry.
 func (me *worseConnSlice) initKeys(opts worseConnLensOpts) {
 	// Keep the key structs contiguous so heap comparisons don't allocate one object per peer.
-	me.keyStorage = make([]worseConnInput, len(me.conns))
-	me.keys = make([]*worseConnInput, len(me.conns))
+	me.keyStorage = slices.Grow(me.keyStorage[:0], len(me.conns))[:len(me.conns)]
+	me.keys = slices.Grow(me.keys[:0], len(me.conns))[:len(me.conns)]
 	for i, c := range me.conns {
 		worseConnInputFromPeer(&me.keyStorage[i], c, opts)
 		me.keys[i] = &me.keyStorage[i]

--- a/worse-conns_test.go
+++ b/worse-conns_test.go
@@ -149,6 +149,28 @@ func TestWorseConnSliceInitKeys(t *testing.T) {
 	qt.Check(t, qt.HasLen(remaining, 0))
 }
 
+// TestWorseConnSliceDropPeerRefs checks a worseConnSlice that has been through a partial drain
+// doesn't retain peers, since it's pooled for reuse.
+func TestWorseConnSliceDropPeerRefs(t *testing.T) {
+	cl := newTestingClient(t)
+	tor := cl.newTorrentForTesting()
+	wcs := worseConnSlice{conns: newTestingPeerConns(cl, tor, 8)}
+	wcs.initKeys(worseConnLensOpts{})
+	heap.Init(&wcs)
+	heap.Pop(&wcs)
+	heap.Pop(&wcs)
+	wcs.dropPeerRefs()
+	qt.Check(t, qt.IsNil(wcs.conns))
+	// The trimmed tails have to be cleared too, not just the live prefixes.
+	for _, key := range wcs.keys[:cap(wcs.keys)] {
+		qt.Check(t, qt.IsNil(key))
+	}
+	for _, key := range wcs.keyStorage[:cap(wcs.keyStorage)] {
+		qt.Check(t, qt.IsNil(key.GetPeerPriority))
+		qt.Check(t, qt.Equals(key.Pointer, 0))
+	}
+}
+
 // newTestingPeerConns adds distinct incoming conns to the Torrent and returns them.
 func newTestingPeerConns(cl *Client, tor *Torrent, num int) (ret []*PeerConn) {
 	ret = make([]*PeerConn, 0, num)

--- a/worse-conns_test.go
+++ b/worse-conns_test.go
@@ -1,9 +1,13 @@
 package torrent
 
 import (
+	"container/heap"
 	"errors"
+	"fmt"
+	"net"
 	"testing"
 	"time"
+	"unsafe"
 
 	qt "github.com/go-quicktest/qt"
 )
@@ -78,3 +82,106 @@ func TestWorseConnSameInputPanic(t *testing.T) {
 }
 
 var errPriorityLookup = errors.New("priority lookup failed")
+
+// TestWorseConnSliceHeapOrder checks the heap pops conns worst-first, exercising the index-based
+// Less, Swap and Pop against key storage that Swap doesn't permute.
+func TestWorseConnSliceHeapOrder(t *testing.T) {
+	const numConns = 16
+	wcs := worseConnSlice{
+		conns:      make([]*PeerConn, numConns),
+		keys:       make([]*worseConnInput, numConns),
+		keyStorage: make([]worseConnInput, numConns),
+	}
+	base := time.Now()
+	ranks := make(map[*PeerConn]int, numConns)
+	for i := range wcs.conns {
+		wcs.conns[i] = new(PeerConn)
+		// 7 is coprime with numConns, so this permutes the ranks and the initial slice order is
+		// neither sorted nor reversed.
+		rank := (i*7 + 3) % numConns
+		ranks[wcs.conns[i]] = rank
+		wcs.keyStorage[i] = worseConnInput{
+			LastHelpful: base.Add(time.Duration(rank) * time.Second),
+			Pointer:     uintptr(rank + 1),
+		}
+		wcs.keys[i] = &wcs.keyStorage[i]
+	}
+	heap.Init(&wcs)
+	var popped []int
+	for wcs.Len() != 0 {
+		popped = append(popped, ranks[heap.Pop(&wcs).(*PeerConn)])
+	}
+	// The oldest LastHelpful is the worst conn, so ranks come out ascending.
+	expected := make([]int, 0, numConns)
+	for i := range numConns {
+		expected = append(expected, i)
+	}
+	qt.Check(t, qt.DeepEquals(popped, expected))
+	qt.Check(t, qt.HasLen(wcs.conns, 0))
+	qt.Check(t, qt.HasLen(wcs.keys, 0))
+}
+
+// TestWorseConnSliceInitKeys checks keys are snapshotted from the peers they're built for, and that
+// draining the heap yields every conn exactly once.
+func TestWorseConnSliceInitKeys(t *testing.T) {
+	cl := newTestingClient(t)
+	tor := cl.newTorrentForTesting()
+	wcs := worseConnSlice{conns: newTestingPeerConns(cl, tor, 8)}
+	wcs.initKeys(worseConnLensOpts{incomingIsBad: true})
+	for i, c := range wcs.conns {
+		qt.Assert(t, qt.Equals(wcs.keys[i], &wcs.keyStorage[i]))
+		qt.Check(t, qt.Equals(wcs.keys[i].Pointer, uintptr(unsafe.Pointer(c))))
+		qt.Check(t, qt.Equals(wcs.keys[i].CompletedHandshake, c.completedHandshake))
+		// All the test conns are incoming, and incomingIsBad was set.
+		qt.Check(t, qt.IsTrue(wcs.keys[i].BadDirection))
+	}
+	remaining := make(map[*PeerConn]struct{}, len(wcs.conns))
+	for _, c := range wcs.conns {
+		remaining[c] = struct{}{}
+	}
+	heap.Init(&wcs)
+	for wcs.Len() != 0 {
+		c := heap.Pop(&wcs).(*PeerConn)
+		_, ok := remaining[c]
+		qt.Assert(t, qt.IsTrue(ok))
+		delete(remaining, c)
+	}
+	qt.Check(t, qt.HasLen(remaining, 0))
+}
+
+// newTestingPeerConns adds distinct incoming conns to the Torrent and returns them.
+func newTestingPeerConns(cl *Client, tor *Torrent, num int) (ret []*PeerConn) {
+	ret = make([]*PeerConn, 0, num)
+	for i := range num {
+		c := cl.newConnection(nil, newConnectionOpts{
+			network:    "test",
+			remoteAddr: &net.TCPAddr{IP: net.IPv4(1, 2, 3, byte(i+1)), Port: 1024 + i},
+			connString: fmt.Sprintf("test-%v", i),
+		})
+		c.setTorrent(tor)
+		c.completedHandshake = time.Now()
+		tor.conns[c] = struct{}{}
+		ret = append(ret, c)
+	}
+	return
+}
+
+func BenchmarkWorstBadConn(b *testing.B) {
+	for _, numConns := range []int{16, 64, 256} {
+		b.Run(fmt.Sprintf("%vConns", numConns), func(b *testing.B) {
+			cl := newTestingClient(b)
+			tor := cl.newTorrentForTesting()
+			newTestingPeerConns(cl, tor, numConns)
+			tor.maxEstablishedConns = numConns
+			opts := worseConnLensOpts{}
+			b.ReportAllocs()
+			for b.Loop() {
+				// Conns all completed their handshake just now, so nothing is droppable and the
+				// whole heap is drained.
+				if tor.worstBadConn(opts) != nil {
+					b.Fatal("expected no bad conn")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
`worseConnSlice.Pop` trimmed `keyStorage` as if it were index-parallel with `keys`, but `Swap` only permutes the key pointers, so after the first swap the trim dropped an arbitrary entry. It was harmless (only the slice length changed, and nothing reads `keyStorage` after `initKeys`) but it advertised a relationship that doesn't hold. Removed.

There was no test coverage of `worseConnSlice` at all — only of `worseConnInput.Less` — so this adds tests for the heap ordering, `initKeys`, and the release path, plus `BenchmarkWorstBadConn`.

The benchmark then answered the question of whether the pooling in this area is worth anything. It wasn't, as it stood: only the conns slice was pooled, and that's the smallest of the three slices. Per ranking of N conns there were 4N+4 allocations, 4 per conn coming from `memoizePeerPriority`'s `sync.Once`, captured variables and closures, and the key arena — around 90% of the bytes — was allocated and discarded every call.

Ranking runs single-threaded under the client lock, so the memoization is now plain fields on the key, and the whole `worseConnSlice` is pooled so the arenas are reused, with the keys cleared on release so pooled entries don't keep dead conns alive.

```
                         │     before     │                 after                 │
                         │     sec/op     │    sec/op      vs base                │
WorstBadConn/16Conns-16     2.182µ ± 18%    1.487µ ± 18%  -31.86% (p=0.000 n=8)
WorstBadConn/64Conns-16     8.700µ ±  4%    6.520µ ±  3%  -25.06% (p=0.000 n=8)
WorstBadConn/256Conns-16    46.20µ ± 14%    34.60µ ±  1%  -25.12% (p=0.000 n=8)

                         │      B/op      │                 B/op                  │
WorstBadConn/16Conns-16     3051.0 ± 0%      283.0 ± 0%   -90.72% (p=0.000 n=8)
WorstBadConn/64Conns-16    11.358Ki ± 0%    1.028Ki ± 0%  -90.95% (p=0.000 n=8)
WorstBadConn/256Conns-16   45.001Ki ± 0%    4.040Ki ± 0%  -91.02% (p=0.000 n=8)

                         │    allocs/op   │               allocs/op               │
WorstBadConn/16Conns-16      68.00 ± 0%      17.00 ± 0%   -75.00% (p=0.000 n=8)
WorstBadConn/64Conns-16     260.00 ± 0%      65.00 ± 0%   -75.00% (p=0.000 n=8)
WorstBadConn/256Conns-16    1028.0 ± 0%      257.0 ± 0%   -75.00% (p=0.000 n=8)
```

The remaining allocation per conn is the `p.peerPriority` bound method value. It could go by storing the peer in the key instead of a func, at the cost of a nil check to keep the func injectable from tests.

Note this branch sits on top of the 5 commits that were on local master but not yet pushed.
