### PR TITLE
Arm peer message writer wakeup before refilling its buffer

### DIFF
--- a/peer-conn-msg-writer.go
+++ b/peer-conn-msg-writer.go
@@ -84,6 +84,10 @@ func (cn *peerConnMsgWriter) run(keepAliveTimeout time.Duration) {
 		if cn.closed.IsSet() {
 			return
 		}
+		// Arm the condition before evaluating the predicate. BroadcastCond does
+		// not retain a broadcast when no channel is armed, and fillWriteBuffer
+		// runs without cn.mu while it observes peer state under another lock.
+		writeCond := cn.writeCond.Signaled()
 		cn.fillWriteBuffer()
 		keepAlive := cn.keepAlive()
 		cn.mu.Lock()
@@ -92,7 +96,6 @@ func (cn *peerConnMsgWriter) run(keepAliveTimeout time.Duration) {
 			torrent.Add("written keepalives", 1)
 		}
 		if cn.writeBuffer.Len() == 0 {
-			writeCond := cn.writeCond.Signaled()
 			cn.mu.Unlock()
 			select {
 			case <-cn.closed.Done():

--- a/peer-conn-msg-writer_test.go
+++ b/peer-conn-msg-writer_test.go
@@ -2,7 +2,9 @@ package torrent
 
 import (
 	"testing"
+	"time"
 
+	"github.com/anacrolix/chansync"
 	"github.com/dustin/go-humanize"
 
 	pp "github.com/anacrolix/torrent/peer_protocol"
@@ -63,5 +65,52 @@ func runBenchmarkMarshalBinaryWrite(b *testing.B, length int64) {
 		writer.writeBuffer.Reset()
 		//b.StartTimer()
 		writer.writeBuffer.Write(msg.MustMarshalBinary())
+	}
+}
+
+// BroadcastCond intentionally drops a broadcast when no Signaled channel is
+// armed. Force the refill/broadcast interleaving that used to strand the
+// writer: the first refill broadcasts while the buffer is empty, and only a
+// correctly pre-armed run loop can observe it and perform the second refill.
+func TestPeerConnMsgWriterArmsWakeupBeforeRefill(t *testing.T) {
+	closed := new(chansync.SetOnce)
+	secondRefill := make(chan struct{})
+	exited := make(chan struct{})
+	fillCalls := 0
+
+	var writer *peerConnMsgWriter
+	writer = &peerConnMsgWriter{
+		closed:      closed,
+		keepAlive:   func() bool { return false },
+		writeBuffer: new(peerConnMsgWriterBuffer),
+	}
+	writer.fillWriteBuffer = func() {
+		fillCalls++
+		switch fillCalls {
+		case 1:
+			writer.writeCond.Broadcast()
+		case 2:
+			close(secondRefill)
+			closed.Set()
+		}
+	}
+
+	go func() {
+		defer close(exited)
+		writer.run(time.Hour)
+	}()
+	t.Cleanup(func() {
+		closed.Set()
+		select {
+		case <-exited:
+		case <-time.After(time.Second):
+			t.Error("peer message writer did not exit after test cleanup")
+		}
+	})
+
+	select {
+	case <-secondRefill:
+	case <-time.After(time.Second):
+		t.Fatal("broadcast during refill was lost before the writer armed its condition")
 	}
 }


### PR DESCRIPTION
## What changed

- arm `writeCond` before `fillWriteBuffer` evaluates whether more peer messages are available
- add a deterministic regression that forces a broadcast during the first empty refill and requires a second refill

## Why

`BroadcastCond` does not retain a broadcast when no `Signaled` channel is armed. The peer message writer previously called `fillWriteBuffer` before arming `writeCond`, while the refill observes peer state outside `cn.mu`. A state transition could therefore broadcast during refill, leave the write buffer empty, and be lost before the writer began waiting. With no later transition, the writer remained asleep.

Arming the condition first retains a broadcast from that refill window without changing the existing closed-channel or keepalive selection.

## Validation

- `go test -run '^TestPeerConnMsgWriterArmsWakeupBeforeRefill$' -count=100 .`
- `cargo build` in the pinned `storage/possum/lib` submodule, then `go test ./...`
- `gofmt` and `git diff --check`

The regression uses channel synchronization and contains no timing sleep for the target interleaving. It fails on commit `8c67afb7185d42ea94dcced246596d79d35feb64` and passes after this change.
