### PR TITLE
Clip file-scoped reads to the file's extent

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -317,6 +317,13 @@ func (r *reader) readAt(ctx context.Context, b []byte, pos int64) (n int, err er
 		err = io.EOF
 		return
 	}
+	// Storage is piece-addressed and knows nothing of this reader's extent, so
+	// a buffer longer than what remains would come back holding the next
+	// file's bytes. Clip it to the extent; readContext turns the boundary into
+	// io.EOF.
+	if remaining := r.length - pos; int64(len(b)) > remaining {
+		b = b[:remaining]
+	}
 	n, err = r.readOnceAt(ctx, b, pos)
 	if err == nil {
 		return

--- a/reader_extent_test.go
+++ b/reader_extent_test.go
@@ -1,0 +1,75 @@
+package torrent
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/anacrolix/torrent/bencode"
+	"github.com/anacrolix/torrent/metainfo"
+	qt "github.com/go-quicktest/qt"
+)
+
+// A reader from File.NewReader must return only that file's bytes, even when
+// the caller's buffer is longer than what remains of the file and the next
+// file shares the piece.
+func TestFileReaderStopsAtFileEnd(t *testing.T) {
+	dataDir := t.TempDir()
+	root := filepath.Join(dataDir, "t")
+	qt.Assert(t, qt.IsNil(os.MkdirAll(root, 0o755)))
+	qt.Assert(t, qt.IsNil(os.WriteFile(filepath.Join(root, "a.txt"), []byte("small"), 0o644)))
+	qt.Assert(t, qt.IsNil(os.WriteFile(filepath.Join(root, "b.txt"), bytes.Repeat([]byte("B"), 100_000), 0o644)))
+	var info metainfo.Info
+	qt.Assert(t, qt.IsNil(info.BuildFromFilePath(root)))
+	infoBytes, err := bencode.Marshal(info)
+	qt.Assert(t, qt.IsNil(err))
+
+	cfg := TestingConfig(t)
+	cfg.DataDir = dataDir
+	cl, err := NewClient(cfg)
+	qt.Assert(t, qt.IsNil(err))
+	defer cl.Close()
+	tor, err := cl.AddTorrent(&metainfo.MetaInfo{InfoBytes: infoBytes})
+	qt.Assert(t, qt.IsNil(err))
+	<-tor.GotInfo()
+	for deadline := time.Now().Add(10 * time.Second); tor.BytesMissing() > 0; time.Sleep(10 * time.Millisecond) {
+		if time.Now().After(deadline) {
+			t.Fatalf("local data never verified: %d bytes missing", tor.BytesMissing())
+		}
+	}
+
+	f := tor.Files()[0]
+	qt.Assert(t, qt.Equals(f.DisplayPath(), "a.txt"))
+
+	r := f.NewReader()
+	defer r.Close()
+	got, err := io.ReadAll(r)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.DeepEquals(got, []byte("small")))
+
+	// A single read with a buffer longer than the whole file.
+	r2 := f.NewReader()
+	defer r2.Close()
+	buf := make([]byte, 64)
+	n, err := r2.Read(buf)
+	qt.Assert(t, qt.Equals(n, 5))
+	qt.Assert(t, qt.DeepEquals(buf[:n], []byte("small")))
+	if err != nil {
+		qt.Assert(t, qt.Equals(err, io.EOF))
+	}
+
+	// Seek near the end, then read past it.
+	r3 := f.NewReader()
+	defer r3.Close()
+	_, err = r3.Seek(3, io.SeekStart)
+	qt.Assert(t, qt.IsNil(err))
+	n, err = r3.Read(buf)
+	qt.Assert(t, qt.Equals(n, 2))
+	qt.Assert(t, qt.DeepEquals(buf[:n], []byte("ll")))
+	if err != nil {
+		qt.Assert(t, qt.Equals(err, io.EOF))
+	}
+}


### PR DESCRIPTION
Fixes #1108 (the gap the maintainer noted in #415 but that never landed).

A reader from `File.NewReader()` refused to *start* a read at or past its end, but handed the caller's whole buffer to storage, which is piece-addressed and knows nothing of the reader's extent. A buffer longer than what remained came back holding the next file's bytes: a 5-byte first file read through `io.ReadAll` as 512 bytes, and `Read` into a 64-byte buffer returned `n=64`.

This clips the buffer to the remaining extent in `reader.readAt` before the read; `readContext` already turns reaching the boundary into `io.EOF`.

The added test builds a two-file torrent over local data, verifies it, and checks three shapes: `io.ReadAll` of the first file, a single oversized `Read` from position 0, and an oversized `Read` after a `Seek` near the end. It fails on master and passes with the change. Run with `GOWORK=off go test ./ -run TestFileReaderStopsAtFileEnd`.
