### PR TITLE
add test pinning TrackerDialContext use for http announces

### DIFF
--- a/client-tracker-dial-context_test.go
+++ b/client-tracker-dial-context_test.go
@@ -1,0 +1,70 @@
+package torrent
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	qt "github.com/go-quicktest/qt"
+
+	"github.com/anacrolix/torrent/metainfo"
+)
+
+// TrackerDialContext must be used when connecting to HTTP trackers. Regression
+// test for #1038, where the client-trackers refactor was reported as dropping
+// it.
+func TestTrackerDialContextUsedForHttpAnnounce(t *testing.T) {
+	trackerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/announce" {
+			http.NotFound(w, r)
+			return
+		}
+		// Minimal compact-response announce: one peer 127.0.0.1:8080.
+		w.Write([]byte("d8:completei1e10:incompletei1e8:intervali60e5:peers6:\x7f\x00\x00\x01\x1f\x90e"))
+	}))
+	defer trackerSrv.Close()
+
+	var mu sync.Mutex
+	var dialedAddrs []string
+	cfg := TestingConfig(t)
+	cfg.DisableTrackers = false
+	cfg.TrackerDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		mu.Lock()
+		dialedAddrs = append(dialedAddrs, network+" "+addr)
+		mu.Unlock()
+		var d net.Dialer
+		return d.DialContext(ctx, network, addr)
+	}
+	cl, err := NewClient(cfg)
+	qt.Assert(t, qt.IsNil(err))
+	t.Cleanup(func() { cl.Close() })
+
+	_, new_, err := cl.AddTorrentSpec(&TorrentSpec{
+		AddTorrentOpts: AddTorrentOpts{
+			InfoHash: metainfo.HashBytes([]byte("issue-1038-probe")),
+		},
+		Trackers: [][]string{{trackerSrv.URL + "/announce"}},
+	})
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.IsTrue(new_))
+
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		mu.Lock()
+		n := len(dialedAddrs)
+		mu.Unlock()
+		if n > 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			mu.Lock()
+			defer mu.Unlock()
+			t.Fatalf("TrackerDialContext never invoked; dialed=%v", dialedAddrs)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
Refs #1038.

## What

Adds `TestTrackerDialContextUsedForHttpAnnounce`: a local httptest tracker plus a recording `TrackerDialContext`, asserting the dialer is invoked for the announce of a metadata-less torrent added via `AddTorrentSpec`. This pins the contract requested in #1038 - if the client-trackers refactor (or anything else) ever stops routing tracker connections through the configured dialer, this fails loudly.

## Findings while investigating #1038

- The http announce path threads `config.TrackerDialContext` into `http.Transport.DialContext` in both v1.61.0 and current master; this test passes against both (verified by running it in a v1.61.0 worktree).
- The udp announce path has never gone through `TrackerDialContext` in either version - UDP has no dialer hook; `ClientConfig.TrackerListenPacket` is the extension point there, and that is unchanged too.
- So if the original report involved udp:// trackers, the proxy can only cover them via `TrackerListenPacket`; if https:// trackers were involved and it still failed on real NordVPN CONNECT proxies, I couldn't reproduce it locally and would need the tracker scheme from the reporter to dig further.
