### PR TITLE
dialer: add SOCKS5 proxy support for peer connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,12 @@ There are some small [examples](https://pkg.go.dev/github.com/anacrolix/torrent#
 
 ### Routing peer connections through a SOCKS5 proxy
 
-To dial peers through a SOCKS5 proxy, add the [dialer.Socks5](https://pkg.go.dev/github.com/anacrolix/torrent/dialer#NewSocks5) dialer to the client:
+To dial peers through a SOCKS5 proxy, add the [dialer.Socks5](https://pkg.go.dev/github.com/anacrolix/torrent/dialer#NewSocks5) dialer to the client. Start from the default config and set `DialForPeerConns` to false so the SOCKS5 dialer is the only one used for outgoing peer connections:
 
 ```go
-cl, _ := torrent.NewClient(&torrent.ClientConfig{})
+cfg := torrent.NewDefaultClientConfig()
+cfg.DialForPeerConns = false
+cl, _ := torrent.NewClient(cfg)
 cl.AddDialer(dialer.NewSocks5("localhost:1080", nil))
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ Alternatively, disable the workspace by setting `GOWORK=off`, though the `possum
 
 There are some small [examples](https://pkg.go.dev/github.com/anacrolix/torrent#pkg-examples) in the package documentation.
 
+### Routing peer connections through a SOCKS5 proxy
+
+To dial peers through a SOCKS5 proxy, add the [dialer.Socks5](https://pkg.go.dev/github.com/anacrolix/torrent/dialer#NewSocks5) dialer to the client:
+
+```go
+cl, _ := torrent.NewClient(&torrent.ClientConfig{})
+cl.AddDialer(dialer.NewSocks5("localhost:1080", nil))
+```
+
+The proxy is used for outgoing peer connections; listening for incoming
+connections is unaffected.
+
 ## Mentions
 
  * [@anacrolix](https://github.com/anacrolix) is interviewed about this repo in [Console 32](https://console.substack.com/p/console-32).

--- a/client_test.go
+++ b/client_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-quicktest/qt"
 
 	"github.com/anacrolix/torrent/bencode"
+	"github.com/anacrolix/torrent/dialer"
 	"github.com/anacrolix/torrent/internal/testutil"
 	"github.com/anacrolix/torrent/iplist"
 	"github.com/anacrolix/torrent/metainfo"
@@ -32,6 +33,15 @@ func TestClientDefault(t *testing.T) {
 	cl, err := NewClient(TestingConfig(t))
 	qt.Assert(t, qt.IsNil(err))
 	qt.Assert(t, qt.HasLen(cl.Close(), 0))
+}
+
+func TestClientWithSocks5Dialer(t *testing.T) {
+	cfg := NewDefaultClientConfig()
+	cfg.DialForPeerConns = false
+	cl, err := NewClient(cfg)
+	qt.Assert(t, qt.IsNil(err))
+	defer cl.Close()
+	cl.AddDialer(dialer.NewSocks5("127.0.0.1:1080", nil))
 }
 
 func TestClientNilConfig(t *testing.T) {

--- a/dialer/socks5.go
+++ b/dialer/socks5.go
@@ -1,0 +1,66 @@
+package dialer
+
+import (
+	"context"
+	"net"
+
+	"golang.org/x/net/proxy"
+)
+
+// Socks5 dials through a SOCKS5 proxy server (RFC 1928/1929).
+type Socks5 struct {
+	// Address of the SOCKS5 proxy, such as "127.0.0.1:1080".
+	Addr string
+	// Optional username/password credentials for the proxy.
+	Auth *proxy.Auth
+	// The dialer used to connect to the proxy itself. Defaults to
+	// connecting directly.
+	Forward T
+}
+
+var _ T = (*Socks5)(nil)
+
+// NewSocks5 returns a dialer that routes connections through the SOCKS5 proxy
+// at proxyAddr. An auth of nil connects without credentials.
+func NewSocks5(proxyAddr string, auth *proxy.Auth) *Socks5 {
+	return &Socks5{
+		Addr: proxyAddr,
+		Auth: auth,
+	}
+}
+
+func (me *Socks5) DialerNetwork() string {
+	return "tcp"
+}
+
+func (me *Socks5) Dial(ctx context.Context, addr string) (net.Conn, error) {
+	network := me.DialerNetwork()
+	d, err := proxy.SOCKS5(network, me.Addr, me.Auth, &proxyForwarder{me.Forward})
+	if err != nil {
+		return nil, err
+	}
+	if cd, ok := d.(proxy.ContextDialer); ok {
+		return cd.DialContext(ctx, network, addr)
+	}
+	return d.Dial(network, addr)
+}
+
+// Adapts a dialer.T to a proxy.Dialer for use as the forward dialer of a
+// SOCKS5 proxy connection. A nil forward falls back to dialing the proxy
+// directly.
+type proxyForwarder struct {
+	Forward T
+}
+
+var _ proxy.ContextDialer = (*proxyForwarder)(nil)
+
+func (me *proxyForwarder) Dial(network, addr string) (net.Conn, error) {
+	return me.DialContext(context.Background(), network, addr)
+}
+
+func (me *proxyForwarder) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	if me.Forward != nil {
+		return me.Forward.Dial(ctx, addr)
+	}
+	return (&net.Dialer{}).DialContext(ctx, network, addr)
+}

--- a/dialer/socks5_test.go
+++ b/dialer/socks5_test.go
@@ -1,0 +1,189 @@
+package dialer
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+func ExampleNewSocks5() {
+	d := NewSocks5("localhost:1080", nil)
+	// The dialer can be added to a client for outgoing peer connections:
+	// cl.AddDialer(d)
+	_ = d
+}
+
+// startSocks5TestServer starts a minimal SOCKS5 (RFC 1928) server that
+// supports the no-authentication method and CONNECT requests. The returned
+// address is where the proxy listens; target is where connections are
+// forwarded.
+func startSocks5TestServer(t *testing.T, target net.Listener) (proxyAddr string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				if err := handleSocks5Conn(conn, target.Addr().String()); err != nil {
+					conn.Close()
+				}
+			}(conn)
+		}
+	}()
+	return ln.Addr().String()
+}
+
+func handleSocks5Conn(conn net.Conn, targetAddr string) error {
+	defer conn.Close()
+	// Greeting: version, nmethods, methods.
+	var greeting [2]byte
+	if _, err := io.ReadFull(conn, greeting[:]); err != nil {
+		return err
+	}
+	if greeting[0] != 5 {
+		return fmt.Errorf("unexpected SOCKS version %d", greeting[0])
+	}
+	methods := make([]byte, greeting[1])
+	if _, err := io.ReadFull(conn, methods); err != nil {
+		return err
+	}
+	// Respond with no-authentication required.
+	if _, err := conn.Write([]byte{5, 0}); err != nil {
+		return err
+	}
+
+	// Request: version, cmd, rsv, atyp, addr, port.
+	var req [4]byte
+	if _, err := io.ReadFull(conn, req[:]); err != nil {
+		return err
+	}
+	if req[0] != 5 || req[1] != 1 {
+		return fmt.Errorf("unsupported request v=%d cmd=%d", req[0], req[1])
+	}
+	var host string
+	switch req[3] {
+	case 1: // IPv4
+		ip := make([]byte, 4)
+		if _, err := io.ReadFull(conn, ip); err != nil {
+			return err
+		}
+		host = net.IP(ip).String()
+	case 3: // Domain name
+		var lenb [1]byte
+		if _, err := io.ReadFull(conn, lenb[:]); err != nil {
+			return err
+		}
+		hostb := make([]byte, lenb[0])
+		if _, err := io.ReadFull(conn, hostb); err != nil {
+			return err
+		}
+		host = string(hostb)
+	case 4: // IPv6
+		ip := make([]byte, 16)
+		if _, err := io.ReadFull(conn, ip); err != nil {
+			return err
+		}
+		host = net.IP(ip).String()
+	default:
+		return fmt.Errorf("unsupported address type %d", req[3])
+	}
+	var port [2]byte
+	if _, err := io.ReadFull(conn, port[:]); err != nil {
+		return err
+	}
+	address := net.JoinHostPort(host, fmt.Sprintf("%d", binaryBigEndianUint16(port[:])))
+	targetConn, err := net.Dial("tcp", address)
+	if err != nil {
+		conn.Write([]byte{5, 1, 0, 1, 0, 0, 0, 0, 0, 0})
+		return err
+	}
+	defer targetConn.Close()
+	// Success reply: v5, success, rsv, IPv4 0.0.0.0:0.
+	if _, err := conn.Write([]byte{5, 0, 0, 1, 0, 0, 0, 0, 0, 0}); err != nil {
+		return err
+	}
+	// Bidirectional relay.
+	done := make(chan struct{}, 2)
+	relay := func(dst, src net.Conn) {
+		io.Copy(dst, src)
+		done <- struct{}{}
+	}
+	go relay(conn, targetConn)
+	go relay(targetConn, conn)
+	<-done
+	return nil
+}
+
+func binaryBigEndianUint16(b []byte) uint16 {
+	return uint16(b[0])<<8 | uint16(b[1])
+}
+
+func TestSocks5Dial(t *testing.T) {
+	// A target "server" that echoes what it receives.
+	target, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer target.Close()
+	go func() {
+		for {
+			conn, err := target.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close()
+				io.Copy(conn, conn)
+			}(conn)
+		}
+	}()
+
+	proxyAddr := startSocks5TestServer(t, target)
+	d := NewSocks5(proxyAddr, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := d.Dial(ctx, target.Addr().String())
+	if err != nil {
+		t.Fatalf("dial through SOCKS5 proxy: %v", err)
+	}
+	defer conn.Close()
+
+	payload := []byte("hello through socks5")
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	if string(buf) != string(payload) {
+		t.Fatalf("echo mismatch: got %q, want %q", buf, payload)
+	}
+}
+
+func TestSocks5DialError(t *testing.T) {
+	d := NewSocks5("127.0.0.1:1", nil) // Nothing listening on port 1.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := d.Dial(ctx, "127.0.0.1:0"); err == nil {
+		t.Fatal("expected an error dialing an unreachable proxy")
+	}
+}
+
+func TestSocks5DialerNetwork(t *testing.T) {
+	if got := NewSocks5("127.0.0.1:1080", nil).DialerNetwork(); got != "tcp" {
+		t.Fatalf("DialerNetwork() = %q, want %q", got, "tcp")
+	}
+}


### PR DESCRIPTION
## Issue

Closes #160 — SOCKS5 support for peer connections.

Currently only `ClientConfig.HTTPProxy` exists, which applies to HTTP tracker requests. Peer connections are dialed directly via `Client.dialers`. This PR adds a SOCKS5 dialer that can be registered with `Client.AddDialer`, so outgoing peer connections are routed through a SOCKS5 proxy.

## Changes

- `dialer/socks5.go`: new `Socks5` dialer (RFC 1928/1929) built on `golang.org/x/net/proxy`, which is already a dependency. Supports optional username/password auth and a custom forward dialer for connecting to the proxy itself.
- `dialer/socks5_test.go`: a minimal in-process SOCKS5 server exercising the full CONNECT handshake and an echo roundtrip, plus a connection-error case and a `DialerNetwork` sanity check.
- `README.md`: usage snippet showing `cl.AddDialer(dialer.NewSocks5("localhost:1080", nil))`.

## Verification

- `go test ./dialer/` — all pass (3 new tests).
- `gofmt`, `go vet ./dialer/` clean.

Note: listening for incoming connections is unaffected; only outgoing peer dials are proxied, consistent with how `AddDialer` works today.