### PR TITLE
bep14: release the exported status paths in TestDiscovery

### DIFF
--- a/bep14_test.go
+++ b/bep14_test.go
@@ -79,13 +79,13 @@ func TestDiscovery(t *testing.T) {
 	qt.Assert(t, qt.IsNil(err))
 	t.Cleanup(func() { client1.Close() })
 	setupTestLPD(client1)
-	testutil.ExportStatusWriter(client1, "1", t)
+	defer testutil.ExportStatusWriter(client1, "1", t)()
 
 	client2, err := NewClient(config)
 	qt.Assert(t, qt.IsNil(err))
 	t.Cleanup(func() { client2.Close() })
 	setupTestLPD(client2)
-	testutil.ExportStatusWriter(client2, "2", t)
+	defer testutil.ExportStatusWriter(client2, "2", t)()
 
 	greetingTempDir, mi := testutil.GreetingTestTorrent()
 	defer os.RemoveAll(greetingTempDir)


### PR DESCRIPTION
`go test -race -count 2 -run TestDiscovery` panics:

```
panic: "/TestDiscovery/1" still in use
```

`testutil.ExportStatusWriter` returns a release func, and every other caller defers it. `TestDiscovery` dropped it for both clients, so re-registering the same path on a second run hits the in-use panic. Fix is `defer ...()`, matching the rest of the tree.

Found by sweeping all 293 tests at `-race -count 200`; this was the only one that broke on its assertions rather than just being slow.
