### PR TITLE
Don't panic when a dropped torrent still has webseed requests in flight

### DIFF
--- a/webseed-requesting.go
+++ b/webseed-requesting.go
@@ -477,6 +477,14 @@ func (cl *Client) yieldKeyAndValue(
 func (cl *Client) iterCurrentWebseedRequestsFromClient() iter.Seq2[webseedUniqueRequestKey, webseedRequestOrderValue] {
 	return func(yield func(webseedUniqueRequestKey, webseedRequestOrderValue) bool) {
 		for key, ar := range cl.activeWebseedRequests {
+			// A dropped torrent leaves cl.torrents synchronously, but its
+			// in-flight requests only leave this map when each one closes
+			// (deleteActiveRequest). Until then they are nobody's to schedule
+			// or cancel — the drop already did that — and counting them would
+			// make this view disagree with the per-torrent one.
+			if _, live := cl.torrents[key.t]; !live {
+				continue
+			}
 			if !cl.yieldKeyAndValue(yield, key, ar) {
 				return
 			}

--- a/webseed_drop_test.go
+++ b/webseed_drop_test.go
@@ -1,0 +1,74 @@
+package torrent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/anacrolix/torrent/bencode"
+	"github.com/anacrolix/torrent/metainfo"
+	qt "github.com/go-quicktest/qt"
+)
+
+// Dropping a torrent while one of its webseed requests is still in flight
+// must not make the next webseed scheduling pass panic: the torrent leaves
+// cl.torrents at once, but its requests leave cl.activeWebseedRequests only
+// when they close.
+func TestUpdateWebseedRequestsAfterDrop(t *testing.T) {
+	release := make(chan struct{})
+	var started atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		started.Add(1)
+		<-release // hold the request open so it stays in flight
+	}))
+	t.Cleanup(srv.Close)
+
+	src := t.TempDir()
+	root := filepath.Join(src, "t")
+	qt.Assert(t, qt.IsNil(os.MkdirAll(root, 0o755)))
+	qt.Assert(t, qt.IsNil(os.WriteFile(filepath.Join(root, "f.bin"), make([]byte, 1<<20), 0o644)))
+	var info metainfo.Info
+	qt.Assert(t, qt.IsNil(info.BuildFromFilePath(root)))
+	infoBytes, err := bencode.Marshal(info)
+	qt.Assert(t, qt.IsNil(err))
+	mi := &metainfo.MetaInfo{InfoBytes: infoBytes, UrlList: metainfo.UrlList{srv.URL + "/"}}
+
+	cfg := TestingConfig(t)
+	cfg.DisableWebseeds = false
+	cl, err := NewClient(cfg)
+	qt.Assert(t, qt.IsNil(err))
+	defer cl.Close()
+	defer close(release) // let the held request finish before the client closes
+	tor, err := cl.AddTorrent(mi)
+	qt.Assert(t, qt.IsNil(err))
+	<-tor.GotInfo()
+	tor.DownloadAll()
+	for deadline := time.Now().Add(10 * time.Second); started.Load() == 0; time.Sleep(10 * time.Millisecond) {
+		if time.Now().After(deadline) {
+			t.Fatal("no webseed request was issued")
+		}
+	}
+
+	// Drop and run the scheduler under one lock hold, so the in-flight
+	// request cannot remove itself in between and the window is certain.
+	// The lock is released even if the scheduler panics, so a failure is a
+	// clean test failure rather than a deadlocked Close.
+	var wg sync.WaitGroup
+	panicked := func() (r any) {
+		defer func() { r = recover() }()
+		cl.lock()
+		defer cl.unlock()
+		cl.dropTorrent(tor, &wg)
+		cl.updateWebseedRequests()
+		return nil
+	}()
+	if panicked != nil {
+		t.Fatalf("updateWebseedRequests panicked after Drop: %v", panicked)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Fixes #1098.

`updateWebseedRequests` asserts that the client-level view of in-flight webseed requests (`cl.activeWebseedRequests`) matches the per-torrent view (`t.webSeeds[*].activeRequests` over `cl.torrents`). Dropping a torrent removes it from `cl.torrents` at once, but its requests leave the client map only when each one closes (`deleteActiveRequest`). If the webseed timer fires in that window the assertion panics on the timer goroutine and takes the process down. The drop path already carries the same invariant under `if false` with a comment describing exactly this.

This makes the client-level iterator skip requests whose torrent is no longer in `cl.torrents`. Those requests are nobody's to schedule or cancel any more — the drop closed their peer and they remove themselves when they finish — so leaving them out is what keeps the two views describing the same thing. Removing them from the map at drop time instead would make the later `deleteActiveRequest` fail its own `MustDelete`, and it would have to pick a moment to decrement the per-host `numWebSeedRequests` counter while the socket is still open. Dropping just the assertion would not be enough either: the same pass later asserts `panicif.True(elem.t.closed.IsSet())` on every entry it schedules, so a dropped torrent's requests have to be kept out of `existingRequests` at the source, which is what this does. Per-host concurrency is unaffected: the counter is paired with each request's own start and close, so a dropped torrent's still-open requests keep occupying their host slots until they drain (measured in microseconds once the peer's context is cancelled), and the scheduler cannot exceed the limit.

The added test holds a webseed request open against an httptest server, drops the torrent and runs the scheduler under one lock hold, so the window is certain rather than timing-dependent. It panics on master (`updateWebseedRequests panicked after Drop: false`) and passes with the change. Run with `GOWORK=off go test ./ -run TestUpdateWebseedRequestsAfterDrop`.
