### PR TITLE
fix(torrent): rearm the msg writer keepalive timer before parking

### DIFF
--- a/peer-conn-msg-writer.go
+++ b/peer-conn-msg-writer.go
@@ -84,6 +84,8 @@ func (cn *peerConnMsgWriter) run(keepAliveTimeout time.Duration) {
 		if cn.closed.IsSet() {
 			return
 		}
+		// Subscribe before checking for work, so a Broadcast landing while filling isn't dropped.
+		writeCond := cn.writeCond.Signaled()
 		cn.fillWriteBuffer()
 		keepAlive := cn.keepAlive()
 		cn.mu.Lock()
@@ -92,8 +94,14 @@ func (cn *peerConnMsgWriter) run(keepAliveTimeout time.Duration) {
 			torrent.Add("written keepalives", 1)
 		}
 		if cn.writeBuffer.Len() == 0 {
-			writeCond := cn.writeCond.Signaled()
 			cn.mu.Unlock()
+			// Wake at the keepalive deadline. If it has already passed (a keepalive wasn't wanted
+			// above), poll again in a full interval.
+			wait := keepAliveTimeout - time.Since(lastWrite)
+			if wait <= 0 {
+				wait = keepAliveTimeout
+			}
+			keepAliveTimer.Reset(wait)
 			select {
 			case <-cn.closed.Done():
 			case <-writeCond:
@@ -136,7 +144,6 @@ func (cn *peerConnMsgWriter) run(keepAliveTimeout time.Duration) {
 		cn.mu.Unlock()
 		frontBuf.pieceDataBytes = 0
 		lastWrite = time.Now()
-		keepAliveTimer.Reset(keepAliveTimeout)
 	}
 }
 

--- a/peer-conn-msg-writer.go
+++ b/peer-conn-msg-writer.go
@@ -97,6 +97,13 @@ func (cn *peerConnMsgWriter) run(keepAliveTimeout time.Duration) {
 		}
 		if cn.writeBuffer.Len() == 0 {
 			cn.mu.Unlock()
+			// Wake at the keepalive deadline. If it has already passed (a keepalive wasn't wanted
+			// above), poll again in a full interval.
+			wait := keepAliveTimeout - time.Since(lastWrite)
+			if wait <= 0 {
+				wait = keepAliveTimeout
+			}
+			keepAliveTimer.Reset(wait)
 			select {
 			case <-cn.closed.Done():
 			case <-writeCond:
@@ -139,7 +146,6 @@ func (cn *peerConnMsgWriter) run(keepAliveTimeout time.Duration) {
 		cn.mu.Unlock()
 		frontBuf.pieceDataBytes = 0
 		lastWrite = time.Now()
-		keepAliveTimer.Reset(keepAliveTimeout)
 	}
 }
 

--- a/peer-conn-msg-writer_test.go
+++ b/peer-conn-msg-writer_test.go
@@ -1,12 +1,178 @@
 package torrent
 
 import (
+	"bytes"
+	stdsync "sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/anacrolix/chansync"
+	"github.com/anacrolix/log"
 	"github.com/dustin/go-humanize"
 
 	pp "github.com/anacrolix/torrent/peer_protocol"
 )
+
+// Collects writer output and signals each write.
+type msgWriterSink struct {
+	mu    stdsync.Mutex
+	buf   bytes.Buffer
+	wrote chan struct{}
+}
+
+func newMsgWriterSink() *msgWriterSink {
+	return &msgWriterSink{wrote: make(chan struct{}, 1)}
+}
+
+func (me *msgWriterSink) Write(b []byte) (int, error) {
+	me.mu.Lock()
+	me.buf.Write(b)
+	me.mu.Unlock()
+	select {
+	case me.wrote <- struct{}{}:
+	default:
+	}
+	return len(b), nil
+}
+
+func (me *msgWriterSink) bytes() []byte {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	return append([]byte(nil), me.buf.Bytes()...)
+}
+
+// Runs the writer and returns an idempotent stop func that joins it. Also registered as cleanup.
+func startMsgWriter(t *testing.T, w *peerConnMsgWriter, closed *chansync.SetOnce, keepAliveTimeout time.Duration) func() {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		w.run(keepAliveTimeout)
+	}()
+	var stopOnce stdsync.Once
+	stop := func() {
+		stopOnce.Do(func() {
+			closed.Set()
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Error("message writer did not stop")
+			}
+		})
+	}
+	t.Cleanup(stop)
+	return stop
+}
+
+// A writeCond Broadcast issued after fillWriteBuffer has checked for pending work, but before the
+// writer parks, must not be lost: production never re-tickles while a request-update reason is
+// pending. The keepalive timeout is high so recovery can only come from the wakeup itself.
+func TestMsgWriterTickleDuringFillNotLost(t *testing.T) {
+	var (
+		closed  chansync.SetOnce
+		fills   atomic.Int32
+		pending atomic.Bool
+		w       *peerConnMsgWriter
+	)
+	sink := newMsgWriterSink()
+	checked := make(chan struct{})
+	release := make(chan struct{})
+	w = &peerConnMsgWriter{
+		fillWriteBuffer: func() {
+			switch fills.Add(1) {
+			case 1:
+				// The check finds nothing pending, then work arrives before the writer parks.
+				if pending.Load() {
+					t.Error("work pending before the first check")
+				}
+				close(checked)
+				select {
+				case <-release:
+				case <-closed.Done():
+				}
+			default:
+				if pending.CompareAndSwap(true, false) {
+					w.mu.Lock()
+					w.writeBuffer.WriteByte(0)
+					w.mu.Unlock()
+				}
+			}
+		},
+		closed:      &closed,
+		logger:      log.Default,
+		w:           sink,
+		keepAlive:   func() bool { return false },
+		writeBuffer: new(peerConnMsgWriterBuffer),
+	}
+	stop := startMsgWriter(t, w, &closed, time.Hour)
+	select {
+	case <-checked:
+	case <-time.After(10 * time.Second):
+		t.Fatal("writer never entered fillWriteBuffer")
+	}
+	pending.Store(true)
+	w.writeCond.Broadcast()
+	close(release)
+	select {
+	case <-sink.wrote:
+	case <-time.After(10 * time.Second):
+		t.Fatal("wakeup between fill and park was lost: writer never wrote")
+	}
+	stop()
+	if got := sink.bytes(); !bytes.Equal(got, []byte{0}) {
+		t.Fatalf("unexpected writer output: %x", got)
+	}
+}
+
+// After the keepalive timer fires without anything to write, it must be armed again: a connection
+// that later becomes useful gets its keepalive from the next expiration, with no tickle involved.
+func TestMsgWriterKeepAliveTimerRearmed(t *testing.T) {
+	const keepAliveTimeout = 20 * time.Millisecond
+	var (
+		closed          chansync.SetOnce
+		keepAliveChecks atomic.Int32
+		keepAliveNow    atomic.Bool
+	)
+	sink := newMsgWriterSink()
+	firstExpiredCheck := make(chan struct{})
+	w := &peerConnMsgWriter{
+		fillWriteBuffer: func() {},
+		closed:          &closed,
+		logger:          log.Default,
+		w:               sink,
+		keepAlive: func() bool {
+			// Capture before signaling, so the check following the first timer expiration is
+			// guaranteed to have observed false. Consuming the flag caps output at one keepalive,
+			// keeping the final output assertion exact regardless of scheduling.
+			check := keepAliveChecks.Add(1)
+			useful := keepAliveNow.CompareAndSwap(true, false)
+			if check == 2 {
+				close(firstExpiredCheck)
+			}
+			return useful
+		},
+		writeBuffer: new(peerConnMsgWriterBuffer),
+	}
+	stop := startMsgWriter(t, w, &closed, keepAliveTimeout)
+	// The check following the first timer expiration has run and returned false: the single-shot
+	// timer has been consumed while the connection wasn't useful.
+	select {
+	case <-firstExpiredCheck:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the first timer expiration")
+	}
+	keepAliveNow.Store(true)
+	select {
+	case <-sink.wrote:
+	case <-time.After(10 * time.Second):
+		t.Fatal("keepalive never written: timer was not rearmed after firing")
+	}
+	stop()
+	if got, want := sink.bytes(), (pp.Message{Keepalive: true}).MustMarshalBinary(); !bytes.Equal(got, want) {
+		t.Fatalf("unexpected writer output: got %x, want %x", got, want)
+	}
+}
 
 func PieceMsg(length int64) pp.Message {
 	return pp.Message{

--- a/peer-conn-msg-writer_test.go
+++ b/peer-conn-msg-writer_test.go
@@ -1,7 +1,9 @@
 package torrent
 
 import (
+	"bytes"
 	"io"
+	stdsync "sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -12,6 +14,106 @@ import (
 
 	pp "github.com/anacrolix/torrent/peer_protocol"
 )
+
+// Collects writer output and signals each write.
+type msgWriterSink struct {
+	mu    stdsync.Mutex
+	buf   bytes.Buffer
+	wrote chan struct{}
+}
+
+func newMsgWriterSink() *msgWriterSink {
+	return &msgWriterSink{wrote: make(chan struct{}, 1)}
+}
+
+func (me *msgWriterSink) Write(b []byte) (int, error) {
+	me.mu.Lock()
+	me.buf.Write(b)
+	me.mu.Unlock()
+	select {
+	case me.wrote <- struct{}{}:
+	default:
+	}
+	return len(b), nil
+}
+
+func (me *msgWriterSink) bytes() []byte {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	return append([]byte(nil), me.buf.Bytes()...)
+}
+
+// Runs the writer and returns an idempotent stop func that joins it. Also registered as cleanup.
+func startMsgWriter(t *testing.T, w *peerConnMsgWriter, closed *chansync.SetOnce, keepAliveTimeout time.Duration) func() {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		w.run(keepAliveTimeout)
+	}()
+	var stopOnce stdsync.Once
+	stop := func() {
+		stopOnce.Do(func() {
+			closed.Set()
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Error("message writer did not stop")
+			}
+		})
+	}
+	t.Cleanup(stop)
+	return stop
+}
+
+// After the keepalive timer fires without anything to write, it must be armed again: a connection
+// that later becomes useful gets its keepalive from the next expiration, with no tickle involved.
+func TestMsgWriterKeepAliveTimerRearmed(t *testing.T) {
+	const keepAliveTimeout = 20 * time.Millisecond
+	var (
+		closed          chansync.SetOnce
+		keepAliveChecks atomic.Int32
+		keepAliveNow    atomic.Bool
+	)
+	sink := newMsgWriterSink()
+	firstExpiredCheck := make(chan struct{})
+	w := &peerConnMsgWriter{
+		fillWriteBuffer: func() {},
+		closed:          &closed,
+		logger:          log.Default,
+		w:               sink,
+		keepAlive: func() bool {
+			// Capture before signaling, so the check following the first timer expiration is
+			// guaranteed to have observed false. Consuming the flag caps output at one keepalive,
+			// keeping the final output assertion exact regardless of scheduling.
+			check := keepAliveChecks.Add(1)
+			useful := keepAliveNow.CompareAndSwap(true, false)
+			if check == 2 {
+				close(firstExpiredCheck)
+			}
+			return useful
+		},
+		writeBuffer: new(peerConnMsgWriterBuffer),
+	}
+	stop := startMsgWriter(t, w, &closed, keepAliveTimeout)
+	// The check following the first timer expiration has run and returned false: the single-shot
+	// timer has been consumed while the connection wasn't useful.
+	select {
+	case <-firstExpiredCheck:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the first timer expiration")
+	}
+	keepAliveNow.Store(true)
+	select {
+	case <-sink.wrote:
+	case <-time.After(10 * time.Second):
+		t.Fatal("keepalive never written: timer was not rearmed after firing")
+	}
+	stop()
+	if got, want := sink.bytes(), (pp.Message{Keepalive: true}).MustMarshalBinary(); !bytes.Equal(got, want) {
+		t.Fatalf("unexpected writer output: got %x, want %x", got, want)
+	}
+}
 
 func PieceMsg(length int64) pp.Message {
 	return pp.Message{


### PR DESCRIPTION
Follow-up to #1078, [as suggested](https://github.com/anacrolix/torrent/pull/1071#issuecomment-5384689612). The wakeup-channel half of this PR landed there, so this is rebased onto master and reduced to the keepalive timer fix.

## Change

`keepAliveTimer` was only `Reset` after a successful write. One bare fire on an idle connection (nothing buffered, `keepAlive()` false) left the timer dead, so the periodic keepalive backstop was gone for the rest of the connection's life.

It is now armed before each park, with the time remaining until the keepalive deadline, falling back to a full interval once that deadline has passed. Arming per park also keeps the deadline accurate, where the old placement restarted the interval on every write.

## Tests

`TestMsgWriterKeepAliveTimerRearmed` lets the timer fire once while the connection is not yet useful, then makes it useful. No tickle is involved, so the keepalive can only come from a re-armed timer. It fails on master with `keepalive never written: timer was not rearmed after firing`, and passes under `-race` with the fix.

Most of the diff is the two helpers the test shares with the file, `msgWriterSink` and `startMsgWriter`.

## External validation

#1078 on its own was not enough downstream. The re-arm here was needed on top of it.

DataHearth/streamline#4 pins master plus this commit. Their bittorrent suite passes, 34/34, including a 30-download-cycle spec that reliably wedged under CPU contention on v1.61.
