### PR TITLE
announce dispatcher: don't record announce keys that couldn't be created

### DIFF
--- a/client-tracker-announcer.go
+++ b/client-tracker-announcer.go
@@ -439,14 +439,16 @@ func (me *regularTrackerAnnounceDispatcher) step() mytimer.TimeValue {
 	return me.nextTimerDelay()
 }
 
-func (me *regularTrackerAnnounceDispatcher) addKey(key torrentTrackerAnnouncerKey) {
+func (me *regularTrackerAnnounceDispatcher) addKey(key torrentTrackerAnnouncerKey) bool {
 	if me.announceData.ContainsKey(key) {
-		return
+		return true
 	}
 	t := me.torrentFromShortInfohash(key.ShortInfohash)
 	if t == nil {
-		// Crude, but the torrent was already dropped. We probably called AddTrackers late.
-		return
+		// Crude, but the torrent was already dropped. We probably called AddTrackers late. The
+		// caller must not record the key in that case, or updateTorrentInput will panic on the
+		// missing announceData entry.
+		return false
 	}
 	g.MakeMapIfNil(&me.torrentForAnnounceRequests)
 	// This can be duplicated when there's multiple trackers for a short infohash. That's fine.
@@ -462,6 +464,7 @@ func (me *regularTrackerAnnounceDispatcher) addKey(key torrentTrackerAnnouncerKe
 		infohashActive:         g.OptionFromTuple(me.infohashAnnouncing.Get(key.ShortInfohash)).Value.count,
 	})
 	me.updateTimer()
+	return true
 }
 
 // Returns nil if the torrent was dropped.

--- a/client-tracker-announcer_test.go
+++ b/client-tracker-announcer_test.go
@@ -9,9 +9,38 @@ import (
 	"testing/synctest"
 	"time"
 
+	g "github.com/anacrolix/generics"
 	"github.com/anacrolix/missinggo/v2/panicif"
 	"github.com/go-quicktest/qt"
+
+	"github.com/anacrolix/torrent/metainfo"
+	infohash_v2 "github.com/anacrolix/torrent/types/infohash-v2"
 )
+
+// Adding a torrent with a v2 infohash but no info bytes used to panic in
+// updateTorrentInput: addKey can't find the torrent by its v2 short hash
+// (not yet in torrentsByShortHash), returns early, but
+// initRegularTrackerAnnounceState still records the key and defers an
+// update. The subsequent updateTorrentInput then hits a key missing from
+// announceData. See #1068.
+func TestV2InfohashUpdateTorrentInputNoPanic(t *testing.T) {
+	cfg := TestingConfig(t)
+	cfg.DisableTrackers = false
+	cl, err := NewClient(cfg)
+	qt.Assert(t, qt.IsNil(err))
+	t.Cleanup(func() { cl.Close() })
+	infoBytes := []byte("d6:lengthi1e4:name1:x12:piece lengthi16384e6:pieces20:aaaaaaaaaaaaaaaaaaaae")
+	v2 := infohash_v2.HashBytes(infoBytes)
+	torr, new_ := cl.AddTorrentOpt(AddTorrentOpts{
+		InfoHash:   metainfo.HashBytes(infoBytes),
+		InfoHashV2: g.Some(v2),
+	})
+	qt.Assert(t, qt.IsTrue(new_))
+	torr.addTrackers([][]string{{"http://tracker.example.com:6969/announce"}})
+	cl.lock()
+	defer cl.unlock()
+	cl.regularTrackerAnnounceDispatcher.updateTorrentInput(torr)
+}
 
 // This test doesn't really do much useful anymore. It is useful to break apart the dispatcher a bit
 // for testing. It's good to have something that hits up the triggers a bit.

--- a/torrent.go
+++ b/torrent.go
@@ -2232,7 +2232,9 @@ func (t *Torrent) startScrapingTrackerWithInfohash(u *url.URL, urlStr trackerAnn
 // We need a key in regularTrackerAnnounceState to ensure we propagate next announce state values.
 func (t *Torrent) initRegularTrackerAnnounceState(key torrentTrackerAnnouncerKey) {
 	g.MakeMapIfNil(&t.regularTrackerAnnounceState)
-	t.cl.regularTrackerAnnounceDispatcher.addKey(key)
+	if !t.cl.regularTrackerAnnounceDispatcher.addKey(key) {
+		return
+	}
 	t.regularTrackerAnnounceState[key] = t.cl.regularTrackerAnnounceDispatcher.announceStates[key]
 	t.deferUpdateRegularTrackerAnnouncing()
 }


### PR DESCRIPTION
Fixes #1068.

## What

`initRegularTrackerAnnounceState` recorded the announce key on the torrent and deferred an input update unconditionally, even when `addKey` bailed out early. `addKey` returns early when `torrentFromShortInfohash(key.ShortInfohash)` is nil — which happens for the **v2** short infohash of a v2/hybrid torrent added without info bytes, because `torrentsByShortHash` only gains the v2 short hash later, in `hashInfoBytes`, when metadata arrives.

The deferred `updateTorrentInput` then iterates the recorded key and hits `panicif.False(res.Exists)` on the missing `announceData` entry — panicking the process from the dispatcher's timer goroutine, unrecoverable for embedding applications. The stack trace in the issue matches exactly.

## Fix

`addKey` now reports whether it registered the key, and `initRegularTrackerAnnounceState` only records the state and defers the update when it did. The `panicif` invariant in `updateTorrentInput` stays: every recorded key now genuinely has an `announceData` entry.

## How tested

New `TestV2InfohashUpdateTorrentInputNoPanic` (`client-tracker-announcer_test.go`): adds a hybrid (v1+v2 infohash) torrent with no info bytes plus a tracker, then runs an input update. On master this panics with `panic: false` at `client-tracker-announcer.go:583` via `step → timerFunc` — verified before applying the fix; with the fix it passes repeatedly. `go build ./...` clean.

Note: I could not run the full package test suite or `-race` in my environment (aarch64 host with 39-bit VMA — the race detector refuses with "unsupported VMA range" and large test binaries segfault intermittently, reproducible on unmodified master), so verification is via the focused tests above.

Follow-up worth considering: registering the v2 short hash in `torrentsByShortHash` at `AddTorrentOpt` time would make v2-key announces work even before metadata arrives, instead of being skipped until then.
