### PR TITLE
request-strategy: measure allocations with AllocsPerRun

### DIFF
--- a/request-strategy-impls_test.go
+++ b/request-strategy-impls_test.go
@@ -2,7 +2,6 @@ package torrent
 
 import (
 	"context"
-	"runtime"
 	"testing"
 
 	g "github.com/anacrolix/generics"
@@ -24,11 +23,10 @@ func TestRequestStrategyPieceDoesntAlloc(t *testing.T) {
 	// Query through the interface, as the request strategy does. Piece is now an index-based call
 	// returning a bool, so no per-piece value is boxed and nothing is allocated.
 	var input requestStrategy.Torrent = requestStrategyTorrent{akshalTorrent}
-	var before, after runtime.MemStats
-	runtime.ReadMemStats(&before)
-	requestStrategyResultSink = input.PieceRequest(0)
-	runtime.ReadMemStats(&after)
-	qt.Assert(t, qt.Equals(before.HeapAlloc, after.HeapAlloc))
+	allocs := testing.AllocsPerRun(10, func() {
+		requestStrategyResultSink = input.PieceRequest(0)
+	})
+	qt.Assert(t, qt.Equals(allocs, 0.0))
 }
 
 type storagePiece struct {


### PR DESCRIPTION
`TestRequestStrategyPieceDoesntAlloc` bracketed one call with `runtime.ReadMemStats` and asserted `HeapAlloc` was unchanged. `HeapAlloc` is process-wide, so any concurrent goroutine allocating between the two reads fails it. It went red on `test (oldstable, macos-latest)`:

```
got:  uint64(6761792)
want: uint64(6761984)
```

`HeapAlloc` went *down*, which no allocation in the call under test can cause. `testing.AllocsPerRun` measures only the function passed to it.

Still catches a regression: adding an allocation inside the closure fails the test. Clean at `-race -count 200`.
