### PR TITLE
storage: add buffered piece completion wrapper

### DIFF
--- a/storage/bolt-piece-completion.go
+++ b/storage/bolt-piece-completion.go
@@ -43,7 +43,7 @@ func NewBoltPieceCompletion(dir string) (ret PieceCompletion, err error) {
 		return
 	}
 	db.NoSync = true
-	ret = &boltPieceCompletion{db}
+	ret = newBufferedPieceCompletion(&boltPieceCompletion{db})
 	return
 }
 
@@ -84,24 +84,38 @@ func (me *boltPieceCompletion) Set(pk metainfo.PieceKey, complete g.Option[bool]
 	if !complete.Ok {
 		return me.delete(pk)
 	}
+	return me.SetBatch([]PieceCompletionChange{{
+		Key:      pk,
+		Complete: complete.Value,
+	}})
+}
+
+func (me *boltPieceCompletion) SetBatch(changes []PieceCompletionChange) error {
 	err := me.db.Update(func(tx *bbolt.Tx) error {
 		c, err := tx.CreateBucketIfNotExists(completionBucketKey)
 		if err != nil {
 			return fmt.Errorf("creating completion bucket: %w", err)
 		}
-		ih, err := c.CreateBucketIfNotExists(pk.InfoHash[:])
-		if err != nil {
-			return fmt.Errorf("creating bucket for infohash %v: %w", pk.InfoHash, err)
+		for _, change := range changes {
+			ih, err := c.CreateBucketIfNotExists(change.Key.InfoHash[:])
+			if err != nil {
+				return fmt.Errorf("creating bucket for infohash %v: %w", change.Key.InfoHash, err)
+			}
+			key := boltPieceCompletionKey(change.Key.Index)
+			err = ih.Put(key[:], []byte(func() string {
+				if change.Complete {
+					return boltDbCompleteValue
+				}
+				return boltDbIncompleteValue
+			}()))
+			if err != nil {
+				return err
+			}
 		}
-		key := boltPieceCompletionKey(pk.Index)
-		value := boltDbIncompleteValue
-		if complete.Value {
-			value = boltDbCompleteValue
-		}
-		return ih.Put(key[:], []byte(value))
+		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("setting completion for %v: %w", pk, err)
+		return fmt.Errorf("setting piece completion batch: %w", err)
 	}
 	return nil
 }

--- a/storage/bolt-piece-completion.go
+++ b/storage/bolt-piece-completion.go
@@ -43,7 +43,7 @@ func NewBoltPieceCompletion(dir string) (ret PieceCompletion, err error) {
 		return
 	}
 	db.NoSync = true
-	ret = newBufferedPieceCompletion(&boltPieceCompletion{db})
+	ret = &boltPieceCompletion{db}
 	return
 }
 

--- a/storage/buffered-piece-completion.go
+++ b/storage/buffered-piece-completion.go
@@ -1,0 +1,139 @@
+package storage
+
+import (
+	"sync"
+
+	g "github.com/anacrolix/generics"
+	"github.com/anacrolix/torrent/metainfo"
+)
+
+// Wraps a persistent completion store so runtime completion changes can become immediately visible
+// without forcing per-piece durability work on the hot download path.
+type bufferedPieceCompletion struct {
+	underlying PieceCompletion
+
+	mu      sync.RWMutex
+	overlay map[metainfo.PieceKey]g.Option[bool]
+	dirty   map[metainfo.PieceKey]struct{}
+}
+
+var _ interface {
+	PieceCompletion
+	PieceCompletionCheckpointer
+	PieceCompletionPersistenter
+} = (*bufferedPieceCompletion)(nil)
+
+func newBufferedPieceCompletion(underlying PieceCompletion) PieceCompletion {
+	return &bufferedPieceCompletion{
+		underlying: underlying,
+	}
+}
+
+func (me *bufferedPieceCompletion) Persistent() bool {
+	// Runtime updates are checkpointed in batches instead of requiring synchronous durability for
+	// every piece completion event.
+	return false
+}
+
+func (me *bufferedPieceCompletion) Get(pk metainfo.PieceKey) (c Completion, err error) {
+	me.mu.RLock()
+	value, ok := me.overlay[pk]
+	me.mu.RUnlock()
+	if ok {
+		c.Ok = value.Ok
+		c.Complete = value.Value
+		return
+	}
+	return me.underlying.Get(pk)
+}
+
+func (me *bufferedPieceCompletion) Set(pk metainfo.PieceKey, complete g.Option[bool]) error {
+	me.mu.Lock()
+	if me.overlay == nil {
+		me.overlay = make(map[metainfo.PieceKey]g.Option[bool])
+	}
+	me.overlay[pk] = complete
+	if complete.Ok && complete.Value {
+		if me.dirty == nil {
+			me.dirty = make(map[metainfo.PieceKey]struct{})
+		}
+		me.dirty[pk] = struct{}{}
+		me.mu.Unlock()
+		return nil
+	}
+	delete(me.dirty, pk)
+	me.mu.Unlock()
+
+	if err := me.underlying.Set(pk, complete); err != nil {
+		return err
+	}
+
+	me.mu.Lock()
+	// Underlying storage now matches the runtime view for this key.
+	if current, ok := me.overlay[pk]; ok && current == complete {
+		delete(me.overlay, pk)
+	}
+	me.mu.Unlock()
+	return nil
+}
+
+func (me *bufferedPieceCompletion) Checkpoint(keys []metainfo.PieceKey) error {
+	me.mu.RLock()
+	changes := make([]PieceCompletionChange, 0, len(keys))
+	for _, key := range keys {
+		if _, ok := me.dirty[key]; !ok {
+			continue
+		}
+		value, ok := me.overlay[key]
+		if !ok {
+			continue
+		}
+		changes = append(changes, PieceCompletionChange{
+			Key:      key,
+			Complete: value.Value,
+		})
+	}
+	me.mu.RUnlock()
+
+	if len(changes) == 0 {
+		return nil
+	}
+	if err := me.persistChanges(changes); err != nil {
+		return err
+	}
+
+	me.mu.Lock()
+	for _, change := range changes {
+		delete(me.dirty, change.Key)
+		if current, ok := me.overlay[change.Key]; ok && current == g.Some(change.Complete) {
+			delete(me.overlay, change.Key)
+		}
+	}
+	me.mu.Unlock()
+	return nil
+}
+
+func (me *bufferedPieceCompletion) Close() error {
+	me.mu.RLock()
+	keys := make([]metainfo.PieceKey, 0, len(me.dirty))
+	for key := range me.dirty {
+		keys = append(keys, key)
+	}
+	me.mu.RUnlock()
+	if err := me.Checkpoint(keys); err != nil {
+		return err
+	}
+	return me.underlying.Close()
+}
+
+func (me *bufferedPieceCompletion) persistChanges(changes []PieceCompletionChange) error {
+	if batchSetter, ok := me.underlying.(PieceCompletionBatchSetter); ok {
+		return batchSetter.SetBatch(changes)
+	}
+	for _, change := range changes {
+		if err := me.underlying.Set(change.Key, g.Some(change.Complete)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/storage/buffered-piece-completion.go
+++ b/storage/buffered-piece-completion.go
@@ -30,9 +30,11 @@ func newBufferedPieceCompletion(underlying PieceCompletion) PieceCompletion {
 }
 
 func (me *bufferedPieceCompletion) Persistent() bool {
-	// Runtime updates are checkpointed in batches instead of requiring synchronous durability for
-	// every piece completion event.
-	return false
+	// This wrapper defers writes, but the underlying store may still be persistent between runs.
+	if p, ok := me.underlying.(PieceCompletionPersistenter); ok {
+		return p.Persistent()
+	}
+	return true
 }
 
 func (me *bufferedPieceCompletion) Get(pk metainfo.PieceKey) (c Completion, err error) {

--- a/storage/buffered-piece-completion_test.go
+++ b/storage/buffered-piece-completion_test.go
@@ -1,0 +1,117 @@
+package storage
+
+import (
+	"sync"
+	"testing"
+
+	g "github.com/anacrolix/generics"
+	"github.com/go-quicktest/qt"
+
+	"github.com/anacrolix/torrent/metainfo"
+)
+
+type recordingPieceCompletion struct {
+	mu    sync.Mutex
+	state map[metainfo.PieceKey]bool
+	batch []PieceCompletionChange
+}
+
+func (me *recordingPieceCompletion) Get(pk metainfo.PieceKey) (c Completion, err error) {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	if me.state == nil {
+		return
+	}
+	value, ok := me.state[pk]
+	if !ok {
+		return
+	}
+	c.Ok = true
+	c.Complete = value
+	return
+}
+
+func (me *recordingPieceCompletion) Set(pk metainfo.PieceKey, complete g.Option[bool]) error {
+	if !complete.Ok {
+		me.mu.Lock()
+		delete(me.state, pk)
+		me.mu.Unlock()
+		return nil
+	}
+	return me.SetBatch([]PieceCompletionChange{{
+		Key:      pk,
+		Complete: complete.Value,
+	}})
+}
+
+func (me *recordingPieceCompletion) SetBatch(changes []PieceCompletionChange) error {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	if me.state == nil {
+		me.state = make(map[metainfo.PieceKey]bool)
+	}
+	for _, change := range changes {
+		me.state[change.Key] = change.Complete
+		me.batch = append(me.batch, change)
+	}
+	return nil
+}
+
+func (me *recordingPieceCompletion) Close() error {
+	return nil
+}
+
+func TestBufferedPieceCompletionDefersTrueUntilCheckpoint(t *testing.T) {
+	underlying := &recordingPieceCompletion{}
+	pc := newBufferedPieceCompletion(underlying)
+	key := metainfo.PieceKey{
+		InfoHash: metainfo.HashBytes([]byte("a")),
+		Index:    1,
+	}
+
+	qt.Assert(t, qt.IsNil(pc.Set(key, g.Some(true))))
+
+	runtimeValue, err := pc.Get(key)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.IsTrue(runtimeValue.Ok))
+	qt.Assert(t, qt.IsTrue(runtimeValue.Complete))
+
+	persistedValue, err := underlying.Get(key)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.IsFalse(persistedValue.Ok))
+
+	checkpointer, ok := pc.(PieceCompletionCheckpointer)
+	qt.Assert(t, qt.IsTrue(ok))
+	qt.Assert(t, qt.IsNil(checkpointer.Checkpoint([]metainfo.PieceKey{key})))
+
+	persistedValue, err = underlying.Get(key)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.IsTrue(persistedValue.Ok))
+	qt.Assert(t, qt.IsTrue(persistedValue.Complete))
+}
+
+func TestBufferedPieceCompletionPersistsFalseImmediately(t *testing.T) {
+	underlying := &recordingPieceCompletion{}
+	pc := newBufferedPieceCompletion(underlying)
+	key := metainfo.PieceKey{
+		InfoHash: metainfo.HashBytes([]byte("b")),
+		Index:    2,
+	}
+
+	qt.Assert(t, qt.IsNil(pc.Set(key, g.Some(true))))
+	qt.Assert(t, qt.IsNil(pc.Set(key, g.Some(false))))
+
+	persistedValue, err := underlying.Get(key)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.IsTrue(persistedValue.Ok))
+	qt.Assert(t, qt.IsFalse(persistedValue.Complete))
+
+	checkpointer, ok := pc.(PieceCompletionCheckpointer)
+	qt.Assert(t, qt.IsTrue(ok))
+	qt.Assert(t, qt.IsNil(checkpointer.Checkpoint([]metainfo.PieceKey{key})))
+
+	underlying.mu.Lock()
+	defer underlying.mu.Unlock()
+	qt.Assert(t, qt.HasLen(underlying.batch, 1))
+	qt.Assert(t, qt.IsFalse(underlying.batch[0].Complete))
+}

--- a/storage/buffered-piece-completion_test.go
+++ b/storage/buffered-piece-completion_test.go
@@ -11,9 +11,10 @@ import (
 )
 
 type recordingPieceCompletion struct {
-	mu    sync.Mutex
-	state map[metainfo.PieceKey]bool
-	batch []PieceCompletionChange
+	mu         sync.Mutex
+	state      map[metainfo.PieceKey]bool
+	batch      []PieceCompletionChange
+	persistent bool
 }
 
 func (me *recordingPieceCompletion) Get(pk metainfo.PieceKey) (c Completion, err error) {
@@ -61,6 +62,10 @@ func (me *recordingPieceCompletion) Close() error {
 	return nil
 }
 
+func (me *recordingPieceCompletion) Persistent() bool {
+	return me.persistent
+}
+
 func TestBufferedPieceCompletionDefersTrueUntilCheckpoint(t *testing.T) {
 	underlying := &recordingPieceCompletion{}
 	pc := newBufferedPieceCompletion(underlying)
@@ -88,6 +93,14 @@ func TestBufferedPieceCompletionDefersTrueUntilCheckpoint(t *testing.T) {
 	qt.Assert(t, qt.IsNil(err))
 	qt.Assert(t, qt.IsTrue(persistedValue.Ok))
 	qt.Assert(t, qt.IsTrue(persistedValue.Complete))
+
+	underlying.mu.Lock()
+	defer underlying.mu.Unlock()
+	qt.Assert(t, qt.HasLen(underlying.batch, 1))
+	qt.Assert(t, qt.DeepEquals(underlying.batch[0], PieceCompletionChange{
+		Key:      key,
+		Complete: true,
+	}))
 }
 
 func TestBufferedPieceCompletionPersistsFalseImmediately(t *testing.T) {
@@ -114,4 +127,57 @@ func TestBufferedPieceCompletionPersistsFalseImmediately(t *testing.T) {
 	defer underlying.mu.Unlock()
 	qt.Assert(t, qt.HasLen(underlying.batch, 1))
 	qt.Assert(t, qt.IsFalse(underlying.batch[0].Complete))
+}
+
+func TestBufferedPieceCompletionPersistsUnknownImmediately(t *testing.T) {
+	underlying := &recordingPieceCompletion{}
+	pc := newBufferedPieceCompletion(underlying)
+	key := metainfo.PieceKey{
+		InfoHash: metainfo.HashBytes([]byte("c")),
+		Index:    3,
+	}
+
+	qt.Assert(t, qt.IsNil(underlying.Set(key, g.Some(true))))
+	qt.Assert(t, qt.IsNil(pc.Set(key, g.Some(true))))
+	qt.Assert(t, qt.IsNil(pc.Set(key, g.Option[bool]{})))
+
+	runtimeValue, err := pc.Get(key)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.IsFalse(runtimeValue.Ok))
+
+	persistedValue, err := underlying.Get(key)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.IsFalse(persistedValue.Ok))
+
+	checkpointer, ok := pc.(PieceCompletionCheckpointer)
+	qt.Assert(t, qt.IsTrue(ok))
+	qt.Assert(t, qt.IsNil(checkpointer.Checkpoint([]metainfo.PieceKey{key})))
+}
+
+func TestBufferedPieceCompletionCloseFlushesDirtyCompletions(t *testing.T) {
+	underlying := &recordingPieceCompletion{}
+	pc := newBufferedPieceCompletion(underlying)
+	key := metainfo.PieceKey{
+		InfoHash: metainfo.HashBytes([]byte("d")),
+		Index:    4,
+	}
+
+	qt.Assert(t, qt.IsNil(pc.Set(key, g.Some(true))))
+	qt.Assert(t, qt.IsNil(pc.Close()))
+
+	persistedValue, err := underlying.Get(key)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.IsTrue(persistedValue.Ok))
+	qt.Assert(t, qt.IsTrue(persistedValue.Complete))
+}
+
+func TestBufferedPieceCompletionPersistentForwardsUnderlyingState(t *testing.T) {
+	underlying := &recordingPieceCompletion{persistent: true}
+	pc := newBufferedPieceCompletion(underlying)
+	persistenter, ok := pc.(PieceCompletionPersistenter)
+	qt.Assert(t, qt.IsTrue(ok))
+	qt.Assert(t, qt.IsTrue(persistenter.Persistent()))
+
+	underlying.persistent = false
+	qt.Assert(t, qt.IsFalse(persistenter.Persistent()))
 }

--- a/storage/piece-completion.go
+++ b/storage/piece-completion.go
@@ -35,6 +35,23 @@ type PieceCompletionPersistenter interface {
 	Persistent() bool
 }
 
+type PieceCompletionChange struct {
+	Key      metainfo.PieceKey
+	Complete bool
+}
+
+// Optional interface for piece completion implementations that can persist multiple changes in a
+// single transaction.
+type PieceCompletionBatchSetter interface {
+	SetBatch([]PieceCompletionChange) error
+}
+
+// Optional interface for piece completion implementations that buffer runtime updates and expose a
+// checkpoint hook to persist them later.
+type PieceCompletionCheckpointer interface {
+	Checkpoint([]metainfo.PieceKey) error
+}
+
 func pieceCompletionIsPersistent(pc PieceCompletion) bool {
 	if p, ok := pc.(PieceCompletionPersistenter); ok {
 		return p.Persistent()


### PR DESCRIPTION
Persisting every completed piece in its own Bolt transaction adds synchronous database work to the download hot path. This PR adds the buffering infrastructure needed to avoid that work, without enabling the buffered wrapper for Bolt by default yet.

This change:

- adds optional batch/checkpoint interfaces for piece completion implementations;
- adds `PieceCompletionChange` for multi-update persistence;
- implements `SetBatch` for Bolt piece completion;
- introduces `bufferedPieceCompletion`, an in-memory overlay wrapper that defers `complete=true` writes until checkpoint or close; and
- keeps incomplete and unknown states persisted immediately so stale completion data cannot survive invalidation.

The actual Bolt wrapping is intentionally left for a follow-up checkpoint batching PR, where the file flush and `PieceCompletionCheckpointer` call sites are introduced together. That keeps this PR from changing the current persistence behavior on its own.

Tests cover deferred completion, immediate false and unknown invalidation, batch checkpoint persistence, close-time flushing, and persistent-state forwarding.

Tests:

- `go test ./storage`
