### PR TITLE
peer-conn-msg-writer: install wakeup channel before filling the buffer

### DIFF
--- a/peer-conn-msg-writer.go
+++ b/peer-conn-msg-writer.go
@@ -84,6 +84,10 @@ func (cn *peerConnMsgWriter) run(keepAliveTimeout time.Duration) {
 		if cn.closed.IsSet() {
 			return
 		}
+		// Install the wakeup channel before filling the buffer, so a
+		// Broadcast that lands during fillWriteBuffer closes a channel the
+		// select below observes, instead of being dropped. See #1070.
+		writeCond := cn.writeCond.Signaled()
 		cn.fillWriteBuffer()
 		keepAlive := cn.keepAlive()
 		cn.mu.Lock()
@@ -92,7 +96,6 @@ func (cn *peerConnMsgWriter) run(keepAliveTimeout time.Duration) {
 			torrent.Add("written keepalives", 1)
 		}
 		if cn.writeBuffer.Len() == 0 {
-			writeCond := cn.writeCond.Signaled()
 			cn.mu.Unlock()
 			select {
 			case <-cn.closed.Done():

--- a/peer-conn-msg-writer_test.go
+++ b/peer-conn-msg-writer_test.go
@@ -1,8 +1,13 @@
 package torrent
 
 import (
+	"io"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/anacrolix/chansync"
+	"github.com/anacrolix/log"
 	"github.com/dustin/go-humanize"
 
 	pp "github.com/anacrolix/torrent/peer_protocol"
@@ -47,6 +52,48 @@ func BenchmarkWritePieceMsg(b *testing.B) {
 				runBenchmarkMarshalBinaryWrite(b, int64(length))
 			})
 		})
+	}
+}
+
+// A broadcast that lands while fillWriteBuffer is running must not be
+// lost. The writer has to install its wakeup channel before filling, so
+// that a concurrent Broadcast closes a channel the subsequent select
+// observes. See #1070.
+func TestMsgWriterBroadcastDuringFillWakesWriter(t *testing.T) {
+	var w *peerConnMsgWriter
+	var fills atomic.Int32
+	w = &peerConnMsgWriter{
+		fillWriteBuffer: func() {
+			if fills.Add(1) == 1 {
+				w.writeCond.Broadcast()
+			}
+		},
+		closed:      new(chansync.SetOnce),
+		logger:      log.Default,
+		w:           io.Discard,
+		keepAlive:   func() bool { return false },
+		writeBuffer: new(peerConnMsgWriterBuffer),
+	}
+	done := make(chan struct{})
+	go func() {
+		w.run(time.Hour)
+		close(done)
+	}()
+	deadline := time.Now().Add(5 * time.Second)
+	for fills.Load() < 2 {
+		if time.Now().After(deadline) {
+			w.closed.Set()
+			w.writeCond.Broadcast()
+			t.Fatal("writer never woke after a broadcast during fill: wakeup lost")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	w.closed.Set()
+	w.writeCond.Broadcast()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("writer run did not return after close")
 	}
 }
 


### PR DESCRIPTION
Fixes #1070.

## What

`peerConnMsgWriter.run` called `fillWriteBuffer()` before installing the `writeCond.Signaled()` channel. A `Broadcast` landing during the fill (e.g. the request-update tickle from `onNeedUpdateRequests`) closes a channel nobody is about to select on, since `BroadcastCond.Broadcast` with no installed channel is a no-op — the wakeup is dropped and the peer wedges until the keepalive timer.

The fix installs the `Signaled()` channel ahead of the fill, so any broadcast during the fill closes a channel the subsequent select observes.

## How tested

New `TestMsgWriterBroadcastDuringFillWakesWriter` in `peer-conn-msg-writer_test.go`: a fake `fillWriteBuffer` broadcasts on its first invocation; the writer must complete a second fill within 5s. On the unfixed loop this fails deterministically (verified before applying the fix), with the fix it passes in ~0s. `go build ./...` and `go vet` clean.

Note: `go test -race` could not run on this machine (aarch64 host with 39-bit VMA, TSan requires 48 — fails on a trivial module too), so the test was run 5x without the race detector instead.
