### PR TITLE
Skip tracker URLs repeated within an added tier

### DIFF
--- a/torrent.go
+++ b/torrent.go
@@ -1908,7 +1908,7 @@ func appendMissingStrings(old, new []string) (ret []string) {
 	ret = old
 new:
 	for _, n := range new {
-		for _, o := range old {
+		for _, o := range ret {
 			if o == n {
 				continue new
 			}

--- a/torrent_test.go
+++ b/torrent_test.go
@@ -246,3 +246,11 @@ func TestRelativeAvailabilityHaveNone(t *testing.T) {
 	tt.Drop()
 	tt.assertAllPiecesRelativeAvailabilityZero()
 }
+
+func TestAppendMissingStringsSkipsRepeats(t *testing.T) {
+	qt.Check(t, qt.DeepEquals(
+		appendMissingStrings(
+			[]string{"http://existing"},
+			[]string{"http://a", "http://b", "http://a", "http://existing"}),
+		[]string{"http://existing", "http://a", "http://b"}))
+}


### PR DESCRIPTION
`Torrent.AddTrackers` keeps a URL that repeats inside one tier, and it stays in the announce-list from then on:

```go
tt.AddTrackers([][]string{{"http://a", "http://b", "http://a"}})
fmt.Println(tt.Metainfo().AnnounceList)
// [[http://a http://b http://a]]
```

`appendMissingStrings` checks each incoming URL against the tier as it was before the call, not the one it's building up, so a repeat inside a single call goes straight in. Loading a .torrent lands in the same place through `UpvertedAnnounceList()`. Announcing doesnt care either way, the scraper map is keyed by URL and drops the second one, but `Torrent.Metainfo()` hands the duplicate back to anyone writing the file out again.

Genuinely small. All it buys you is a .torrent that wont gain another copy every round trip, so no hard feelings if you'd rather leave it.
