### PR TITLE
storage: skip part-file promotion when disabled

### DIFF
--- a/storage/file-piece.go
+++ b/storage/file-piece.go
@@ -238,14 +238,14 @@ func (me *filePieceImpl) MarkNotComplete() (err error) {
 }
 
 func (me *filePieceImpl) promotePartFile(f file) (err error) {
-	// Flush file on completion, even if we don't promote it.
+	if !me.partFiles() {
+		return nil
+	}
+	// Flush the part file before promotion so its contents are durable.
 	err = me.t.io.flush(f.partFilePath(), 0, f.length())
 	if err != nil {
 		me.logger().Warn("error flushing file before promotion", "file", f.partFilePath(), "err", err)
 		err = nil
-	}
-	if !me.partFiles() {
-		return nil
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/storage/file-piece_partfiles_test.go
+++ b/storage/file-piece_partfiles_test.go
@@ -1,0 +1,75 @@
+package storage
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/go-quicktest/qt"
+
+	g "github.com/anacrolix/generics"
+	"github.com/anacrolix/torrent/metainfo"
+)
+
+type trackingFileIo struct {
+	flushed []string
+	renamed bool
+}
+
+func (me *trackingFileIo) openForRead(string) (fileReader, error) {
+	panic("unexpected openForRead")
+}
+
+func (me *trackingFileIo) openForSharedRead(string) (sharableReader, error) {
+	panic("unexpected openForSharedRead")
+}
+
+func (me *trackingFileIo) openForWrite(string, int64) (fileWriter, error) {
+	panic("unexpected openForWrite")
+}
+
+func (me *trackingFileIo) flush(name string, _, _ int64) error {
+	me.flushed = append(me.flushed, name)
+	return nil
+}
+
+func (me *trackingFileIo) rename(string, string) error {
+	me.renamed = true
+	return nil
+}
+
+func (me *trackingFileIo) Close() error {
+	return nil
+}
+
+func (me *trackingFileIo) closeWriters() (closedPaths []string, remaining int, err error) {
+	return nil, 0, nil
+}
+
+func TestPromotePartFileSkipsPartPathWhenDisabled(t *testing.T) {
+	ioImpl := &trackingFileIo{}
+	torrent := &fileTorrentImpl{
+		info: &metainfo.Info{
+			PieceLength: 1,
+		},
+		files: []fileExtra{{
+			safeOsPath: "a.bin",
+		}},
+		metainfoFileInfos: []metainfo.FileInfo{{
+			Path:   []string{"a.bin"},
+			Length: 1,
+		}},
+		io: ioImpl,
+		client: &fileClientImpl{
+			opts: NewFileClientOpts{
+				UsePartFiles: g.Option[bool]{Ok: true, Value: false},
+				Logger:       slog.Default(),
+			},
+		},
+	}
+	pieceImpl := &filePieceImpl{t: torrent}
+
+	err := pieceImpl.promotePartFile(torrent.file(0))
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.HasLen(ioImpl.flushed, 0))
+	qt.Assert(t, qt.IsFalse(ioImpl.renamed))
+}


### PR DESCRIPTION
`MarkComplete` calls `promotePartFile` after every file becomes complete. When part files are disabled, `promotePartFile` still flushed the synthetic `.part` path before checking the option, causing unnecessary filesystem access and warnings for a path that should not be used.

Return before touching the `.part` path when `UsePartFiles` is disabled.

This change adds a regression test that verifies neither flush nor rename is attempted in that case.

Tests:

- `go test -timeout=5m ./...`
