### PR TITLE
tracker: reset announce state when re-adding a torrent

### DIFF
--- a/client-tracker-announcer.go
+++ b/client-tracker-announcer.go
@@ -440,9 +440,6 @@ func (me *regularTrackerAnnounceDispatcher) step() mytimer.TimeValue {
 }
 
 func (me *regularTrackerAnnounceDispatcher) addKey(key torrentTrackerAnnouncerKey) bool {
-	if me.announceData.ContainsKey(key) {
-		return true
-	}
 	t := me.torrentFromShortInfohash(key.ShortInfohash)
 	if t == nil {
 		// Crude, but the torrent was already dropped. We probably called AddTrackers late. The
@@ -458,6 +455,17 @@ func (me *regularTrackerAnnounceDispatcher) addKey(key torrentTrackerAnnouncerKe
 		g.MapMustAssignNew(me.announceStates, key, g.PtrTo(announceState{}))
 	}
 	t.regularTrackerAnnounceState[key] = g.MapMustGet(me.announceStates, key)
+	if me.announceData.ContainsKey(key) {
+		me.resetAnnounceStateForReadd(key)
+		res := me.announceData.Update(key, func(av nextAnnounceInput) nextAnnounceInput {
+			av.torrent = me.makeTorrentInput(t)
+			av.nextAnnounceStateInput = me.makeAnnounceStateInput(key)
+			return av
+		})
+		panicif.False(res.Exists)
+		me.updateTimer()
+		return true
+	}
 	me.announceData.Create(key, nextAnnounceInput{
 		torrent:                me.makeTorrentInput(t),
 		nextAnnounceStateInput: me.makeAnnounceStateInput(key),
@@ -562,6 +570,13 @@ func (me *regularTrackerAnnounceDispatcher) finishedAnnounce(key torrentTrackerA
 
 func (me *regularTrackerAnnounceDispatcher) syncAnnounceState(key torrentTrackerAnnouncerKey) {
 	input := me.makeAnnounceStateInput(key)
+
+	if input.When.IsZero() {
+		me.announceData.Delete(key)
+		delete(me.announceStates, key)
+		return
+	}
+
 	me.announceData.UpdateOrCreate(key, func(old nextAnnounceInput) nextAnnounceInput {
 		old.nextAnnounceStateInput = input
 		return old
@@ -676,6 +691,15 @@ func (me *regularTrackerAnnounceDispatcher) updateAnnounceState(
 	as := me.announceStates[key]
 	update(as)
 	me.syncAnnounceState(key)
+}
+
+func (me *regularTrackerAnnounceDispatcher) resetAnnounceStateForReadd(key torrentTrackerAnnouncerKey) {
+	me.updateAnnounceState(key, func(state *announceState) {
+		state.lastOk = lastAnnounceOk{}
+		state.Err = nil
+		state.lastAttemptCompleted = time.Time{}
+		state.sentCompleted = false
+	})
 }
 
 func (me *regularTrackerAnnounceDispatcher) getAnnounceOpts() trHttp.AnnounceOpt {
@@ -841,7 +865,7 @@ func (me *regularTrackerAnnounceDispatcher) nextAnnounceEvent(key torrentTracker
 	if !state.sentCompleted && t.sawInitiallyIncompleteData && t.haveAllPieces() {
 		return tracker.Completed, time.Now()
 	}
-	if lastOk.Completed.IsZero() {
+	if lastOk.Completed.IsZero() || lastOk.AnnouncedEvent == tracker.Stopped {
 		// Returning now should be fine as sorting should occur on "overdue" derived value.
 		return tracker.Started, time.Now()
 	}

--- a/client-tracker-announcer_test.go
+++ b/client-tracker-announcer_test.go
@@ -3,6 +3,7 @@
 package torrent
 
 import (
+	"errors"
 	"log/slog"
 	"net/url"
 	"testing"
@@ -11,6 +12,7 @@ import (
 
 	g "github.com/anacrolix/generics"
 	"github.com/anacrolix/missinggo/v2/panicif"
+	"github.com/anacrolix/torrent/tracker"
 	"github.com/go-quicktest/qt"
 
 	"github.com/anacrolix/torrent/metainfo"
@@ -80,4 +82,46 @@ func TestUpdateOverdueRecursion(t *testing.T) {
 		// updateOverdue we can test for thrashing, but it's non-trivial.
 		d.updateOverdue()
 	})
+}
+
+func TestReAddForcesFreshStartedAnnounce(t *testing.T) {
+	cl := &Client{
+		config:              &ClientConfig{TorrentPeersLowWater: 50},
+		torrents:            make(map[*Torrent]struct{}),
+		torrentsByShortHash: make(map[shortInfohash]*Torrent),
+	}
+	tor := &Torrent{cl: cl}
+	cl.torrents[tor] = struct{}{}
+
+	var key torrentTrackerAnnouncerKey
+	key.ShortInfohash[0] = 1
+	key.url = trackerAnnouncerKey("http://tracker.example/announce")
+	cl.torrentsByShortHash[key.ShortInfohash] = tor
+
+	d := regularTrackerAnnounceDispatcher{torrentClient: cl, logger: slog.Default()}
+	d.initTables()
+	d.initTimerNoop()
+	u, err := url.Parse(string(key.url))
+	qt.Assert(t, qt.IsNil(err))
+	d.initTrackerClient(u, key.url, cl.config, slog.Default())
+	d.announceStates = map[torrentTrackerAnnouncerKey]*announceState{
+		key: {
+			lastOk: lastAnnounceOk{
+				AnnouncedEvent: tracker.None,
+				Completed:      time.Now(),
+				Interval:       time.Hour,
+			},
+			Err:                  errors.New("stale announce error"),
+			lastAttemptCompleted: time.Now(),
+			sentCompleted:        true,
+		},
+	}
+	d.resetAnnounceStateForReadd(key)
+
+	event, when := d.nextAnnounceEvent(key)
+	qt.Assert(t, qt.Equals(event, tracker.Started))
+	qt.Assert(t, qt.IsFalse(when.IsZero()))
+	state := d.announceStates[key]
+	qt.Assert(t, qt.IsFalse(state.sentCompleted))
+	qt.Assert(t, qt.IsNil(state.Err))
 }


### PR DESCRIPTION
A dropped torrent can leave announce state behind for an existing tracker key. If the same torrent is added again, the dispatcher reuses stale lifecycle state and torrent input. This can prevent a fresh `Started` announce and leave the re-added torrent unable to discover peers.

This change:

- associates the replacement torrent before handling an existing announce key;
- resets stale announce error, completion, and interval state;
- refreshes the indexed torrent and announce-state input;
- removes dormant announce entries once they have no next event; and
- treats a previous `Stopped` event as requiring a new `Started` announce.

A regression test covers re-adding a torrent with stale announce state.

Tests:

- `go test -timeout=5m ./...`
