### PR TITLE
storage: track remaining pieces per part file

### DIFF
--- a/storage/file-client.go
+++ b/storage/file-client.go
@@ -111,6 +111,11 @@ func (fs *fileClientImpl) OpenTorrent(
 			err = fmt.Errorf("setting completion from part files: %w", err)
 			return
 		}
+		err = t.initFileCompletionTracking()
+		if err != nil {
+			err = fmt.Errorf("initializing file completion tracking: %w", err)
+			return
+		}
 	}
 	return TorrentImpl{
 		Piece: t.Piece,

--- a/storage/file-misc.go
+++ b/storage/file-misc.go
@@ -88,6 +88,9 @@ type fileExtra struct {
 	mu sync.RWMutex
 	// The safe, OS-local file path.
 	safeOsPath string
+	// Remaining pieces touching this file that are not yet complete.
+	remainingPieces int
+	remainingKnown  bool
 	// Utility value to help the race detector find issues for us.
 	race byte
 }

--- a/storage/file-piece.go
+++ b/storage/file-piece.go
@@ -168,6 +168,7 @@ func (me *filePieceImpl) markIncompletePieces(file *file, size int64) {
 }
 
 func (me *filePieceImpl) MarkComplete() (err error) {
+	prevCompletion := me.t.getCompletion(me.p.Index())
 	err = me.pieceCompletion().Set(me.pieceKey(), g.Some(true))
 	if err != nil {
 		return
@@ -178,8 +179,18 @@ func (me *filePieceImpl) MarkComplete() (err error) {
 			me.logger().Warn("error flushing completed piece", "piece", me.p.Index(), "err", err)
 		}
 	}
-	for f := range me.pieceFiles() {
-		res := me.allFilePiecesComplete(f)
+	for fileIndex := range me.fileExtents() {
+		f := me.t.file(fileIndex)
+		res := g.Result[bool]{}
+		if !(prevCompletion.Ok && prevCompletion.Complete) {
+			if allComplete, tracked := me.t.markFilePieceComplete(fileIndex); tracked {
+				res.SetOk(allComplete)
+			} else {
+				res = me.allFilePiecesComplete(f)
+			}
+		} else {
+			res = me.allFilePiecesComplete(f)
+		}
 		if res.Err != nil {
 			err = res.Err
 			return
@@ -222,11 +233,16 @@ func (me *filePieceImpl) allFilePiecesComplete(f file) (ret g.Result[bool]) {
 }
 
 func (me *filePieceImpl) MarkNotComplete() (err error) {
+	prevCompletion := me.t.getCompletion(me.p.Index())
 	err = me.pieceCompletion().Set(me.pieceKey(), g.Some(false))
 	if err != nil {
 		return
 	}
-	for f := range me.pieceFiles() {
+	for fileIndex := range me.fileExtents() {
+		if prevCompletion.Ok && prevCompletion.Complete {
+			me.t.markFilePieceIncomplete(fileIndex)
+		}
+		f := me.t.file(fileIndex)
 		err = me.onFileNotComplete(f)
 		if err != nil {
 			err = fmt.Errorf("preparing incomplete file %q: %w", f.safeOsPath, err)

--- a/storage/file-torrent.go
+++ b/storage/file-torrent.go
@@ -86,6 +86,51 @@ func (me *fileTorrentImpl) setCompletionFromPartFiles() error {
 	return nil
 }
 
+func (me *fileTorrentImpl) initFileCompletionTracking() error {
+	for fileIndex := range me.files {
+		f := me.file(fileIndex)
+		remaining := 0
+		for pieceIndex := f.beginPieceIndex(); pieceIndex < f.endPieceIndex(); pieceIndex++ {
+			c := me.getCompletion(pieceIndex)
+			if c.Err != nil {
+				return fmt.Errorf("getting completion for piece %d: %w", pieceIndex, c.Err)
+			}
+			if !c.Ok || !c.Complete {
+				remaining++
+			}
+		}
+		me.files[fileIndex].mu.Lock()
+		me.files[fileIndex].remainingPieces = remaining
+		me.files[fileIndex].remainingKnown = true
+		me.files[fileIndex].mu.Unlock()
+	}
+	return nil
+}
+
+func (me *fileTorrentImpl) markFilePieceComplete(fileIndex int) (allComplete, tracked bool) {
+	file := &me.files[fileIndex]
+	file.mu.Lock()
+	defer file.mu.Unlock()
+	if !file.remainingKnown {
+		return false, false
+	}
+	if file.remainingPieces > 0 {
+		file.remainingPieces--
+	}
+	return file.remainingPieces == 0, true
+}
+
+func (me *fileTorrentImpl) markFilePieceIncomplete(fileIndex int) (tracked bool) {
+	file := &me.files[fileIndex]
+	file.mu.Lock()
+	defer file.mu.Unlock()
+	if !file.remainingKnown {
+		return false
+	}
+	file.remainingPieces++
+	return true
+}
+
 func (me *fileTorrentImpl) partFiles() bool {
 	return me.client.opts.partFiles()
 }


### PR DESCRIPTION
Part-file promotion checked every piece touching a file whenever any piece completed. For large files this repeatedly scanned the same completion range on the hot piece-completion path.

This change:

- initializes a remaining-piece count for each file when part-file storage opens;
- updates that count only when a piece completion state changes;
- promotes the file when the count reaches zero; and
- falls back to the existing range scan if tracking is unavailable.

This keeps the existing promotion behavior while avoiding repeated full-range completion scans for large files.

Tests:

- `go test ./storage`
