### PR TITLE
storage: expose cached writer cleanup

### DIFF
--- a/storage/file-client.go
+++ b/storage/file-client.go
@@ -113,7 +113,8 @@ func (fs *fileClientImpl) OpenTorrent(
 		}
 	}
 	return TorrentImpl{
-		Piece: t.Piece,
-		Close: t.Close,
+		Piece:        t.Piece,
+		Close:        t.Close,
+		CloseWriters: t.CloseWriters,
 	}, nil
 }

--- a/storage/file-io-classic.go
+++ b/storage/file-io-classic.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"sort"
 	"sync"
 )
 
@@ -21,13 +22,18 @@ func newClassicFileIo() fileIo {
 func (me *classicFileIo) Close() error {
 	me.mu.Lock()
 	defer me.mu.Unlock()
-	var err error
-	for name, f := range me.writers {
-		err = errors.Join(err, f.Close())
-		delete(me.writers, name)
-	}
+	_, _, err := me.closeWritersLocked()
 	me.closed = true
 	return err
+}
+
+func (me *classicFileIo) closeWriters() (closedPaths []string, remaining int, err error) {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	if err := me.closedErr(); err != nil {
+		return nil, 0, err
+	}
+	return me.closeWritersLocked()
 }
 
 func (me *classicFileIo) rename(from, to string) error {
@@ -106,6 +112,23 @@ func (me *classicFileIo) closeWriterLocked(name string) error {
 	}
 	delete(me.writers, name)
 	return f.Close()
+}
+
+func (me *classicFileIo) closeWritersLocked() (closedPaths []string, remaining int, err error) {
+	if me.writers == nil {
+		return nil, 0, nil
+	}
+	closedPaths = make([]string, 0, len(me.writers))
+	for name := range me.writers {
+		closedPaths = append(closedPaths, name)
+	}
+	sort.Strings(closedPaths)
+	for _, name := range closedPaths {
+		f := me.writers[name]
+		delete(me.writers, name)
+		err = errors.Join(err, f.Close())
+	}
+	return closedPaths, len(me.writers), err
 }
 
 func (me *classicFileIo) closedErr() error {

--- a/storage/file-io-classic_test.go
+++ b/storage/file-io-classic_test.go
@@ -53,3 +53,22 @@ func TestClassicFileIoOpenForReadBorrowsWriterHandle(t *testing.T) {
 	qt.Assert(t, qt.Equals(n, 5))
 	qt.Assert(t, qt.DeepEquals(buf, []byte("hello")))
 }
+func TestClassicFileIoCloseWritersClearsCachedHandles(t *testing.T) {
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "data.bin")
+
+	ioImpl, ok := newClassicFileIo().(*classicFileIo)
+	qt.Assert(t, qt.IsTrue(ok))
+	t.Cleanup(func() { _ = ioImpl.Close() })
+
+	writer, err := ioImpl.openForWrite(filePath, 0)
+	qt.Assert(t, qt.IsNil(err))
+	_, err = writer.WriteAt([]byte("hello"), 0)
+	qt.Assert(t, qt.IsNil(err))
+
+	closedPaths, remaining, err := ioImpl.closeWriters()
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.DeepEquals(closedPaths, []string{filePath}))
+	qt.Assert(t, qt.Equals(remaining, 0))
+	qt.Assert(t, qt.HasLen(ioImpl.writers, 0))
+}

--- a/storage/file-io-mmap.go
+++ b/storage/file-io-mmap.go
@@ -62,6 +62,10 @@ func (me *mmapFileIo) Close() error {
 	return nil
 }
 
+func (me *mmapFileIo) closeWriters() (closedPaths []string, remaining int, err error) {
+	return nil, 0, nil
+}
+
 func (me *mmapFileIo) closedErr() error {
 	if me.closed {
 		return fs.ErrClosed

--- a/storage/file-io.go
+++ b/storage/file-io.go
@@ -23,6 +23,7 @@ var defaultFileIo = func() fileIo {
 
 type fileIo interface {
 	Close() error
+	closeWriters() (closedPaths []string, remaining int, err error)
 
 	openForSharedRead(name string) (sharableReader, error)
 	openForRead(name string) (fileReader, error)

--- a/storage/file-torrent.go
+++ b/storage/file-torrent.go
@@ -119,6 +119,26 @@ func (me *fileTorrentImpl) Close() error {
 	return me.io.Close()
 }
 
+func (me *fileTorrentImpl) CloseWriters() error {
+	closedPaths, remaining, err := me.io.closeWriters()
+	me.logger().Debug("closing writer cache after torrent completion", "count", len(closedPaths))
+	for _, path := range closedPaths {
+		me.logger().Debug("closed cached writer after torrent completion", "path", path)
+	}
+	me.logger().Debug(
+		"writer cache close result after torrent completion",
+		"closedCount",
+		len(closedPaths),
+		"remainingCount",
+		remaining,
+		"cleared",
+		remaining == 0,
+		"err",
+		err,
+	)
+	return err
+}
+
 func (me *fileTorrentImpl) file(index int) file {
 	return file{
 		Info:      me.info,

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -32,6 +32,7 @@ type TorrentImpl struct {
 	// Preferred over PieceWithHash. Called with the piece hash if it's available.
 	PieceWithHash func(p metainfo.Piece, pieceHash g.Option[[]byte]) PieceImpl
 	Close         func() error
+	CloseWriters  func() error
 	// Storages that share the same space, will provide equal pointers. The function is called once
 	// to determine the storage for torrents sharing the same function pointer, and mutated in
 	// place.

--- a/storage/wrappers.go
+++ b/storage/wrappers.go
@@ -35,6 +35,13 @@ type Torrent struct {
 	TorrentImpl
 }
 
+func (t *Torrent) CloseWriters() error {
+	if t.TorrentImpl.CloseWriters == nil {
+		return nil
+	}
+	return t.TorrentImpl.CloseWriters()
+}
+
 // Deprecated. Use PieceWithHash, as this doesn't work with pure v2 torrents.
 func (t *Torrent) Piece(p metainfo.Piece) Piece {
 	return t.PieceWithHash(p, g.Some(p.V1Hash().Unwrap().Bytes()))

--- a/torrent.go
+++ b/torrent.go
@@ -3597,6 +3597,15 @@ func (t *Torrent) canonicalShortInfohash() *infohash.T {
 	return t.infoHashV2.UnwrapPtr().ToShort()
 }
 
+func (t *Torrent) CloseWriters() error {
+	t.storageLock.RLock()
+	defer t.storageLock.RUnlock()
+	if t.storage == nil {
+		return nil
+	}
+	return t.storage.CloseWriters()
+}
+
 func (t *Torrent) iterShortInfohashes() iter.Seq[shortInfohash] {
 	return func(yield func(shortInfohash) bool) {
 		t.eachShortInfohash(func(short [20]byte) {


### PR DESCRIPTION
The classic backend keeps writer handles open to avoid repeated filesystem opens, but callers need a way to release those handles after a torrent finishes downloading without closing the entire storage instance.

This change:

- adds an optional torrent-level `CloseWriters` operation;
- implements it for file storage;
- exposes it through `storage.Torrent` and `torrent.Torrent`;
- closes and reports cached paths for the classic backend; and
- keeps mmap and storage implementations without writer caches as no-ops.

Tests verify that the classic writer cache is empty after cleanup.

Tests:

- `go test ./storage`
