### PR TITLE
Add ClientConfig.StealRequestGrace: a minimum request age before stealing

### DIFF
--- a/config.go
+++ b/config.go
@@ -92,6 +92,26 @@ type ClientConfig struct {
 	DownloadRateLimiter *rate.Limiter
 	// Maximum unverified bytes across all torrents. Not used if zero.
 	MaxUnverifiedBytes int64
+	// Minimum age an outstanding request must reach before another peer is allowed to steal it.
+	// Zero or negative disables the check, which is the historical behaviour.
+	//
+	// Stealing (see PeerConn.applyRequestState) hands a request to a peer that looks better, and
+	// its trigger is a one-request difference in queue depth. Across a large peer set that
+	// difference is noise: queue depths move by one every time a chunk lands, so without a floor
+	// the same request can migrate several times inside a single round-trip. Each migration is a
+	// Cancel on the wire, and a Cancel only prevents a transfer if it reaches the peer before the
+	// peer has served the request. Otherwise the block arrives regardless and is thrown away as
+	// ConnStats.ChunksReadWasted, while the stealer requests the same block again.
+	//
+	// A request younger than a round-trip has not yet had the opportunity to be answered, so its
+	// holder has not been shown to be failing and there is no information in moving it. Requiring
+	// an age gives each holder one uninterrupted attempt, and because the age is reset every time
+	// the request is issued (PeerConn.request), it also caps how often a single request can move.
+	//
+	// Latency is what makes this matter: the data already committed to the wire when a Cancel is
+	// sent scales with round-trip time, so on a LAN the cost of a steal is near zero and on a
+	// tunnelled path it is not.
+	StealRequestGrace time.Duration
 
 	// User-provided Client peer ID. If not present, one is generated automatically.
 	PeerID string
@@ -255,6 +275,7 @@ func NewDefaultClientConfig() *ClientConfig {
 		DialForPeerConns:       true,
 		AcceptPeerConnections:  true,
 		MaxUnverifiedBytes:     64 << 20,
+		StealRequestGrace:      initDurationFromEnv(stealRequestGraceEnvKey, defaultStealRequestGrace),
 		DialRateLimiter:        rate.NewLimiter(10, 10),
 		PieceHashersPerTorrent: 2,
 	}

--- a/env.go
+++ b/env.go
@@ -3,6 +3,7 @@ package torrent
 import (
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/anacrolix/missinggo/v2/panicif"
 	"golang.org/x/exp/constraints"
@@ -24,4 +25,19 @@ func strconvFromEnv[T, U constraints.Integer](key string, defaultValue T, bitSiz
 	i64, err := conv(s, 10, bitSize)
 	panicif.Err(err)
 	return T(i64)
+}
+
+// initDurationFromEnv reads a time.ParseDuration-formatted value from the environment,
+// falling back to defaultValue when the variable is unset or empty. Like the numeric
+// helpers above it panics on a malformed value rather than silently using the default:
+// these variables exist to be swept in experiments, and a typo that quietly reverts to
+// the default arm produces a measurement that looks valid and is not.
+func initDurationFromEnv(key string, defaultValue time.Duration) time.Duration {
+	s := os.Getenv(key)
+	if s == "" {
+		return defaultValue
+	}
+	d, err := time.ParseDuration(s)
+	panicif.Err(err)
+	return d
 }

--- a/requesting.go
+++ b/requesting.go
@@ -391,6 +391,12 @@ func (p *PeerConn) applyRequestState(next desiredRequestState) {
 			if diff > 1 || (diff == 1 && !p.lastUsefulChunkReceived.After(existing.lastUsefulChunkReceived)) {
 				continue
 			}
+			// Don't steal a request the current holder has not had time to answer. The tests
+			// above compare queue depths, which say nothing about whether the block is already
+			// on the wire; see ClientConfig.StealRequestGrace.
+			if !t.stealRequestGraceElapsed(req) {
+				continue
+			}
 			t.cancelRequest(req)
 		}
 		more = p.mustRequest(req)
@@ -411,6 +417,21 @@ func (p *PeerConn) applyRequestState(next desiredRequestState) {
 	// 	"requests %v->%v (peak %v->%v) reason %q (peer %v)",
 	// 	originalRequestCount, current.Requests.GetCardinality(), p.peakRequests, newPeakRequests, p.needRequestUpdate, p)
 	p.peakRequests = newPeakRequests
+}
+
+// stealRequestGraceElapsed reports whether req has been outstanding with its current holder
+// long enough for another peer to be allowed to take it. Always true when
+// ClientConfig.StealRequestGrace is unset, which is the historical behaviour.
+//
+// The clock is requestState.when, which PeerConn.request rewrites on every issue, so the
+// grace is measured against the current holder rather than the request's total lifetime.
+func (t *Torrent) stealRequestGraceElapsed(req RequestIndex) bool {
+	grace := t.cl.config.StealRequestGrace
+	if grace <= 0 {
+		return true
+	}
+	// The caller has already resolved a requesting peer for req, so the state is present.
+	return time.Since(t.requestState[req].when) >= grace
 }
 
 // This could be set to 10s to match the unchoke/request update interval recommended by some

--- a/steal-request-grace.go
+++ b/steal-request-grace.go
@@ -1,0 +1,18 @@
+package torrent
+
+import "time"
+
+// stealRequestGraceEnvKey overrides ClientConfig.StealRequestGrace for callers that build
+// their config with NewDefaultClientConfig and expose no knob of their own. It takes a
+// time.ParseDuration value ("0", "25ms", "1s"), and exists so the grace can be swept across
+// runs of a downstream client without rebuilding it.
+const stealRequestGraceEnvKey = "TORRENT_STEAL_REQUEST_GRACE"
+
+// defaultStealRequestGrace is the grace applied when neither the caller nor the environment
+// asks for one.
+//
+// Zero, so that a client built from NewDefaultClientConfig behaves exactly as it did before
+// the grace existed. The value that should be shipped is the one an experiment picks; until
+// there is one, defaulting to any other number would change every downstream's request
+// behaviour on the strength of an argument rather than a measurement.
+const defaultStealRequestGrace time.Duration = 0

--- a/steal-request-grace_test.go
+++ b/steal-request-grace_test.go
@@ -1,0 +1,81 @@
+package torrent
+
+import (
+	"testing"
+	"time"
+
+	qt "github.com/go-quicktest/qt"
+)
+
+// torrentWithRequestAge builds the minimum Torrent that stealRequestGraceElapsed reads: a
+// config carrying the grace, and one request state whose issue time is age in the past.
+func torrentWithRequestAge(grace, age time.Duration) (*Torrent, RequestIndex) {
+	const req RequestIndex = 7
+	return &Torrent{
+		cl: &Client{config: &ClientConfig{StealRequestGrace: grace}},
+		requestState: map[RequestIndex]requestState{
+			req: {when: time.Now().Add(-age)},
+		},
+	}, req
+}
+
+func TestStealRequestGraceElapsed(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		grace time.Duration
+		age   time.Duration
+		want  bool
+	}{
+		// Zero and negative are both "no grace", so a client that never sets the field keeps
+		// the unconditional stealing this guard was added to bound.
+		{"disabled steals a brand new request", 0, 0, true},
+		{"negative is treated as disabled", -time.Second, 0, true},
+		// The point of the change: a request its holder has not had time to answer stays put.
+		{"younger than the grace is not stealable", time.Second, time.Millisecond, false},
+		{"just under the grace is not stealable", time.Second, 999 * time.Millisecond, false},
+		// And the load balancing the grace is bounding still happens, just later.
+		{"at the grace is stealable", time.Second, time.Second, true},
+		{"older than the grace is stealable", time.Second, time.Minute, true},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			tor, req := torrentWithRequestAge(c.grace, c.age)
+			qt.Check(t, qt.Equals(tor.stealRequestGraceElapsed(req), c.want))
+		})
+	}
+}
+
+// The grace has to survive a steal, or a request could hop from peer to peer indefinitely as
+// long as each hop happened within one grace of the original request. PeerConn.request rewrites
+// requestState.when on every issue, which is what makes the grace per-holder.
+func TestStealRequestGraceIsPerHolderNotPerRequest(t *testing.T) {
+	tor, req := torrentWithRequestAge(50*time.Millisecond, time.Hour)
+	qt.Assert(t, qt.IsTrue(tor.stealRequestGraceElapsed(req)))
+
+	// Stand in for the re-issue in PeerConn.request that follows the steal.
+	tor.requestState[req] = requestState{when: time.Now()}
+	qt.Check(t, qt.IsFalse(tor.stealRequestGraceElapsed(req)))
+}
+
+func TestNewDefaultClientConfigStealRequestGrace(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		// Explicitly empty rather than merely unset: the suite is also run with the variable
+		// exported, to check a grace does not stall the end-to-end download tests.
+		t.Setenv(stealRequestGraceEnvKey, "")
+		qt.Check(t, qt.Equals(NewDefaultClientConfig().StealRequestGrace, defaultStealRequestGrace))
+	})
+	t.Run("env override", func(t *testing.T) {
+		t.Setenv(stealRequestGraceEnvKey, "250ms")
+		qt.Check(t, qt.Equals(NewDefaultClientConfig().StealRequestGrace, 250*time.Millisecond))
+	})
+	// The control arm of a sweep is an explicit zero, so it has to be distinguishable from
+	// "unset" rather than falling through to the default.
+	t.Run("env override can select the control arm", func(t *testing.T) {
+		t.Setenv(stealRequestGraceEnvKey, "0s")
+		qt.Check(t, qt.Equals(NewDefaultClientConfig().StealRequestGrace, 0))
+	})
+	// A typo in a sweep must not quietly produce another run of the default arm.
+	t.Run("malformed env value panics", func(t *testing.T) {
+		t.Setenv(stealRequestGraceEnvKey, "250")
+		qt.Check(t, qt.PanicMatches(func() { NewDefaultClientConfig() }, ".*missing unit.*"))
+	})
+}


### PR DESCRIPTION
Fixes most of #1094.

## What this changes

`ClientConfig.StealRequestGrace` — a minimum age a request must reach before another peer is allowed to steal it. Checked last in the steal block, so it costs nothing until a candidate has already passed the queue-depth and recency tests:

```go
// Don't steal a request the current holder has not had time to answer. The tests
// above compare queue depths, which say nothing about whether the block is already
// on the wire; see ClientConfig.StealRequestGrace.
if !t.stealRequestGraceElapsed(req) {
    continue
}
t.cancelRequest(req)
```

The clock is `requestState.when`, which `PeerConn.request` rewrites on every issue, so the grace is **per-holder**: each peer gets one uninterrupted attempt, and a single request cannot migrate more than once per grace period. The "don't steal from the poor" and recency tests are untouched.

**Zero or negative disables it, and zero is the default**, so `NewDefaultClientConfig` behaves exactly as it does today. Nothing changes for anyone who does not opt in.

## Measurements

Same setup as #1094: three public-tracker torrents totalling ~86 GB over a commercial WireGuard VPN exit, `EstablishedConnsPerTorrent` 200, 480 s windows after a 300 s ramp, all figures from counter deltas.

One binary throughout — the only thing differing between arms is the grace — with controls interleaved to bound swarm drift.

| grace | peers | wire MB/s | payload MB/s | duplicate | `wasted/(useful+wasted)` |
|---|---|---|---|---|---|
| 0 | 175 | 48.91 | 39.89 | 11.4% | 12.28% |
| 0 | 221 | 54.20 | 43.05 | 13.2% | 14.26% |
| 0 | 241 | 65.20 | 52.53 | 11.9% | 12.83% |
| 25 ms | 253 | 63.99 | 52.24 | 11.3% | 12.18% |
| 100 ms | 243 | 66.87 | 54.67 | 11.1% | 11.88% |
| **250 ms** | 212 | 69.92 | 59.51 | **7.5%** | **7.99%** |
| **1000 ms** | 213 | 53.14 | 46.64 | **5.1%** | **5.52%** |

A second sweep after the test machine's disk and RAM changed, so these are bracketed by their own controls and are not comparable to the table above:

| grace | peers | wire MB/s | payload MB/s | duplicate | `wasted/(useful+wasted)` |
|---|---|---|---|---|---|
| 0 | 193 | 41.61 | 35.01 | 8.7% | 9.39% |
| **2000 ms** | 228 | 50.43 | 45.36 | **2.6%** | **2.8%** |
| 0 | 239 | 66.02 | 55.12 | 9.6% | 10.3% |

### It is a threshold, not a gradient

25 ms and 100 ms are indistinguishable from control. The 100 ms arm and its nearest control are the closest-matched pair in the set — 243 vs 241 peers, 66.87 vs 65.20 MB/s — and differ by 0.8 points, inside the control-to-control spread.

Nothing happens until somewhere between 100 and 250 ms, then it bites. That is consistent with the grace needing to exceed the path's round-trip before a cancel can prevent anything, and it argues against the alternative reading that this works by limiting churn — churn limiting would have paid off smoothly from 25 ms upward.

Measured against each arm's own contemporaneous control, the series is monotone and has not flattened:

| grace | fraction of its control's duplicates |
|---|---|
| 250 ms | 0.61 |
| 1000 ms | 0.42 |
| 2000 ms | 0.28 |

### It is not swarm drift

Five control arms across two sweeps: 11.4 / 13.2 / 11.9 / 8.7 / 9.6%. Two pairs are matched closely enough to read directly:

| | peers | wire | duplicate |
|---|---|---|---|
| control | 221 | 54.20 | 13.2% |
| 1000 ms | 213 | 53.14 | **5.1%** |

Essentially one operating point, 2.6x apart. And the 2000 ms arm ran **busier than both of its controls** — 228 peers against 193 and 239, 50.4 MB/s against 41.6 — which by the peer-count scaling in #1094 predicts *more* duplication, not less. It produced 3.5x less, so drift can only be understating the effect.

### No regression

Payload never fell below the controls' range and peer count never dropped, so the grace is not suppressing connections or starving the request pipeline:

| | controls | treatments |
|---|---|---|
| payload MB/s | 35.0–55.1 | 45.4–59.5 |
| peers at end | 175–241 | 212–253 |

## What this does not do

**It does not reach the under-1% of #253.** At 2000 ms duplicate piece data is 2.6% — below Transmission's 4–5% on the same path for the first time, but the remaining ~2.6% is not explained by this mechanism.

**A constant is the wrong shape.** The threshold is a property of the path's round-trip time, and 2000 ms is a generous guess at one exit's. A per-peer RTT estimate is what this actually wants; there is none in the library today, so the constant is what a first version can do. If a peer RTT ever lands, this should read from it.

**The tail is unmeasured.** Every window here is 480 s taken mid-download. With no endgame mode, a request parked on a slow peer near completion cannot be re-issued for the length of the grace. That is the reason the default is off, and the first thing to turn down if last-piece latency looks wrong.

If the request-age idea is sound but the interface is not, I am happy to rework it — an internal constant, a bool, or keying it off something existing rather than a new `ClientConfig` field.

## Tests

`steal-request-grace_test.go` covers the predicate (disabled, younger than, at, and older than the grace), that the grace is per-holder rather than per-request lifetime, and the `NewDefaultClientConfig` plumbing including a malformed environment value. The existing suite passes unchanged with the grace at 0, 250 ms and 1 s — the 1 s run is the useful one, since it shows an aggressive grace does not stall the end-to-end download tests.
