### PR TITLE
possum: log ChunksReader at Debug, not Error

### DIFF
--- a/storage/possum/possum-provider.go
+++ b/storage/possum/possum-provider.go
@@ -70,8 +70,7 @@ type ChunkReader interface {
 // trying to read discontinuous or incomplete sequences of chunks?
 func (p Provider) ChunksReader(dir string) (ret storage.PieceReader, err error) {
 	prefix := dir + "/"
-	p.slogger().Error("ChunkReader", "prefix", prefix)
-	//debug.PrintStack()
+	p.slogger().Debug("ChunkReader", "prefix", prefix)
 	pr, err := p.Handle.NewReader()
 	if err != nil {
 		return


### PR DESCRIPTION
## Summary

`storage/possum.Provider.ChunksReader` logs at Error severity on every call. It is a routine reader constructor, not a failure path.

With a logger attached to the possum backend, every piece reader open emits an Error line. Filtering at Info still lets it through.

The sibling method `ReadConsecutiveChunks` logs the same kind of entry at Debug.

## Change

- Log `ChunksReader` at Debug, matching `ReadConsecutiveChunks`.
- Drop the commented-out `debug.PrintStack()` beside it; `runtime/debug` is not imported.

## Call path

`piecePerResourcePiece.NewReader` then `getChunksReader` then `ChunksReaderer.ChunksReader`, when the resource provider implements that interface, which possum does. It fires once per piece reader open, not only on failures.

## Verification

- `go build ./...` passes on this branch and on master.
- `go test -count=1 ./storage/ ./storage/possum/` passes on both. The possum package has benchmarks only, so the log level is not covered by a unit test; a logger-capture test seemed like more ceremony than the change warrants.

Happy to delete the line instead of demoting it, or to drop this entirely if the level was deliberate.
