### PR TITLE
Try to fix "panic: is zero" when adding pure v2 torrent (#1089)

### DIFF
--- a/client.go
+++ b/client.go
@@ -1584,7 +1584,7 @@ func (cl *Client) AddTorrentInfoHashWithStorage(
 // then this Storage is ignored and the existing torrent returned with `new` set to `false`.
 func (cl *Client) AddTorrentOpt(opts AddTorrentOpts) (t *Torrent, new bool) {
 	infoHash := opts.InfoHash
-	panicif.Zero(infoHash)
+	panicif.True(infoHash.IsZero() && !opts.InfoHashV2.Ok)
 	cl.lock()
 	t, ok := cl.torrentsByShortHash[infoHash]
 	if ok {

--- a/client_test.go
+++ b/client_test.go
@@ -200,6 +200,19 @@ func TestCompletedPieceWrongSize(t *testing.T) {
 	qt.Check(t, qt.IsNil(iotest.TestReader(r, []byte(testutil.GreetingFileContents))))
 }
 
+// https://github.com/anacrolix/torrent/issues/1089
+func TestAddPureV2Torrent(t *testing.T) {
+	cl, err := NewClient(TestingConfig(t))
+	qt.Assert(t, qt.IsNil(err))
+	defer cl.Close()
+	tt, err := cl.AddTorrentFromFile("testdata/bittorrent-v2-test.torrent")
+	qt.Assert(t, qt.IsNil(err))
+	defer tt.Drop()
+	qt.Check(t, qt.IsFalse(tt.infoHash.Ok))
+	qt.Check(t, qt.IsTrue(tt.infoHashV2.Ok))
+	qt.Check(t, qt.Not(qt.DeepEquals(tt.InfoHash(), metainfo.Hash{})))
+}
+
 func BenchmarkAddLargeTorrent(b *testing.B) {
 	cfg := TestingConfig(b)
 	cfg.DisableTCP = true


### PR DESCRIPTION
Fixes anacrolix/torrent#1089

So I added a test (c4f78539ce7d52550121faed1941f22872f5caf1) using the existing v2 test torrent, to try to catch out issues like this.

Then fixed (309e13b3b6ad539a7ff2ee9e67c961e0db71f601) the main issue, caused by asserting torrent has a hash, ignoring potential v2 torrents.

But once that was done, tests hang forever instead, and I was a bit lost in sauce why this would be. Claude code suggested fixes (https://github.com/oBusk/anacrolix__torrent/compare/fix-1089...oBusk:anacrolix__torrent:fix-v2-torrents), but I'm not sure about them, so leaving them off PR for now. 