### PR TITLE
metainfo: size symlinked files by their target in BuildFromFilePath

### DIFF
--- a/metainfo/info.go
+++ b/metainfo/info.go
@@ -59,6 +59,18 @@ func (info *Info) BuildFromFilePath(root string) (err error) {
 		if err != nil {
 			return err
 		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			// Walk reports the link itself; GeneratePieces opens the path and
+			// so reads the target. Sizes must describe the bytes that get
+			// hashed, or the torrent silently records a truncated file.
+			fi, err = os.Stat(path)
+			if err != nil {
+				return err
+			}
+			if !fi.Mode().IsRegular() {
+				return fmt.Errorf("%q: symlink to a non-regular file is not supported", path)
+			}
+		}
 		if fi.IsDir() {
 			// Directories are implicit in torrent files.
 			return nil

--- a/metainfo/info_test.go
+++ b/metainfo/info_test.go
@@ -1,6 +1,9 @@
 package metainfo
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -106,5 +109,39 @@ func TestFileTreeValidate(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// A symlink to a regular file is recorded with the target's length, which is
+// what GeneratePieces hashes; Walk's Lstat size (the link's own) must not
+// leak into the torrent.
+func TestBuildFromFilePathFollowsFileSymlinks(t *testing.T) {
+	realDir, linkDir := t.TempDir(), t.TempDir()
+	target := filepath.Join(realDir, "payload.bin")
+	if err := os.WriteFile(target, bytes.Repeat([]byte("x"), 5000), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(linkDir, "payload.bin")); err != nil {
+		t.Skip(err)
+	}
+	var overLinks, overReal Info
+	if err := overLinks.BuildFromFilePath(linkDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := overReal.BuildFromFilePath(realDir); err != nil {
+		t.Fatal(err)
+	}
+	if got := overLinks.UpvertedFiles()[0].Length; got != 5000 {
+		t.Fatalf("length through symlink = %d, want 5000", got)
+	}
+	if !bytes.Equal(overLinks.Pieces, overReal.Pieces) {
+		t.Fatal("pieces differ between the linked and the real tree")
+	}
+	// A symlink to a directory is refused rather than silently mis-sized.
+	if err := os.Symlink(realDir, filepath.Join(linkDir, "dir")); err == nil {
+		var info Info
+		if err := info.BuildFromFilePath(linkDir); err == nil {
+			t.Fatal("symlink to a directory accepted")
+		}
 	}
 }


### PR DESCRIPTION
Fixes #1109.

`filepath.Walk` hands the callback the `Lstat` result, so a symlink to a file was recorded with the link's own length (the length of its target path), while `GeneratePieces` opened the path, followed the link, and hashed only that many bytes of the target. The torrent was well-formed and every piece verified, but the file was silently truncated: a 5000-byte target became a 65-byte entry.

This stats through the link so the recorded length describes the bytes that are hashed, and refuses a symlink to anything but a regular file rather than mis-sizing it (Walk does not descend into linked directories, so silently skipping them would be the other surprising outcome).

If you would rather reject symlinks outright than follow them, the same callback is the place, and I am happy to change the PR to that policy; the thing that should not survive is one file's length paired with another file's bytes.

The added test checks that a tree of symlinks yields the same lengths and pieces as the real tree, and that a symlink to a directory is refused. It fails on master (`length through symlink = 71, want 5000`) and passes with the change.
