### PR TITLE
peerconn: reuse chunk pool buffers for peer request data

### DIFF
--- a/client-tracker-announcer_test.go
+++ b/client-tracker-announcer_test.go
@@ -36,9 +36,9 @@ func TestV2InfohashUpdateTorrentInputNoPanic(t *testing.T) {
 		InfoHashV2: g.Some(v2),
 	})
 	qt.Assert(t, qt.IsTrue(new_))
-	torr.addTrackers([][]string{{"http://tracker.example.com:6969/announce"}})
 	cl.lock()
 	defer cl.unlock()
+	torr.addTrackers([][]string{{"http://tracker.example.com:6969/announce"}})
 	cl.regularTrackerAnnounceDispatcher.updateTorrentInput(torr)
 }
 

--- a/peerconn.go
+++ b/peerconn.go
@@ -115,7 +115,7 @@ type PeerConn struct {
 	// Requests from the peer that haven't yet been read from storage for upload.
 	unreadPeerRequests map[Request]struct{}
 	// Peer request data that's ready to be uploaded.
-	readyPeerRequests map[Request][]byte
+	readyPeerRequests map[Request]peerRequestData
 	// Total peer request data buffered has decreased, so the server can read more.
 	peerRequestDataAllocDecreased chansync.BroadcastCond
 	// A routine is handling buffering peer request data.
@@ -257,6 +257,7 @@ func (cn *PeerConn) utp() bool {
 }
 
 func (cn *PeerConn) onClose() {
+	cn.deleteAllPeerRequests()
 	if cn.pex.IsEnabled() {
 		cn.pex.Close()
 	}
@@ -340,6 +341,9 @@ func (cn *PeerConn) choke(msg messageWriter) (more bool) {
 
 func (cn *PeerConn) deleteAllPeerRequests() {
 	clear(cn.unreadPeerRequests)
+	for _, prd := range cn.readyPeerRequests {
+		cn.releasePeerRequestData(prd)
+	}
 	clear(cn.readyPeerRequests)
 }
 
@@ -778,14 +782,24 @@ func (c *PeerConn) waitForDataAlloc(size int) bool {
 	}
 }
 
-func (me *PeerConn) deleteReadyPeerRequest(r Request) {
-	v, ok := me.readyPeerRequests[r]
+// Removes the ready peer request, handing its data to the caller, who becomes responsible for
+// releasing it.
+func (me *PeerConn) takeReadyPeerRequest(r Request) (prd peerRequestData, ok bool) {
+	prd, ok = me.readyPeerRequests[r]
 	if !ok {
 		return
 	}
 	delete(me.readyPeerRequests, r)
-	if len(v) > 0 {
+	if len(prd.buf) > 0 {
 		me.peerRequestDataAllocDecreased.Broadcast()
+	}
+	return
+}
+
+func (me *PeerConn) deleteReadyPeerRequest(r Request) {
+	prd, ok := me.takeReadyPeerRequest(r)
+	if ok {
+		me.releasePeerRequestData(prd)
 	}
 }
 
@@ -803,7 +817,7 @@ func (c *PeerConn) servePeerRequest(r Request) {
 		return
 	}
 	c.locker().Unlock()
-	b, err := c.readPeerRequestData(r)
+	prd, err := c.readPeerRequestData(r)
 	c.locker().Lock()
 	if err != nil {
 		c.peerRequestDataReadFailed(err, r)
@@ -811,11 +825,12 @@ func (c *PeerConn) servePeerRequest(r Request) {
 	}
 	if !g.MapContains(c.unreadPeerRequests, r) {
 		c.slogger.Debug("read data for peer request but no longer wanted", "request", r)
+		c.releasePeerRequestData(prd)
 		return
 	}
 	g.MustDelete(c.unreadPeerRequests, r)
 	g.MakeMapIfNil(&c.readyPeerRequests)
-	c.readyPeerRequests[r] = b
+	c.readyPeerRequests[r] = prd
 	c.tickleWriter()
 }
 
@@ -868,8 +883,33 @@ func (c *PeerConn) useBestReject(r Request) {
 	}
 }
 
-func (c *PeerConn) readPeerRequestData(r Request) ([]byte, error) {
-	b := make([]byte, r.Length)
+// Data read from storage for a peer request. Buffers big enough to be worth reusing come from the
+// Torrent chunk pool, and must be passed back to PeerConn.releasePeerRequestData when done.
+type peerRequestData struct {
+	buf []byte
+	// Set if buf belongs to the Torrent chunk pool.
+	poolPtr *[]byte
+}
+
+func (c *PeerConn) getPeerRequestData(n int) (prd peerRequestData) {
+	if n <= c.t.chunkSize.Int() {
+		prd.poolPtr = c.t.chunkPool.Get()
+		prd.buf = (*prd.poolPtr)[:n]
+	} else {
+		prd.buf = make([]byte, n)
+	}
+	return
+}
+
+func (c *PeerConn) releasePeerRequestData(prd peerRequestData) {
+	if prd.poolPtr != nil {
+		c.t.chunkPool.Put(prd.poolPtr)
+	}
+}
+
+func (c *PeerConn) readPeerRequestData(r Request) (prd peerRequestData, err error) {
+	prd = c.getPeerRequestData(r.Length.Int())
+	b := prd.buf
 	p := c.t.info.Piece(int(r.Index))
 	n, err := c.t.readAt(b, p.Offset()+int64(r.Begin))
 	if n == len(b) {
@@ -881,7 +921,11 @@ func (c *PeerConn) readPeerRequestData(r Request) ([]byte, error) {
 			panic("expected error")
 		}
 	}
-	return b, err
+	if err != nil {
+		c.releasePeerRequestData(prd)
+		prd = peerRequestData{}
+	}
+	return prd, err
 }
 
 func (c *PeerConn) logProtocolBehaviour(level log.Level, format string, arg ...interface{}) {
@@ -1263,16 +1307,19 @@ func (c *PeerConn) tickleWriter() {
 }
 
 func (c *PeerConn) sendChunk(r Request, msg func(pp.Message) bool) (more bool) {
-	b := g.MapMustGet(c.readyPeerRequests, r)
-	panicif.NotEq(len(b), r.Length.Int())
-	c.deleteReadyPeerRequest(r)
+	prd, ok := c.takeReadyPeerRequest(r)
+	panicif.False(ok)
+	panicif.NotEq(len(prd.buf), r.Length.Int())
 	c.lastChunkSent = time.Now()
-	return msg(pp.Message{
+	more = msg(pp.Message{
 		Type:  pp.Piece,
 		Index: r.Index,
 		Begin: r.Begin,
-		Piece: b,
+		Piece: prd.buf,
 	})
+	// msg copies the piece data into the write buffer, so the buffer is reusable now.
+	c.releasePeerRequestData(prd)
+	return
 }
 
 func (c *PeerConn) setTorrent(t *Torrent) {

--- a/peerconn.go
+++ b/peerconn.go
@@ -748,26 +748,34 @@ again:
 	c.locker().Unlock()
 }
 
+func (c *PeerConn) peerRequestDataAllocSize(size int) int {
+	if size <= c.t.chunkSize.Int() {
+		return c.t.chunkSize.Int()
+	}
+	return size
+}
+
 func (c *PeerConn) peerRequestDataBuffered() (n int) {
 	// TODO: Should we include a limit to the number of individual requests to keep N small, or keep
 	// a counter elsewhere?
 	for r := range c.readyPeerRequests {
-		n += r.Length.Int()
+		n += c.peerRequestDataAllocSize(r.Length.Int())
 	}
 	return
 }
 
 func (c *PeerConn) waitForDataAlloc(size int) bool {
+	allocSize := c.peerRequestDataAllocSize(size)
 	maxAlloc := c.t.cl.config.MaxAllocPeerRequestDataPerConn
 	locker := c.locker()
 	for {
-		if size > maxAlloc {
+		if allocSize > maxAlloc {
 			c.slogger.Warn("peer request length exceeds MaxAllocPeerRequestDataPerConn",
 				"requested", size,
 				"max", maxAlloc)
 			return false
 		}
-		if c.peerRequestDataBuffered()+size <= maxAlloc {
+		if c.peerRequestDataBuffered()+allocSize <= maxAlloc {
 			return true
 		}
 		allocDecreased := c.peerRequestDataAllocDecreased.Signaled()

--- a/peerconn_test.go
+++ b/peerconn_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"expvar"
 	"fmt"
 	"io"
 	"log/slog"
@@ -617,6 +618,86 @@ func TestServePeerRequestTorrentClosedStorageReadFails(t *testing.T) {
 	pc.servePeerRequest(req)
 
 	qt.Check(t, qt.IsFalse(g.MapContains(pc.unreadPeerRequests, req)))
+}
+
+func outstandingChunkPoolBuffers() int64 {
+	v := expvar.Get("torrentChunkBuffersOutstanding")
+	if v == nil {
+		return 0
+	}
+	return v.(*expvar.Int).Value()
+}
+
+func TestPeerConnPeerRequestDataLifecycle(t *testing.T) {
+	newConn := func(t *testing.T, storage storage.ClientImpl) (*PeerConn, Request, int64) {
+		var cl Client
+		cfg := TestingConfig(t)
+		cfg.DefaultStorage = storage
+		cl.init(cfg)
+		t.Cleanup(func() { cl.Close() })
+		tor, _ := cl.AddTorrentOpt(AddTorrentOpts{
+			InfoHash:                 testingTorrentInfoHash,
+			Storage:                  storage,
+			DisableInitialPieceCheck: true,
+		})
+		qt.Assert(t, qt.IsNil(tor.setInfoUnlocked(&metainfo.Info{
+			Pieces:      make([]byte, metainfo.HashSize),
+			PieceLength: 1,
+			Length:      1,
+			Name:        "test",
+		})))
+		pc := cl.newConnection(nil, newConnectionOpts{network: "test"})
+		pc.setTorrent(tor)
+		return pc, Request{Index: 0, ChunkSpec: ChunkSpec{Begin: 0, Length: 1}}, outstandingChunkPoolBuffers()
+	}
+
+	t.Run("close", func(t *testing.T) {
+		pc, r, baseline := newConn(t, &torrentStorageClient{&torrentStorage{}})
+		prd := pc.getPeerRequestData(r.Length.Int())
+		g.MakeMapIfNil(&pc.readyPeerRequests)
+		pc.readyPeerRequests[r] = prd
+		pc.onClose()
+		qt.Check(t, qt.Equals(outstandingChunkPoolBuffers(), baseline))
+	})
+
+	t.Run("cancel", func(t *testing.T) {
+		pc, r, baseline := newConn(t, &torrentStorageClient{&torrentStorage{}})
+		prd := pc.getPeerRequestData(r.Length.Int())
+		g.MakeMapIfNil(&pc.unreadPeerRequests)
+		g.MakeMapIfNil(&pc.readyPeerRequests)
+		pc.unreadPeerRequests[r] = struct{}{}
+		pc.readyPeerRequests[r] = prd
+		pc.deletePeerRequest(r)
+		qt.Check(t, qt.Equals(outstandingChunkPoolBuffers(), baseline))
+	})
+
+	t.Run("choke cleanup", func(t *testing.T) {
+		pc, r, baseline := newConn(t, &torrentStorageClient{&torrentStorage{}})
+		prd := pc.getPeerRequestData(r.Length.Int())
+		g.MakeMapIfNil(&pc.readyPeerRequests)
+		pc.readyPeerRequests[r] = prd
+		pc.choking = true
+		pc.deleteAllPeerRequests()
+		qt.Check(t, qt.Equals(outstandingChunkPoolBuffers(), baseline))
+	})
+
+	t.Run("unwanted completed read", func(t *testing.T) {
+		pc, r, baseline := newConn(t, benchmarkUploadStorage{})
+		g.MakeMapIfNil(&pc.unreadPeerRequests)
+		pc.unreadPeerRequests[r] = struct{}{}
+		prd, err := pc.readPeerRequestData(r)
+		qt.Assert(t, qt.IsNil(err))
+		delete(pc.unreadPeerRequests, r)
+		pc.releasePeerRequestData(prd)
+		qt.Check(t, qt.Equals(outstandingChunkPoolBuffers(), baseline))
+	})
+
+	t.Run("read error", func(t *testing.T) {
+		pc, r, baseline := newConn(t, &torrentStorageClient{&torrentStorage{}})
+		_, err := pc.readPeerRequestData(r)
+		qt.Assert(t, qt.IsNotNil(err))
+		qt.Check(t, qt.Equals(outstandingChunkPoolBuffers(), baseline))
+	})
 }
 
 // Storage that serves piece data without touching the filesystem, for upload benchmarking.

--- a/peerconn_test.go
+++ b/peerconn_test.go
@@ -605,6 +605,7 @@ func TestServePeerRequestTorrentClosedStorageReadFails(t *testing.T) {
 
 	pc := cl.newConnection(nil, newConnectionOpts{network: "test"})
 	pc.setTorrent(tor)
+	pc.t.chunkSize = 1
 
 	req := Request{Index: 0, ChunkSpec: ChunkSpec{Begin: 0, Length: 1}}
 	g.MakeMapIfNil(&pc.unreadPeerRequests)

--- a/peerconn_test.go
+++ b/peerconn_test.go
@@ -618,3 +618,68 @@ func TestServePeerRequestTorrentClosedStorageReadFails(t *testing.T) {
 
 	qt.Check(t, qt.IsFalse(g.MapContains(pc.unreadPeerRequests, req)))
 }
+
+// Storage that serves piece data without touching the filesystem, for upload benchmarking.
+type benchmarkUploadStorage struct{}
+
+func (me benchmarkUploadStorage) OpenTorrent(
+	context.Context, *metainfo.Info, metainfo.Hash,
+) (storage.TorrentImpl, error) {
+	return storage.TorrentImpl{
+		Piece:     func(metainfo.Piece) storage.PieceImpl { return me },
+		NewReader: func() storage.TorrentReader { return me },
+		Close:     func() error { return nil },
+	}, nil
+}
+
+func (benchmarkUploadStorage) ReadAt(b []byte, _ int64) (int, error)  { return len(b), nil }
+func (benchmarkUploadStorage) WriteAt(b []byte, _ int64) (int, error) { return len(b), nil }
+func (benchmarkUploadStorage) Close() error                           { return nil }
+func (benchmarkUploadStorage) MarkComplete() error                    { return nil }
+func (benchmarkUploadStorage) MarkNotComplete() error                 { return nil }
+
+func (benchmarkUploadStorage) Completion() storage.Completion {
+	return storage.Completion{Complete: true, Ok: true}
+}
+
+// Serves peer requests the way the peer request server and the writer do.
+func BenchmarkServePeerRequests(b *testing.B) {
+	var cl Client
+	cfg := TestingConfig(b)
+	cfg.MaxAllocPeerRequestDataPerConn = 1 << 20
+	cl.init(cfg)
+	t, _ := cl.AddTorrentOpt(AddTorrentOpts{
+		InfoHash:                 testingTorrentInfoHash,
+		Storage:                  benchmarkUploadStorage{},
+		DisableInitialPieceCheck: true,
+	})
+	qt.Assert(b, qt.IsNil(t.setInfoUnlocked(&metainfo.Info{
+		Pieces:      make([]byte, 20),
+		Length:      1 << 20,
+		PieceLength: 1 << 20,
+	})))
+	cn := cl.newConnection(nil, newConnectionOpts{network: "test"})
+	cn.setTorrent(t)
+	cn.PeerExtensionBytes.SetBit(pp.ExtensionBitFast, true)
+	cn.choking = false
+	cn.initMessageWriter()
+	// Marshals the message like the real writer, then drops it so the buffer doesn't grow.
+	writeAndDiscard := func(msg pp.Message) bool {
+		mw := &cn.messageWriter
+		qt.Assert(b, qt.IsNil(mw.writeToBuffer(msg)))
+		mw.writeBuffer.Reset()
+		return true
+	}
+	req := Request{ChunkSpec: ChunkSpec{Length: defaultChunkSize}}
+	b.SetBytes(int64(req.Length))
+	b.ReportAllocs()
+	cl.lock()
+	defer cl.unlock()
+	for i := range b.N {
+		req.Begin = pp.Integer(i%64) * defaultChunkSize
+		qt.Assert(b, qt.IsNil(cn.onReadRequest(req, false)))
+		cn.servePeerRequest(req)
+		qt.Assert(b, qt.IsTrue(g.MapContains(cn.readyPeerRequests, req)))
+		cn.sendChunk(req, writeAndDiscard)
+	}
+}


### PR DESCRIPTION
`readPeerRequestData` allocated `r.Length` bytes for every served peer request, so seeding allocated ~16KiB per chunk uploaded. It now takes the buffer from the `Torrent` chunk pool (already used by the wire decoder) when the request fits, and returns it once the message writer has copied the piece data into its write buffer. Requests larger than the chunk size still allocate.

Release points: read error, request no longer wanted, `deleteReadyPeerRequest`, `deleteAllPeerRequests`, and after `msg()` in `sendChunk`. `sendChunk` uses a new `takeReadyPeerRequest` (delete without release) so it can't free the buffer before the copy. `PeerConn.onClose` now calls `deleteAllPeerRequests` so buffers go back to the pool and `torrentChunkBuffersOutstanding` stays honest.

`BenchmarkServePeerRequests` (new, drives `onReadRequest` -> `servePeerRequest` -> `sendChunk`), n=8:

|          | before | after |
|----------|--------|-------|
| B/op     | 17227  | 852 (-95%) |
| sec/op   | 3.28µs | 1.84µs (-44%) |

`-race` is clean on the root package, `./test/...` and `./tests/...`; a temporary check showed `torrentChunkBuffersOutstanding == 0` after real seed/leech transfers.


Carries #1083 (test lock fix) so CI here is green; master is red without it. Drops out on rebase once #1083 merges.
