### PR TITLE
storage: avoid recursive RLock in piece resource WriteTo fallback

### DIFF
--- a/storage/piece-resource.go
+++ b/storage/piece-resource.go
@@ -131,7 +131,14 @@ func (s piecePerResourcePiece) WriteTo(w io.Writer) (int64, error) {
 	if ccr, ok := s.rp.(ConsecutiveChunkReader); ok {
 		return s.writeConsecutiveChunks(ccr, s.incompleteDirPath(), w)
 	}
-	return io.Copy(w, io.NewSectionReader(s, 0, s.mp.Length()))
+	// Read chunks directly under the held RLock. SectionReader(s) would call
+	// ReadAt → NewReader and RLock again; sync.RWMutex is not recursive.
+	r, err := s.getChunksReader(s.incompleteDirPath())
+	if err != nil {
+		return 0, err
+	}
+	defer r.Close()
+	return io.Copy(w, io.NewSectionReader(r, 0, s.mp.Length()))
 }
 
 func (s piecePerResourcePiece) writeConsecutiveChunks(

--- a/storage/piece_resource_writeto_rlock_test.go
+++ b/storage/piece_resource_writeto_rlock_test.go
@@ -1,0 +1,127 @@
+package storage
+
+import (
+	"context"
+	"io"
+	"io/fs"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	g "github.com/anacrolix/generics"
+	"github.com/anacrolix/missinggo/v2/filecache"
+	"github.com/anacrolix/missinggo/v2/resource"
+
+	"github.com/anacrolix/torrent/metainfo"
+)
+
+// hangProvider does not implement ConsecutiveChunkReader. Incomplete WriteTo
+// therefore falls back to io.SectionReader(piece), which calls ReadAt → NewReader
+// and takes the piece RLock a second time. Blocking completed Stat once lets a
+// concurrent MarkComplete queue for Lock between those two RLocks.
+type hangProvider struct {
+	resource.Provider
+	statOnce sync.Once
+	entered  chan struct{}
+	release  chan struct{}
+}
+
+func (p *hangProvider) NewInstance(name string) (resource.Instance, error) {
+	i, err := p.Provider.NewInstance(name)
+	if err != nil {
+		return nil, err
+	}
+	return hangInstance{Instance: i, p: p, name: name}, nil
+}
+
+type hangInstance struct {
+	resource.Instance
+	p    *hangProvider
+	name string
+}
+
+func (i hangInstance) Stat() (fs.FileInfo, error) {
+	if strings.HasPrefix(i.name, "completed/") {
+		i.p.statOnce.Do(func() {
+			close(i.p.entered)
+			<-i.p.release
+		})
+	}
+	return i.Instance.Stat()
+}
+
+func (i hangInstance) Readdirnames() ([]string, error) {
+	return i.Instance.(resource.DirInstance).Readdirnames()
+}
+
+func TestWriteToFallbackRecursiveRLockDeadlock(t *testing.T) {
+	cache, err := filecache.NewCache(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	prov := &hangProvider{
+		Provider: cache.AsResourceProvider(),
+		entered:  make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+
+	info := metainfo.Info{
+		Files:       []metainfo.FileInfo{{Path: []string{"p"}, Length: 4}},
+		PieceLength: 4,
+		Pieces:      make([]byte, 20),
+	}
+	ti, err := NewResourcePieces(prov).OpenTorrent(
+		context.Background(), &info, metainfo.HashBytes([]byte("t")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ti.Close()
+
+	piece := ti.PieceWithHash(info.Piece(0), g.Some(make([]byte, 20)))
+	if _, err := piece.WriteAt([]byte("data"), 0); err != nil {
+		t.Fatal(err)
+	}
+	wt, ok := piece.(io.WriterTo)
+	if !ok {
+		t.Fatal("piecePerResourcePiece should implement io.WriterTo")
+	}
+
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := wt.WriteTo(io.Discard)
+		writeDone <- err
+	}()
+
+	select {
+	case <-prov.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("WriteTo never reached completed Stat under outer RLock")
+	}
+
+	markDone := make(chan error, 1)
+	go func() { markDone <- piece.MarkComplete() }()
+
+	// Let MarkComplete block on Lock behind WriteTo's held RLock.
+	time.Sleep(50 * time.Millisecond)
+	close(prov.release)
+
+	timeout := time.After(3 * time.Second)
+	var gotWrite, gotMark bool
+	for !gotWrite || !gotMark {
+		select {
+		case err := <-writeDone:
+			gotWrite = true
+			if err != nil {
+				t.Fatalf("WriteTo: %v", err)
+			}
+		case err := <-markDone:
+			gotMark = true
+			if err != nil {
+				t.Fatalf("MarkComplete: %v", err)
+			}
+		case <-timeout:
+			t.Fatalf("deadlock: WriteTo fallback re-acquires piece RLock via ReadAt/NewReader while MarkComplete waits for write lock (writeDone=%v markDone=%v)", gotWrite, gotMark)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`piecePerResourcePiece.WriteTo` holds the piece `RLock` for its whole body. For an incomplete piece whose provider does not implement `ConsecutiveChunkReader`, the fallback used `io.SectionReader` on the piece value itself. That read path calls `ReadAt` then `NewReader`, which takes the same `RLock` again.

`sync.RWMutex` is not recursive. If a writer is queued between the two `RLock` acquisitions, the second `RLock` blocks while the writer waits on the first. `MarkComplete` takes that write lock.

This is the same class of bug fixed in b623d9be ("Remove some recursive read locking") for `mustIsComplete` and `Completion` inside the same function.

## Reachability

- In-tree providers that do not implement `ConsecutiveChunkReader` take this fallback. `filecache.Cache.AsResourceProvider()` is one, used via `NewResourcePieces`.
- `storage/possum` implements `ConsecutiveChunkReader` and does not use this fallback.
- Default `Client` storage is `NewFile`, not `NewResourcePieces`, so the default file backend is unaffected.
- The engine hash-then-mark sequence runs `WriteTo` and `MarkComplete` sequentially on one piece and gates on `hashing` and `marking`, so the stock hasher does not currently self-collide on this path. The lock ordering is still wrong for any concurrent `WriteTo` and `MarkComplete` on the same resource piece.

## Change

In the incomplete non-`ConsecutiveChunkReader` fallback, obtain a chunks reader with `getChunksReader` under the `RLock` already held and copy from that, instead of `SectionReader` on the piece, which re-enters via `NewReader`.

Complete and `ConsecutiveChunkReader` paths are unchanged.

## Verification

- On the base commit, `go test -count=1 -timeout 30s ./storage/ -run TestWriteToFallbackRecursiveRLockDeadlock` fails in about three seconds with `deadlock: WriteTo fallback re-acquires piece RLock via ReadAt/NewReader while MarkComplete waits for write lock`.
- With the change, the same command passes.
- `go test -count=20 -race -timeout 30s ./storage/ -run TestWriteToFallbackRecursiveRLockDeadlock` passes 20 of 20.
- `go test -race ./storage/` passes.
