### PR TITLE
storage: cache classic file writer handles

### DIFF
--- a/storage/file-io-classic.go
+++ b/storage/file-io-classic.go
@@ -1,36 +1,126 @@
 package storage
 
 import (
+	"errors"
 	"io"
+	"io/fs"
 	"os"
+	"sync"
 )
 
-type classicFileIo struct{}
-
-// Lifetimes of files are scoped to their use, so let's hope everyone is being a good citizen.
-func (me classicFileIo) Close() error {
-	return nil
+type classicFileIo struct {
+	mu      sync.Mutex
+	writers map[string]*os.File
+	closed  bool
 }
 
-func (me classicFileIo) rename(from, to string) error {
-	return os.Rename(from, to)
+func newClassicFileIo() fileIo {
+	return &classicFileIo{}
 }
 
-func (me classicFileIo) flush(name string, offset, nbytes int64) error {
+func (me *classicFileIo) Close() error {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	var err error
+	for name, f := range me.writers {
+		err = errors.Join(err, f.Close())
+		delete(me.writers, name)
+	}
+	me.closed = true
+	return err
+}
+
+func (me *classicFileIo) rename(from, to string) error {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	if err := me.closedErr(); err != nil {
+		return err
+	}
+	err := me.closeWriterLocked(from)
+	err = errors.Join(err, me.closeWriterLocked(to))
+	err = errors.Join(err, os.Rename(from, to))
+	return err
+}
+
+func (me *classicFileIo) flush(name string, offset, nbytes int64) error {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	if err := me.closedErr(); err != nil {
+		return err
+	}
+	if f, ok := me.writers[name]; ok {
+		return f.Sync()
+	}
 	return fsync(name)
 }
 
-func (me classicFileIo) openForSharedRead(name string) (sharableReader, error) {
+func (me *classicFileIo) openForSharedRead(name string) (sharableReader, error) {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	if err := me.closedErr(); err != nil {
+		return nil, err
+	}
 	return os.Open(name)
 }
 
-func (me classicFileIo) openForRead(name string) (fileReader, error) {
+func (me *classicFileIo) openForRead(name string) (fileReader, error) {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	if err := me.closedErr(); err != nil {
+		return nil, err
+	}
+	if writer, ok := me.writers[name]; ok {
+		return &classicBorrowedFileReader{f: writer}, nil
+	}
 	f, err := os.Open(name)
 	return classicFileReader{f}, err
 }
 
-func (classicFileIo) openForWrite(p string, size int64) (f fileWriter, err error) {
-	return openFileExtra(p, os.O_WRONLY)
+func (me *classicFileIo) openForWrite(p string, size int64) (f fileWriter, err error) {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	if err := me.closedErr(); err != nil {
+		return nil, err
+	}
+	if cached, ok := me.writers[p]; ok {
+		return classicFileWriter{cached}, nil
+	}
+	cached, err := openFileExtra(p, os.O_RDWR)
+	if err != nil {
+		return nil, err
+	}
+	if me.writers == nil {
+		me.writers = make(map[string]*os.File)
+	}
+	me.writers[p] = cached
+	return classicFileWriter{cached}, nil
+}
+
+func (me *classicFileIo) closeWriterLocked(name string) error {
+	if me.writers == nil {
+		return nil
+	}
+	f, ok := me.writers[name]
+	if !ok {
+		return nil
+	}
+	delete(me.writers, name)
+	return f.Close()
+}
+
+func (me *classicFileIo) closedErr() error {
+	if me.closed {
+		return fs.ErrClosed
+	}
+	return nil
+}
+
+type classicFileWriter struct {
+	*os.File
+}
+
+func (classicFileWriter) Close() error {
+	return nil
 }
 
 type classicFileReader struct {
@@ -50,5 +140,50 @@ func (c classicFileReader) seekDataOrEof(offset int64) (ret int64, err error) {
 	if err == io.EOF {
 		ret, err = c.File.Seek(0, io.SeekEnd)
 	}
+	return
+}
+
+// Reuses the open writer handle to avoid an extra open during piece hashing.
+// This is intentionally only used for openForRead, not shared readers, so the
+// borrowed handle lifetime stays scoped to storage-internal operations.
+type classicBorrowedFileReader struct {
+	f   *os.File
+	pos int64
+}
+
+func (c *classicBorrowedFileReader) Close() error {
+	return nil
+}
+
+func (c *classicBorrowedFileReader) Read(p []byte) (n int, err error) {
+	n, err = c.f.ReadAt(p, c.pos)
+	c.pos += int64(n)
+	if err == io.EOF && n > 0 {
+		err = nil
+	}
+	return
+}
+
+func (c *classicBorrowedFileReader) writeToN(w io.Writer, n int64) (written int64, err error) {
+	written, err = io.Copy(w, io.NewSectionReader(c.f, c.pos, n))
+	c.pos += written
+	return
+}
+
+func (c *classicBorrowedFileReader) seekDataOrEof(offset int64) (ret int64, err error) {
+	ret, err = seekData(c.f, offset)
+	if err == io.EOF {
+		var fi os.FileInfo
+		fi, err = c.f.Stat()
+		if err != nil {
+			return c.pos, err
+		}
+		ret = fi.Size()
+		err = nil
+	}
+	if err != nil {
+		return c.pos, err
+	}
+	c.pos = ret
 	return
 }

--- a/storage/file-io-classic_test.go
+++ b/storage/file-io-classic_test.go
@@ -1,0 +1,55 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-quicktest/qt"
+)
+
+func TestClassicFileIoRenameClosesCachedWriter(t *testing.T) {
+	tempDir := t.TempDir()
+	oldPath := filepath.Join(tempDir, "old.bin")
+	newPath := filepath.Join(tempDir, "new.bin")
+
+	ioImpl, ok := newClassicFileIo().(*classicFileIo)
+	qt.Assert(t, qt.IsTrue(ok))
+	t.Cleanup(func() { _ = ioImpl.Close() })
+
+	writer, err := ioImpl.openForWrite(oldPath, 0)
+	qt.Assert(t, qt.IsNil(err))
+	_, err = writer.WriteAt([]byte("hello"), 0)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.IsNil(writer.Close()))
+
+	qt.Assert(t, qt.IsNil(ioImpl.rename(oldPath, newPath)))
+
+	data, err := os.ReadFile(newPath)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.DeepEquals(data, []byte("hello")))
+}
+
+func TestClassicFileIoOpenForReadBorrowsWriterHandle(t *testing.T) {
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "data.bin")
+
+	ioImpl, ok := newClassicFileIo().(*classicFileIo)
+	qt.Assert(t, qt.IsTrue(ok))
+	t.Cleanup(func() { _ = ioImpl.Close() })
+
+	writer, err := ioImpl.openForWrite(filePath, 0)
+	qt.Assert(t, qt.IsNil(err))
+	_, err = writer.WriteAt([]byte("hello"), 0)
+	qt.Assert(t, qt.IsNil(err))
+
+	reader, err := ioImpl.openForRead(filePath)
+	qt.Assert(t, qt.IsNil(err))
+	defer reader.Close()
+
+	buf := make([]byte, 5)
+	n, err := reader.Read(buf)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.Equals(n, 5))
+	qt.Assert(t, qt.DeepEquals(buf, []byte("hello")))
+}

--- a/storage/file-io-mmap.go
+++ b/storage/file-io-mmap.go
@@ -36,7 +36,7 @@ func init() {
 		}
 	case "classic":
 		defaultFileIo = func() fileIo {
-			return classicFileIo{}
+			return newClassicFileIo()
 		}
 	default:
 		panic(s)

--- a/storage/file-io-mmap_test.go
+++ b/storage/file-io-mmap_test.go
@@ -22,7 +22,7 @@ func TestFileIoImplementationsSeekDataDetection(t *testing.T) {
 		name   string
 		fileIo fileIo
 	}{
-		{"classic", classicFileIo{}},
+		{"classic", newClassicFileIo()},
 		{"mmap", &mmapFileIo{}},
 	}
 

--- a/storage/file-io.go
+++ b/storage/file-io.go
@@ -18,7 +18,7 @@ type fileReader interface {
 
 // This gets clobbered by a hybrid mmap implementation if mmap is available.
 var defaultFileIo = func() fileIo {
-	return classicFileIo{}
+	return newClassicFileIo()
 }
 
 type fileIo interface {


### PR DESCRIPTION
The classic file backend opened and closed a file for every chunk write. This adds avoidable filesystem overhead on active downloads, particularly on Windows.

This change:

- keeps writable files cached for the lifetime of the backend;
- returns lightweight writers whose `Close` leaves the cached handle open;
- reuses an existing writer handle for storage-internal reads;
- flushes cached handles directly; and
- closes affected handles before rename so part-file promotion remains safe.

The existing default backend selection is unchanged.

Tests cover cached-handle rename and borrowed reads.

Tests:

- `go test -timeout=5m ./...`
