### PR TITLE
storage: batch file and completion checkpoints

### DIFF
--- a/storage/bolt-piece-completion.go
+++ b/storage/bolt-piece-completion.go
@@ -43,7 +43,7 @@ func NewBoltPieceCompletion(dir string) (ret PieceCompletion, err error) {
 		return
 	}
 	db.NoSync = true
-	ret = &boltPieceCompletion{db}
+	ret = newBufferedPieceCompletion(&boltPieceCompletion{db})
 	return
 }
 
@@ -84,24 +84,38 @@ func (me *boltPieceCompletion) Set(pk metainfo.PieceKey, complete g.Option[bool]
 	if !complete.Ok {
 		return me.delete(pk)
 	}
+	return me.SetBatch([]PieceCompletionChange{{
+		Key:      pk,
+		Complete: complete.Value,
+	}})
+}
+
+func (me *boltPieceCompletion) SetBatch(changes []PieceCompletionChange) error {
 	err := me.db.Update(func(tx *bbolt.Tx) error {
 		c, err := tx.CreateBucketIfNotExists(completionBucketKey)
 		if err != nil {
 			return fmt.Errorf("creating completion bucket: %w", err)
 		}
-		ih, err := c.CreateBucketIfNotExists(pk.InfoHash[:])
-		if err != nil {
-			return fmt.Errorf("creating bucket for infohash %v: %w", pk.InfoHash, err)
+		for _, change := range changes {
+			ih, err := c.CreateBucketIfNotExists(change.Key.InfoHash[:])
+			if err != nil {
+				return fmt.Errorf("creating bucket for infohash %v: %w", change.Key.InfoHash, err)
+			}
+			key := boltPieceCompletionKey(change.Key.Index)
+			err = ih.Put(key[:], []byte(func() string {
+				if change.Complete {
+					return boltDbCompleteValue
+				}
+				return boltDbIncompleteValue
+			}()))
+			if err != nil {
+				return err
+			}
 		}
-		key := boltPieceCompletionKey(pk.Index)
-		value := boltDbIncompleteValue
-		if complete.Value {
-			value = boltDbCompleteValue
-		}
-		return ih.Put(key[:], []byte(value))
+		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("setting completion for %v: %w", pk, err)
+		return fmt.Errorf("setting piece completion batch: %w", err)
 	}
 	return nil
 }

--- a/storage/bolt-piece-completion.go
+++ b/storage/bolt-piece-completion.go
@@ -43,7 +43,7 @@ func NewBoltPieceCompletion(dir string) (ret PieceCompletion, err error) {
 		return
 	}
 	db.NoSync = true
-	ret = newBufferedPieceCompletion(&boltPieceCompletion{db})
+	ret = &boltPieceCompletion{db}
 	return
 }
 

--- a/storage/bolt-piece-completion.go
+++ b/storage/bolt-piece-completion.go
@@ -43,7 +43,7 @@ func NewBoltPieceCompletion(dir string) (ret PieceCompletion, err error) {
 		return
 	}
 	db.NoSync = true
-	ret = &boltPieceCompletion{db}
+	ret = newBufferedPieceCompletion(&boltPieceCompletion{db})
 	return
 }
 

--- a/storage/buffered-piece-completion.go
+++ b/storage/buffered-piece-completion.go
@@ -1,0 +1,139 @@
+package storage
+
+import (
+	"sync"
+
+	g "github.com/anacrolix/generics"
+	"github.com/anacrolix/torrent/metainfo"
+)
+
+// Wraps a persistent completion store so runtime completion changes can become immediately visible
+// without forcing per-piece durability work on the hot download path.
+type bufferedPieceCompletion struct {
+	underlying PieceCompletion
+
+	mu      sync.RWMutex
+	overlay map[metainfo.PieceKey]g.Option[bool]
+	dirty   map[metainfo.PieceKey]struct{}
+}
+
+var _ interface {
+	PieceCompletion
+	PieceCompletionCheckpointer
+	PieceCompletionPersistenter
+} = (*bufferedPieceCompletion)(nil)
+
+func newBufferedPieceCompletion(underlying PieceCompletion) PieceCompletion {
+	return &bufferedPieceCompletion{
+		underlying: underlying,
+	}
+}
+
+func (me *bufferedPieceCompletion) Persistent() bool {
+	// Runtime updates are checkpointed in batches instead of requiring synchronous durability for
+	// every piece completion event.
+	return false
+}
+
+func (me *bufferedPieceCompletion) Get(pk metainfo.PieceKey) (c Completion, err error) {
+	me.mu.RLock()
+	value, ok := me.overlay[pk]
+	me.mu.RUnlock()
+	if ok {
+		c.Ok = value.Ok
+		c.Complete = value.Value
+		return
+	}
+	return me.underlying.Get(pk)
+}
+
+func (me *bufferedPieceCompletion) Set(pk metainfo.PieceKey, complete g.Option[bool]) error {
+	me.mu.Lock()
+	if me.overlay == nil {
+		me.overlay = make(map[metainfo.PieceKey]g.Option[bool])
+	}
+	me.overlay[pk] = complete
+	if complete.Ok && complete.Value {
+		if me.dirty == nil {
+			me.dirty = make(map[metainfo.PieceKey]struct{})
+		}
+		me.dirty[pk] = struct{}{}
+		me.mu.Unlock()
+		return nil
+	}
+	delete(me.dirty, pk)
+	me.mu.Unlock()
+
+	if err := me.underlying.Set(pk, complete); err != nil {
+		return err
+	}
+
+	me.mu.Lock()
+	// Underlying storage now matches the runtime view for this key.
+	if current, ok := me.overlay[pk]; ok && current == complete {
+		delete(me.overlay, pk)
+	}
+	me.mu.Unlock()
+	return nil
+}
+
+func (me *bufferedPieceCompletion) Checkpoint(keys []metainfo.PieceKey) error {
+	me.mu.RLock()
+	changes := make([]PieceCompletionChange, 0, len(keys))
+	for _, key := range keys {
+		if _, ok := me.dirty[key]; !ok {
+			continue
+		}
+		value, ok := me.overlay[key]
+		if !ok {
+			continue
+		}
+		changes = append(changes, PieceCompletionChange{
+			Key:      key,
+			Complete: value.Value,
+		})
+	}
+	me.mu.RUnlock()
+
+	if len(changes) == 0 {
+		return nil
+	}
+	if err := me.persistChanges(changes); err != nil {
+		return err
+	}
+
+	me.mu.Lock()
+	for _, change := range changes {
+		delete(me.dirty, change.Key)
+		if current, ok := me.overlay[change.Key]; ok && current == g.Some(change.Complete) {
+			delete(me.overlay, change.Key)
+		}
+	}
+	me.mu.Unlock()
+	return nil
+}
+
+func (me *bufferedPieceCompletion) Close() error {
+	me.mu.RLock()
+	keys := make([]metainfo.PieceKey, 0, len(me.dirty))
+	for key := range me.dirty {
+		keys = append(keys, key)
+	}
+	me.mu.RUnlock()
+	if err := me.Checkpoint(keys); err != nil {
+		return err
+	}
+	return me.underlying.Close()
+}
+
+func (me *bufferedPieceCompletion) persistChanges(changes []PieceCompletionChange) error {
+	if batchSetter, ok := me.underlying.(PieceCompletionBatchSetter); ok {
+		return batchSetter.SetBatch(changes)
+	}
+	for _, change := range changes {
+		if err := me.underlying.Set(change.Key, g.Some(change.Complete)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/storage/buffered-piece-completion.go
+++ b/storage/buffered-piece-completion.go
@@ -30,9 +30,11 @@ func newBufferedPieceCompletion(underlying PieceCompletion) PieceCompletion {
 }
 
 func (me *bufferedPieceCompletion) Persistent() bool {
-	// Runtime updates are checkpointed in batches instead of requiring synchronous durability for
-	// every piece completion event.
-	return false
+	// This wrapper defers writes, but the underlying store may still be persistent between runs.
+	if p, ok := me.underlying.(PieceCompletionPersistenter); ok {
+		return p.Persistent()
+	}
+	return true
 }
 
 func (me *bufferedPieceCompletion) Get(pk metainfo.PieceKey) (c Completion, err error) {

--- a/storage/buffered-piece-completion_test.go
+++ b/storage/buffered-piece-completion_test.go
@@ -1,0 +1,117 @@
+package storage
+
+import (
+	"sync"
+	"testing"
+
+	g "github.com/anacrolix/generics"
+	"github.com/go-quicktest/qt"
+
+	"github.com/anacrolix/torrent/metainfo"
+)
+
+type recordingPieceCompletion struct {
+	mu    sync.Mutex
+	state map[metainfo.PieceKey]bool
+	batch []PieceCompletionChange
+}
+
+func (me *recordingPieceCompletion) Get(pk metainfo.PieceKey) (c Completion, err error) {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	if me.state == nil {
+		return
+	}
+	value, ok := me.state[pk]
+	if !ok {
+		return
+	}
+	c.Ok = true
+	c.Complete = value
+	return
+}
+
+func (me *recordingPieceCompletion) Set(pk metainfo.PieceKey, complete g.Option[bool]) error {
+	if !complete.Ok {
+		me.mu.Lock()
+		delete(me.state, pk)
+		me.mu.Unlock()
+		return nil
+	}
+	return me.SetBatch([]PieceCompletionChange{{
+		Key:      pk,
+		Complete: complete.Value,
+	}})
+}
+
+func (me *recordingPieceCompletion) SetBatch(changes []PieceCompletionChange) error {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	if me.state == nil {
+		me.state = make(map[metainfo.PieceKey]bool)
+	}
+	for _, change := range changes {
+		me.state[change.Key] = change.Complete
+		me.batch = append(me.batch, change)
+	}
+	return nil
+}
+
+func (me *recordingPieceCompletion) Close() error {
+	return nil
+}
+
+func TestBufferedPieceCompletionDefersTrueUntilCheckpoint(t *testing.T) {
+	underlying := &recordingPieceCompletion{}
+	pc := newBufferedPieceCompletion(underlying)
+	key := metainfo.PieceKey{
+		InfoHash: metainfo.HashBytes([]byte("a")),
+		Index:    1,
+	}
+
+	qt.Assert(t, qt.IsNil(pc.Set(key, g.Some(true))))
+
+	runtimeValue, err := pc.Get(key)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.IsTrue(runtimeValue.Ok))
+	qt.Assert(t, qt.IsTrue(runtimeValue.Complete))
+
+	persistedValue, err := underlying.Get(key)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.IsFalse(persistedValue.Ok))
+
+	checkpointer, ok := pc.(PieceCompletionCheckpointer)
+	qt.Assert(t, qt.IsTrue(ok))
+	qt.Assert(t, qt.IsNil(checkpointer.Checkpoint([]metainfo.PieceKey{key})))
+
+	persistedValue, err = underlying.Get(key)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.IsTrue(persistedValue.Ok))
+	qt.Assert(t, qt.IsTrue(persistedValue.Complete))
+}
+
+func TestBufferedPieceCompletionPersistsFalseImmediately(t *testing.T) {
+	underlying := &recordingPieceCompletion{}
+	pc := newBufferedPieceCompletion(underlying)
+	key := metainfo.PieceKey{
+		InfoHash: metainfo.HashBytes([]byte("b")),
+		Index:    2,
+	}
+
+	qt.Assert(t, qt.IsNil(pc.Set(key, g.Some(true))))
+	qt.Assert(t, qt.IsNil(pc.Set(key, g.Some(false))))
+
+	persistedValue, err := underlying.Get(key)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.IsTrue(persistedValue.Ok))
+	qt.Assert(t, qt.IsFalse(persistedValue.Complete))
+
+	checkpointer, ok := pc.(PieceCompletionCheckpointer)
+	qt.Assert(t, qt.IsTrue(ok))
+	qt.Assert(t, qt.IsNil(checkpointer.Checkpoint([]metainfo.PieceKey{key})))
+
+	underlying.mu.Lock()
+	defer underlying.mu.Unlock()
+	qt.Assert(t, qt.HasLen(underlying.batch, 1))
+	qt.Assert(t, qt.IsFalse(underlying.batch[0].Complete))
+}

--- a/storage/buffered-piece-completion_test.go
+++ b/storage/buffered-piece-completion_test.go
@@ -11,9 +11,10 @@ import (
 )
 
 type recordingPieceCompletion struct {
-	mu    sync.Mutex
-	state map[metainfo.PieceKey]bool
-	batch []PieceCompletionChange
+	mu         sync.Mutex
+	state      map[metainfo.PieceKey]bool
+	batch      []PieceCompletionChange
+	persistent bool
 }
 
 func (me *recordingPieceCompletion) Get(pk metainfo.PieceKey) (c Completion, err error) {
@@ -61,6 +62,10 @@ func (me *recordingPieceCompletion) Close() error {
 	return nil
 }
 
+func (me *recordingPieceCompletion) Persistent() bool {
+	return me.persistent
+}
+
 func TestBufferedPieceCompletionDefersTrueUntilCheckpoint(t *testing.T) {
 	underlying := &recordingPieceCompletion{}
 	pc := newBufferedPieceCompletion(underlying)
@@ -88,6 +93,14 @@ func TestBufferedPieceCompletionDefersTrueUntilCheckpoint(t *testing.T) {
 	qt.Assert(t, qt.IsNil(err))
 	qt.Assert(t, qt.IsTrue(persistedValue.Ok))
 	qt.Assert(t, qt.IsTrue(persistedValue.Complete))
+
+	underlying.mu.Lock()
+	defer underlying.mu.Unlock()
+	qt.Assert(t, qt.HasLen(underlying.batch, 1))
+	qt.Assert(t, qt.DeepEquals(underlying.batch[0], PieceCompletionChange{
+		Key:      key,
+		Complete: true,
+	}))
 }
 
 func TestBufferedPieceCompletionPersistsFalseImmediately(t *testing.T) {
@@ -114,4 +127,57 @@ func TestBufferedPieceCompletionPersistsFalseImmediately(t *testing.T) {
 	defer underlying.mu.Unlock()
 	qt.Assert(t, qt.HasLen(underlying.batch, 1))
 	qt.Assert(t, qt.IsFalse(underlying.batch[0].Complete))
+}
+
+func TestBufferedPieceCompletionPersistsUnknownImmediately(t *testing.T) {
+	underlying := &recordingPieceCompletion{}
+	pc := newBufferedPieceCompletion(underlying)
+	key := metainfo.PieceKey{
+		InfoHash: metainfo.HashBytes([]byte("c")),
+		Index:    3,
+	}
+
+	qt.Assert(t, qt.IsNil(underlying.Set(key, g.Some(true))))
+	qt.Assert(t, qt.IsNil(pc.Set(key, g.Some(true))))
+	qt.Assert(t, qt.IsNil(pc.Set(key, g.Option[bool]{})))
+
+	runtimeValue, err := pc.Get(key)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.IsFalse(runtimeValue.Ok))
+
+	persistedValue, err := underlying.Get(key)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.IsFalse(persistedValue.Ok))
+
+	checkpointer, ok := pc.(PieceCompletionCheckpointer)
+	qt.Assert(t, qt.IsTrue(ok))
+	qt.Assert(t, qt.IsNil(checkpointer.Checkpoint([]metainfo.PieceKey{key})))
+}
+
+func TestBufferedPieceCompletionCloseFlushesDirtyCompletions(t *testing.T) {
+	underlying := &recordingPieceCompletion{}
+	pc := newBufferedPieceCompletion(underlying)
+	key := metainfo.PieceKey{
+		InfoHash: metainfo.HashBytes([]byte("d")),
+		Index:    4,
+	}
+
+	qt.Assert(t, qt.IsNil(pc.Set(key, g.Some(true))))
+	qt.Assert(t, qt.IsNil(pc.Close()))
+
+	persistedValue, err := underlying.Get(key)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.IsTrue(persistedValue.Ok))
+	qt.Assert(t, qt.IsTrue(persistedValue.Complete))
+}
+
+func TestBufferedPieceCompletionPersistentForwardsUnderlyingState(t *testing.T) {
+	underlying := &recordingPieceCompletion{persistent: true}
+	pc := newBufferedPieceCompletion(underlying)
+	persistenter, ok := pc.(PieceCompletionPersistenter)
+	qt.Assert(t, qt.IsTrue(ok))
+	qt.Assert(t, qt.IsTrue(persistenter.Persistent()))
+
+	underlying.persistent = false
+	qt.Assert(t, qt.IsFalse(persistenter.Persistent()))
 }

--- a/storage/file-client.go
+++ b/storage/file-client.go
@@ -103,7 +103,11 @@ func (fs *fileClientImpl) OpenTorrent(
 		info.FileSegmentsIndex(),
 		infoHash,
 		defaultFileIo(),
+		nil,
 		fs,
+	}
+	if checkpointer, ok := fs.opts.PieceCompletion.(PieceCompletionCheckpointer); ok {
+		t.checkpoint = newTorrentCheckpointBuffer(t, checkpointer)
 	}
 	if t.partFiles() {
 		err = t.setCompletionFromPartFiles()

--- a/storage/file-piece.go
+++ b/storage/file-piece.go
@@ -172,7 +172,12 @@ func (me *filePieceImpl) MarkComplete() (err error) {
 	if err != nil {
 		return
 	}
-	if pieceCompletionIsPersistent(me.pieceCompletion()) {
+	if me.t.checkpoint != nil {
+		err = me.t.checkpoint.queuePiece(me.pieceKey(), me.p.Length(), me.checkpointTargets())
+		if err != nil {
+			me.logger().Warn("error checkpointing completed piece", "piece", me.p.Index(), "err", err)
+		}
+	} else if pieceCompletionIsPersistent(me.pieceCompletion()) {
 		err := me.Flush()
 		if err != nil {
 			me.logger().Warn("error flushing completed piece", "piece", me.p.Index(), "err", err)
@@ -296,6 +301,28 @@ func (me *filePieceImpl) onFileNotComplete(f file) (err error) {
 
 func (me *filePieceImpl) partFiles() bool {
 	return me.t.partFiles()
+}
+
+func (me *filePieceImpl) checkpointTargets() []fileCheckpointTarget {
+	targets := make([]fileCheckpointTarget, 0, len(me.t.files))
+	seen := make(map[string]struct{})
+	for fileIndex := range me.fileExtents() {
+		f := me.t.file(fileIndex)
+		primary := me.t.pathForWrite(&f)
+		if _, ok := seen[primary]; ok {
+			continue
+		}
+		seen[primary] = struct{}{}
+		target := fileCheckpointTarget{
+			primary: primary,
+			length:  f.length(),
+		}
+		if primary != f.safeOsPath {
+			target.fallback = f.safeOsPath
+		}
+		targets = append(targets, target)
+	}
+	return targets
 }
 
 func (me *filePieceImpl) WriteTo(w io.Writer) (n int64, err error) {

--- a/storage/file-torrent-checkpoint.go
+++ b/storage/file-torrent-checkpoint.go
@@ -1,0 +1,152 @@
+package storage
+
+import (
+	"errors"
+	"io/fs"
+	"sync"
+	"time"
+
+	"github.com/anacrolix/torrent/metainfo"
+)
+
+const (
+	defaultBufferedCheckpointInterval = time.Second
+	defaultBufferedCheckpointBytes    = 128 << 20
+)
+
+type fileCheckpointTarget struct {
+	primary  string
+	fallback string
+	length   int64
+}
+
+type torrentCheckpointBuffer struct {
+	t            *fileTorrentImpl
+	checkpointer PieceCompletionCheckpointer
+
+	mu sync.Mutex
+
+	pendingPieces map[metainfo.PieceKey]struct{}
+	pendingFiles  map[string]fileCheckpointTarget
+	pendingBytes  int64
+
+	lastCheckpoint time.Time
+}
+
+func newTorrentCheckpointBuffer(
+	t *fileTorrentImpl,
+	checkpointer PieceCompletionCheckpointer,
+) *torrentCheckpointBuffer {
+	return &torrentCheckpointBuffer{
+		t:              t,
+		checkpointer:   checkpointer,
+		pendingPieces:  make(map[metainfo.PieceKey]struct{}),
+		pendingFiles:   make(map[string]fileCheckpointTarget),
+		lastCheckpoint: time.Now(),
+	}
+}
+
+func (me *torrentCheckpointBuffer) queuePiece(
+	key metainfo.PieceKey,
+	length int64,
+	targets []fileCheckpointTarget,
+) error {
+	me.mu.Lock()
+	if _, ok := me.pendingPieces[key]; !ok {
+		me.pendingPieces[key] = struct{}{}
+		me.pendingBytes += length
+	}
+	for _, target := range targets {
+		me.pendingFiles[target.primary] = target
+	}
+	shouldCheckpoint := me.shouldCheckpointLocked()
+	me.mu.Unlock()
+	if shouldCheckpoint {
+		return me.checkpoint()
+	}
+	return nil
+}
+
+func (me *torrentCheckpointBuffer) shouldCheckpointLocked() bool {
+	if len(me.pendingPieces) == 0 {
+		return false
+	}
+	if me.pendingBytes >= defaultBufferedCheckpointBytes {
+		return true
+	}
+	return time.Since(me.lastCheckpoint) >= defaultBufferedCheckpointInterval
+}
+
+func (me *torrentCheckpointBuffer) checkpoint() error {
+	keys, targets := me.takePending()
+	if len(keys) == 0 {
+		return nil
+	}
+
+	for _, target := range targets {
+		if err := me.flushTarget(target); err != nil {
+			me.restorePending(keys, targets)
+			return err
+		}
+	}
+	if err := me.checkpointer.Checkpoint(keys); err != nil {
+		me.restorePending(keys, targets)
+		return err
+	}
+	me.mu.Lock()
+	me.lastCheckpoint = time.Now()
+	me.mu.Unlock()
+	return nil
+}
+
+func (me *torrentCheckpointBuffer) close() error {
+	return me.checkpoint()
+}
+
+func (me *torrentCheckpointBuffer) flushTarget(target fileCheckpointTarget) error {
+	err := me.t.io.flush(target.primary, 0, target.length)
+	if err == nil {
+		return nil
+	}
+	if target.fallback != "" && errors.Is(err, fs.ErrNotExist) {
+		return me.t.io.flush(target.fallback, 0, target.length)
+	}
+	return err
+}
+
+func (me *torrentCheckpointBuffer) takePending() ([]metainfo.PieceKey, []fileCheckpointTarget) {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	if len(me.pendingPieces) == 0 {
+		return nil, nil
+	}
+	keys := make([]metainfo.PieceKey, 0, len(me.pendingPieces))
+	for key := range me.pendingPieces {
+		keys = append(keys, key)
+	}
+	targets := make([]fileCheckpointTarget, 0, len(me.pendingFiles))
+	for _, target := range me.pendingFiles {
+		targets = append(targets, target)
+	}
+	clear(me.pendingPieces)
+	clear(me.pendingFiles)
+	me.pendingBytes = 0
+	return keys, targets
+}
+
+func (me *torrentCheckpointBuffer) restorePending(
+	keys []metainfo.PieceKey,
+	targets []fileCheckpointTarget,
+) {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	for _, key := range keys {
+		if _, ok := me.pendingPieces[key]; !ok {
+			me.pendingPieces[key] = struct{}{}
+			me.pendingBytes += int64(me.t.info.Piece(key.Index).Length())
+		}
+	}
+	for _, target := range targets {
+		me.pendingFiles[target.primary] = target
+	}
+}

--- a/storage/file-torrent-checkpoint_test.go
+++ b/storage/file-torrent-checkpoint_test.go
@@ -1,0 +1,134 @@
+package storage
+
+import (
+	"io/fs"
+	"log/slog"
+	"sync"
+	"testing"
+
+	g "github.com/anacrolix/generics"
+	"github.com/go-quicktest/qt"
+
+	"github.com/anacrolix/torrent/metainfo"
+)
+
+type checkpointCountingFileIo struct {
+	flushes []string
+	closed  bool
+}
+
+func (me *checkpointCountingFileIo) openForSharedRead(string) (sharableReader, error) {
+	panic("unexpected openForSharedRead")
+}
+
+func (me *checkpointCountingFileIo) openForRead(string) (fileReader, error) {
+	panic("unexpected openForRead")
+}
+
+func (me *checkpointCountingFileIo) openForWrite(string, int64) (fileWriter, error) {
+	panic("unexpected openForWrite")
+}
+
+func (me *checkpointCountingFileIo) flush(name string, _, _ int64) error {
+	me.flushes = append(me.flushes, name)
+	return nil
+}
+
+func (me *checkpointCountingFileIo) rename(string, string) error {
+	return fs.ErrNotExist
+}
+
+func (me *checkpointCountingFileIo) Close() error {
+	me.closed = true
+	return nil
+}
+
+func TestBufferedCheckpointDefersFileFlushUntilTorrentClose(t *testing.T) {
+	info := &metainfo.Info{
+		Files:       []metainfo.FileInfo{{Path: []string{"a.bin"}, Length: 1}},
+		Pieces:      make([]byte, 20),
+		PieceLength: 1,
+	}
+	files := []fileExtra{{
+		safeOsPath: "a.bin",
+	}}
+	pc := newBufferedPieceCompletion(&recordingPieceCompletion{})
+	checkpointer, ok := pc.(PieceCompletionCheckpointer)
+	qt.Assert(t, qt.IsTrue(ok))
+	ioImpl := &checkpointCountingFileIo{}
+	torrent := &fileTorrentImpl{
+		info:              info,
+		files:             files,
+		metainfoFileInfos: info.UpvertedFiles(),
+		segmentLocater:    info.FileSegmentsIndex(),
+		infoHash:          metainfo.HashBytes([]byte("x")),
+		io:                ioImpl,
+		client: &fileClientImpl{
+			opts: NewFileClientOpts{
+				PieceCompletion: pc,
+				UsePartFiles:    g.Some(false),
+				Logger:          slog.Default(),
+			},
+		},
+	}
+	torrent.checkpoint = newTorrentCheckpointBuffer(torrent, checkpointer)
+
+	piece := &filePieceImpl{
+		t: torrent,
+		p: info.Piece(0),
+	}
+	qt.Assert(t, qt.IsNil(piece.MarkComplete()))
+	qt.Assert(t, qt.HasLen(ioImpl.flushes, 0))
+
+	qt.Assert(t, qt.IsNil(torrent.Close()))
+	qt.Assert(t, qt.DeepEquals(ioImpl.flushes, []string{"a.bin"}))
+
+	completion, err := pc.Get(metainfo.PieceKey{
+		InfoHash: torrent.infoHash,
+		Index:    0,
+	})
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.IsTrue(completion.Ok))
+	qt.Assert(t, qt.IsTrue(completion.Complete))
+	qt.Assert(t, qt.IsTrue(ioImpl.closed))
+}
+
+func TestTorrentCheckpointBufferConcurrentQueuePiece(t *testing.T) {
+	info := &metainfo.Info{
+		PieceLength: 1,
+		Pieces:      make([]byte, 20*4),
+	}
+	pc := newBufferedPieceCompletion(&recordingPieceCompletion{})
+	checkpointer, ok := pc.(PieceCompletionCheckpointer)
+	qt.Assert(t, qt.IsTrue(ok))
+	torrent := &fileTorrentImpl{
+		info:     info,
+		infoHash: metainfo.HashBytes([]byte("y")),
+		io:       &checkpointCountingFileIo{},
+	}
+	buffer := newTorrentCheckpointBuffer(torrent, checkpointer)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 32; j++ {
+				err := buffer.queuePiece(
+					metainfo.PieceKey{
+						InfoHash: torrent.infoHash,
+						Index:    i*32 + j,
+					},
+					1,
+					[]fileCheckpointTarget{{
+						primary: "a.bin",
+						length:  1,
+					}},
+				)
+				qt.Assert(t, qt.IsNil(err))
+			}
+		}(i)
+	}
+	wg.Wait()
+	qt.Assert(t, qt.IsNil(buffer.close()))
+}

--- a/storage/file-torrent.go
+++ b/storage/file-torrent.go
@@ -22,6 +22,7 @@ type fileTorrentImpl struct {
 	segmentLocater    segments.Index
 	infoHash          metainfo.Hash
 	io                fileIo
+	checkpoint        *torrentCheckpointBuffer
 	// Save memory by pointing to the other data.
 	client *fileClientImpl
 }
@@ -116,7 +117,12 @@ func (me *fileTorrentImpl) Piece(p metainfo.Piece) PieceImpl {
 }
 
 func (me *fileTorrentImpl) Close() error {
-	return me.io.Close()
+	var err error
+	if me.checkpoint != nil {
+		err = errors.Join(err, me.checkpoint.close())
+	}
+	err = errors.Join(err, me.io.Close())
+	return err
 }
 
 func (me *fileTorrentImpl) file(index int) file {

--- a/storage/piece-completion.go
+++ b/storage/piece-completion.go
@@ -35,6 +35,23 @@ type PieceCompletionPersistenter interface {
 	Persistent() bool
 }
 
+type PieceCompletionChange struct {
+	Key      metainfo.PieceKey
+	Complete bool
+}
+
+// Optional interface for piece completion implementations that can persist multiple changes in a
+// single transaction.
+type PieceCompletionBatchSetter interface {
+	SetBatch([]PieceCompletionChange) error
+}
+
+// Optional interface for piece completion implementations that buffer runtime updates and expose a
+// checkpoint hook to persist them later.
+type PieceCompletionCheckpointer interface {
+	Checkpoint([]metainfo.PieceKey) error
+}
+
 func pieceCompletionIsPersistent(pc PieceCompletion) bool {
 	if p, ok := pc.(PieceCompletionPersistenter); ok {
 		return p.Persistent()


### PR DESCRIPTION
Depends on #1088. Also builds on #1086, which has already been merged.

Persistent piece completion currently flushes file data for every completed piece before recording completion. This creates repeated synchronous flush and database work on the download hot path.

This change:

- enables the buffered wrapper for Bolt piece completion;
- queues completed pieces and their files when the completion store supports checkpoints;
- flushes queued files and checkpoints queued completion records at a one-second or 128 MiB threshold;
- flushes and checkpoints pending work when the torrent closes; and
- snapshots and restores pending state around I/O so concurrent queueing remains safe and failed checkpoints can be retried.

The buffered wrapper and batch/checkpoint interfaces are introduced in #1088. Bolt is wired through the wrapper here because this PR also adds the file flush and `PieceCompletionCheckpointer` call sites needed to preserve persistence behavior.

Tests cover deferred flush, close-time persistence, and concurrent queueing.

Tests:

- `go test ./storage`
