### PR TITLE
storage: resolve default file io lazily from env

### DIFF
--- a/storage/file-io-classic_test.go
+++ b/storage/file-io-classic_test.go
@@ -8,6 +8,29 @@ import (
 	"github.com/go-quicktest/qt"
 )
 
+func TestDefaultFileIoDefaultsToMmapWithoutEnv(t *testing.T) {
+	t.Setenv("TORRENT_STORAGE_DEFAULT_FILE_IO", "")
+	qt.Assert(t, qt.IsNil(os.Unsetenv("TORRENT_STORAGE_DEFAULT_FILE_IO")))
+	ioImpl := defaultFileIo()
+	t.Cleanup(func() { _ = ioImpl.Close() })
+	_, ok := ioImpl.(*mmapFileIo)
+	qt.Assert(t, qt.IsTrue(ok))
+}
+
+func TestDefaultFileIoReadsEnvironmentLazily(t *testing.T) {
+	t.Setenv("TORRENT_STORAGE_DEFAULT_FILE_IO", "classic")
+	ioImpl := defaultFileIo()
+	t.Cleanup(func() { _ = ioImpl.Close() })
+	_, ok := ioImpl.(*classicFileIo)
+	qt.Assert(t, qt.IsTrue(ok))
+
+	t.Setenv("TORRENT_STORAGE_DEFAULT_FILE_IO", "mmap")
+	ioImpl = defaultFileIo()
+	t.Cleanup(func() { _ = ioImpl.Close() })
+	_, ok = ioImpl.(*mmapFileIo)
+	qt.Assert(t, qt.IsTrue(ok))
+}
+
 func TestClassicFileIoRenameClosesCachedWriter(t *testing.T) {
 	tempDir := t.TempDir()
 	oldPath := filepath.Join(tempDir, "old.bin")

--- a/storage/file-io-mmap.go
+++ b/storage/file-io-mmap.go
@@ -22,22 +22,21 @@ import (
 const lockHandleOperations = false
 
 func init() {
+	// Resolve the environment variable when storage is instantiated rather than during package init,
+	// so applications can still configure it from their own init or main functions.
+	defaultFileIo = newDefaultFileIo
+}
+
+func newDefaultFileIo() fileIo {
 	s, ok := os.LookupEnv("TORRENT_STORAGE_DEFAULT_FILE_IO")
 	if !ok {
-		defaultFileIo = func() fileIo {
-			return &mmapFileIo{}
-		}
-		return
+		return &mmapFileIo{}
 	}
 	switch s {
 	case "mmap":
-		defaultFileIo = func() fileIo {
-			return &mmapFileIo{}
-		}
+		return &mmapFileIo{}
 	case "classic":
-		defaultFileIo = func() fileIo {
-			return newClassicFileIo()
-		}
+		return newClassicFileIo()
 	default:
 		panic(s)
 	}


### PR DESCRIPTION
Move default file I/O selection out of package-init time and resolve `TORRENT_STORAGE_DEFAULT_FILE_IO` when a storage backend instance is actually created.

Applications embedding the library may set `TORRENT_STORAGE_DEFAULT_FILE_IO` from their own init functions or from main. Reading the environment in the storage package init ran too early for those callers, so late configuration was silently ignored.

This change:

- keeps the existing `defaultFileIo` entry point but routes it through a lazy constructor;
- resolves `TORRENT_STORAGE_DEFAULT_FILE_IO` at instantiation time instead of package initialization time;
- keeps the implicit default as mmap when no override is set; and
- preserves explicit `classic` and `mmap` overrides.

Tests cover the default-without-env behavior and prove that environment changes made during test execution take effect.

Tests:

- `go test ./storage`
